### PR TITLE
chore: archive one-shot script + log v1.9 decoupling backlog

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ item has a short rationale so future contributors (including future
 iterations of the author) can quickly reconstruct why a thing is or is not
 on the list.
 
-**Last updated**: 2026-04-20 (session closes v1.8 Codex review #2 round 2, 562/562 passing)
+**Last updated**: 2026-04-20 (handoff-prep cleanup: Tier A archival shipped, v1.9 decouplings logged, 562/562 passing)
 
 **Threat model anchor**: Liu et al., *Your Agent Is Mine: Measuring
 Malicious Intermediary Attacks on the LLM Supply Chain*, arXiv:2604.08407.
@@ -278,6 +278,90 @@ rather than real bugs — the v1.8.1 fixes themselves are correct,
 these tests just harden the regression guard. Revisit when the next
 feature cycle starts (same session that picks up 2.5 over-engineering
 prune is a natural fit).
+
+### 2.45 v1.9 — controlled-blast decouplings (handoff-prep triage, 2026-04-20)
+
+**Status**: audit done 2026-04-20 before front-end handoff.
+**Shipped in this audit**: Tier A archival — `scripts/verify_signature_
+schema.py` moved to `scripts/experiments/` (zero blast, no imports
+anywhere in the repo, one-shot investigation artifact).
+**Deferred to v1.9**: three real decoupling candidates ranked by
+blast-radius vs. leverage.
+
+1. **Extract `REFUSAL_MARKERS` + `_looks_like_refusal`**
+   from `scripts/audit.py` (lines 81, 156-158) into a new module
+   `api_relay_audit/refusal.py`.
+   **Scope**: ~25 LOC extraction + 6 import-site rewrites in
+   `scripts/audit.py` + 1 import rewrite in
+   `tests/test_refusal_detector.py` (currently references
+   `modular._looks_like_refusal`). Standalone `audit.py` keeps its
+   inline copy unchanged — the `TestRefusalMarkerParity` parity test
+   covers drift.
+   **Blast radius**: LOW. Parity test is the regression guard; if it
+   stays green and the test suite passes, the extraction is safe.
+   **Why now-safe**: unlike a client.py / audit.py split, this does
+   NOT require a standalone refactor because the parity strategy
+   already treats refusal markers as "inline on standalone, imported
+   on modular" in principle — we just need to complete that on the
+   modular side.
+   **Prereq**: none.
+   **Time estimate**: 25-30 min.
+   **Why deferred past this handoff**: medium-value, not zero-blast.
+   Parity tests exist but a typo in an import path or a missed call
+   site would produce a silent refusal-detection regression that
+   tests might miss if the test suite does not cover Step 4/6 end-
+   to-end with the moved module. Worth a proper code review rather
+   than a 30-min squeeze before handoff.
+
+2. **Split `api_relay_audit/client.py` (924 LOC)**
+   into `client/transport.py` + `client/format_detection.py` +
+   `client/stream.py` + `client/__init__.py` (re-exports).
+   **Scope**: ~300 LOC moved + all downstream import sites (every
+   module + every test that constructs `APIClient`). Public API
+   surface (`APIClient.call / get_models / raw_request / stream_call
+   / ensure_format`) preserved via `__init__.py` re-exports.
+   **Blast radius**: HIGH. Touches every module.
+   **Why not now**: standalone `audit.py` cannot be split in the
+   same way (it is a single flat file by design). Splitting modular
+   means the dual-distribution mirroring strategy has to change from
+   "character-identical blocks" to "character-identical blocks PLUS
+   class extraction into flat standalone". No clean playbook yet.
+   **Prereq**: dual-distribution policy decision (keep standalone /
+   deprecate standalone / auto-generate standalone from modular).
+   Without that decision any split strategy is guessing.
+   **Time estimate**: 2-3 hours, plus standalone strategy design.
+
+3. **Split `scripts/audit.py` (1536 LOC)**
+   into `scripts/steps/` subdirectory, one file per numbered step.
+   **Scope**: ~1200 LOC moved + `scripts/audit.py` becomes a thin
+   orchestrator that imports from `scripts.steps.step_NN_*`.
+   **Blast radius**: MEDIUM-HIGH. The `test_risk_matrix_character_
+   identical` parity test slices text between `# Overall rating`
+   and `# Output` comments; if the split moves those comments into
+   a step module the parity test breaks unless we relocate the slice
+   markers.
+   **Prereq**: same dual-distribution decision as #2; also needs the
+   parity test's slice markers redesigned.
+   **Time estimate**: 3-4 hours.
+
+4. **Extract `web/` dashboard to a separate repo**
+   `api-relay-audit-dashboard`.
+   **Scope**: `git filter-repo` / manual copy + new repo setup +
+   updated README pointing at it. `web/index.html` is currently
+   75 KB with inline JS/CSS; splitting into HTML + CSS + JS is a
+   separate frontend task.
+   **Blast radius**: LOW on backend (nothing imports the dashboard),
+   but the decision affects our front-end colleague who is about
+   to pick it up.
+   **Why not now**: defer to the front-end colleague's first-day
+   discussion. They may prefer to keep it in-tree for one more
+   iteration.
+   **Time estimate**: 1 hour (mechanical).
+
+**Cost of deferring further**: moderate. #1 is the highest-leverage
+of the three because it ships real module cohesion without touching
+standalone. #2 and #3 are blocked on the dual-distribution decision,
+which is itself ROADMAP 2.5 item #1 (biggest-debt candidate).
 
 ### 2.5 v1.9 — over-engineering prune (backlog, handoff-prep triage)
 **Status**: audit done 2026-04-20 before front-end handoff; no deletions

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -387,11 +387,13 @@ blast-radius vs. leverage.
      this workflow when extracting and rewire inside the new
      repo, or (b) keep a thin `web/` symlink/submodule in this
      repo that still satisfies the paths filter.
-   - `scripts/extract-data.py` produces `web/data.json` by
-     default (its docstring invocation is
-     `--output ./web/data.json`). After extraction, either the
-     script default changes or its output is piped into the
-     dashboard repo via CI.
+   - `scripts/extract-data.py` has `--output` as a **required
+     flag with no default** (`scripts/extract-data.py:197`);
+     the CLAUDE.md + docstring example just happens to pass
+     `--output ./web/data.json`. After extraction, either the
+     script gains a default pointing at the new repo path or
+     every caller/doc/CI invocation is updated to the new
+     location.
    - `web/index.html` is 75 KB with inline JS/CSS; splitting
      into HTML + CSS + JS is a separate frontend task that
      probably wants to happen IN the new repo rather than this

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -283,53 +283,84 @@ prune is a natural fit).
 
 **Status**: audit done 2026-04-20 before front-end handoff.
 **Shipped in this audit**: Tier A archival — `scripts/verify_signature_
-schema.py` moved to `scripts/experiments/` (zero blast, no imports
-anywhere in the repo, one-shot investigation artifact).
-**Deferred to v1.9**: three real decoupling candidates ranked by
+schema.py` moved to `scripts/experiments/` (zero blast on imports, no
+module references the archived script). Codex review on the move
+caught one latent path-drift bug: `OUT_DIR = Path(__file__).parent.
+parent / "reports"` would have written to `scripts/reports/` rather
+than `<repo_root>/reports/` after the rename. Fixed in the same
+branch by bumping the anchor to `.parent.parent.parent`. Regression
+lesson: whenever a script moves deeper into the tree, `__file__`-
+relative paths inside it must be re-verified.
+**Deferred to v1.9**: four real decoupling candidates ranked by
 blast-radius vs. leverage.
 
 1. **Extract `REFUSAL_MARKERS` + `_looks_like_refusal`**
    from `scripts/audit.py` (lines 81, 156-158) into a new module
    `api_relay_audit/refusal.py`.
-   **Scope**: ~25 LOC extraction + 6 import-site rewrites in
-   `scripts/audit.py` + 1 import rewrite in
-   `tests/test_refusal_detector.py` (currently references
-   `modular._looks_like_refusal`). Standalone `audit.py` keeps its
-   inline copy unchanged — the `TestRefusalMarkerParity` parity test
-   covers drift.
-   **Blast radius**: LOW. Parity test is the regression guard; if it
-   stays green and the test suite passes, the extraction is safe.
-   **Why now-safe**: unlike a client.py / audit.py split, this does
-   NOT require a standalone refactor because the parity strategy
-   already treats refusal markers as "inline on standalone, imported
-   on modular" in principle — we just need to complete that on the
-   modular side.
+   **Scope** (verified via grep, 2026-04-20 Codex review):
+   - 3 call sites of `_looks_like_refusal` in `scripts/audit.py`
+     (lines 178, 403, 559) — NOT 6 as initially stated
+   - `tests/test_refusal_detector.py` already imports
+     `modular._looks_like_refusal` directly; a re-export on
+     `scripts/audit.py` keeps the test untouched, a hard rename
+     does not
+   - `tests/test_clean_summary_flags.py` does not import the
+     helpers but does exercise Step 4/6 with a `CLEAN_REFUSAL`
+     fixture, so any behavior change in the helper surfaces here
+   - Standalone `audit.py` keeps its inline copy unchanged — the
+     existing `TestRefusalMarkerParity` parity test covers drift
+   **Blast radius**: LOW. Parity test is the regression guard; if
+   it stays green and the test suite passes, the extraction is
+   safe. Recommended approach: re-export on `scripts.audit` so
+   `tests/test_refusal_detector.py` needs zero changes.
+   **Why now-safe**: unlike a client.py / audit.py split, this
+   does NOT require a standalone refactor because the parity
+   strategy already treats refusal markers as "inline on
+   standalone, imported on modular" in principle — we just need
+   to complete that on the modular side.
    **Prereq**: none.
    **Time estimate**: 25-30 min.
-   **Why deferred past this handoff**: medium-value, not zero-blast.
-   Parity tests exist but a typo in an import path or a missed call
-   site would produce a silent refusal-detection regression that
-   tests might miss if the test suite does not cover Step 4/6 end-
-   to-end with the moved module. Worth a proper code review rather
-   than a 30-min squeeze before handoff.
+   **Why deferred past this handoff**: medium-value, not zero-
+   blast. A typo in an import path or a missed call site would
+   produce a silent refusal-detection regression; worth a
+   proper code review rather than a 30-min squeeze before
+   handoff.
 
 2. **Split `api_relay_audit/client.py` (924 LOC)**
    into `client/transport.py` + `client/format_detection.py` +
    `client/stream.py` + `client/__init__.py` (re-exports).
-   **Scope**: ~300 LOC moved + all downstream import sites (every
-   module + every test that constructs `APIClient`). Public API
-   surface (`APIClient.call / get_models / raw_request / stream_call
-   / ensure_format`) preserved via `__init__.py` re-exports.
-   **Blast radius**: HIGH. Touches every module.
-   **Why not now**: standalone `audit.py` cannot be split in the
-   same way (it is a single flat file by design). Splitting modular
-   means the dual-distribution mirroring strategy has to change from
-   "character-identical blocks" to "character-identical blocks PLUS
-   class extraction into flat standalone". No clean playbook yet.
-   **Prereq**: dual-distribution policy decision (keep standalone /
-   deprecate standalone / auto-generate standalone from modular).
-   Without that decision any split strategy is guessing.
-   **Time estimate**: 2-3 hours, plus standalone strategy design.
+
+   **Codex review follow-up (2026-04-20)**: my original "HIGH
+   blast / blocked on dual-distribution policy" framing was over-
+   pessimistic. A cheaper incremental path exists:
+
+     *Phase 2a — transport extraction only, facade-preserved.*
+     Move just the httpx-vs-curl transport code into an internal
+     `api_relay_audit/_transport.py` helper module and have
+     `api_relay_audit/client.py` import from it. `APIClient`
+     class stays in `client.py`; all public imports stay valid.
+     No test changes. Standalone `audit.py` stays flat because
+     modular's public API is unchanged — the parity constraint
+     does not care what's behind the facade. Blast radius: LOW.
+     Time estimate: 60-90 min.
+
+   After 2a lands and stabilizes, Phase 2b (stream extraction)
+   and 2c (format-detection extraction) can follow the same
+   pattern. Only Phase 2d ("promote the internal modules to
+   public re-exports under `api_relay_audit.client.*`") needs
+   the dual-distribution policy decision, because that is when
+   the standalone flat copy starts diverging.
+
+   **Scope (Phase 2a only)**: ~300 LOC moved into internal
+   helper + ~30 LOC of import rewiring inside `client.py`. No
+   change to public import paths. No change to standalone.
+   **Blast radius (Phase 2a)**: LOW.
+   **Prereq (Phase 2a)**: none.
+   **Time estimate (Phase 2a)**: 60-90 min.
+
+   **Original full-split Phase 2d** (for reference): HIGH blast,
+   blocked on dual-distribution policy (keep / deprecate /
+   auto-generate standalone from modular). 2-3 hours plus design.
 
 3. **Split `scripts/audit.py` (1536 LOC)**
    into `scripts/steps/` subdirectory, one file per numbered step.
@@ -346,22 +377,44 @@ blast-radius vs. leverage.
 
 4. **Extract `web/` dashboard to a separate repo**
    `api-relay-audit-dashboard`.
-   **Scope**: `git filter-repo` / manual copy + new repo setup +
-   updated README pointing at it. `web/index.html` is currently
-   75 KB with inline JS/CSS; splitting into HTML + CSS + JS is a
-   separate frontend task.
-   **Blast radius**: LOW on backend (nothing imports the dashboard),
-   but the decision affects our front-end colleague who is about
-   to pick it up.
-   **Why not now**: defer to the front-end colleague's first-day
-   discussion. They may prefer to keep it in-tree for one more
-   iteration.
-   **Time estimate**: 1 hour (mechanical).
 
-**Cost of deferring further**: moderate. #1 is the highest-leverage
-of the three because it ships real module cohesion without touching
-standalone. #2 and #3 are blocked on the dual-distribution decision,
-which is itself ROADMAP 2.5 item #1 (biggest-debt candidate).
+   **Codex review follow-up (2026-04-20)**: my "1h mechanical"
+   estimate was wrong — `web/` has live wiring into the rest of
+   the repo that must be re-established after extraction:
+
+   - `.github/workflows/pages.yml` deploys `web/**` to GitHub
+     Pages; triggered by `paths: [web/**]`. Either (a) remove
+     this workflow when extracting and rewire inside the new
+     repo, or (b) keep a thin `web/` symlink/submodule in this
+     repo that still satisfies the paths filter.
+   - `scripts/extract-data.py` produces `web/data.json` by
+     default (its docstring invocation is
+     `--output ./web/data.json`). After extraction, either the
+     script default changes or its output is piped into the
+     dashboard repo via CI.
+   - `web/index.html` is 75 KB with inline JS/CSS; splitting
+     into HTML + CSS + JS is a separate frontend task that
+     probably wants to happen IN the new repo rather than this
+     one.
+
+   **Blast radius**: LOW on the Python backend (nothing under
+   `api_relay_audit/*` or `scripts/audit.py` imports the
+   dashboard), but MEDIUM on CI/deployment because the
+   GitHub Pages workflow currently depends on `web/` living
+   in-tree.
+   **Why not now**: defer to the front-end colleague's first-
+   day discussion. They may prefer to keep it in-tree for one
+   more iteration OR prefer a clean extract where they own
+   the new repo from day one. Either answer is reasonable.
+   **Time estimate**: 2-3 hours (extraction + CI rewire +
+   README cross-links), NOT 1 hour.
+
+**Cost of deferring further**: moderate. #1 and the Phase-2a slice of
+#2 are the highest-leverage of the four because they ship real module
+cohesion without touching standalone. Full-split Phase-2d of #2 and
+the whole of #3 are blocked on the dual-distribution decision, which
+is itself ROADMAP 2.5 item #1 (biggest-debt candidate). #4 is a front-
+end colleague conversation, not a backend task.
 
 ### 2.5 v1.9 — over-engineering prune (backlog, handoff-prep triage)
 **Status**: audit done 2026-04-20 before front-end handoff; no deletions

--- a/scripts/experiments/verify_signature_schema.py
+++ b/scripts/experiments/verify_signature_schema.py
@@ -39,7 +39,12 @@ from pathlib import Path
 
 ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
 MODEL = "claude-opus-4-5"  # any thinking-capable model is fine
-OUT_DIR = Path(__file__).resolve().parent.parent / "reports"
+# Archival note (2026-04-20): file lives at
+# ``scripts/experiments/<this file>`` so repo root is 3 levels up
+# (was 2 before the move; Codex review flagged the drift).
+# Keeps the report at ``<repo_root>/reports/signature-schema-probe.txt``
+# regardless of where the script is invoked from.
+OUT_DIR = Path(__file__).resolve().parent.parent.parent / "reports"
 OUT_FILE = OUT_DIR / "signature-schema-probe.txt"
 
 # A prompt that reliably triggers extended-thinking content blocks.

--- a/scripts/experiments/verify_signature_schema.py
+++ b/scripts/experiments/verify_signature_schema.py
@@ -7,7 +7,7 @@ across channels (direct / bedrock / vertex / reverse-proxy).
 
 Usage:
     set ANTHROPIC_API_KEY=sk-ant-...
-    python scripts/verify_signature_schema.py
+    python scripts/experiments/verify_signature_schema.py
 
 Output: `reports/signature-schema-probe.txt` (hex dumps + parsed field
 tuples + 3-run stability diff). Read the report and decide:
@@ -18,6 +18,12 @@ tuples + 3-run stability diff). Read the report and decide:
     → abandon item 5, fall back to header-presence fingerprinting.
 
 Zero deps: stdlib only, curl-free (uses urllib). Python 3.7+.
+
+Status: archived under ``scripts/experiments/`` on 2026-04-20 as a
+one-shot investigation artifact. Not part of the production audit
+pipeline; no module imports it. Kept in-tree so the investigation is
+reproducible; move to a separate gist or delete if/when ROADMAP item
+5 closes definitively.
 """
 
 import base64


### PR DESCRIPTION
## Summary
- **Tier A archival** from the 2026-04-20 handoff-prep tech-debt audit: `scripts/verify_signature_schema.py` moves to `scripts/experiments/`. Verified via `grep` that no module imports it — it's a one-shot investigation artifact for the channel-fingerprint ROADMAP item, self-declared as such in its docstring. Moving clarifies it's not production pipeline.
- **ROADMAP item 2.45 added** logging the three deferred decoupling candidates that were deliberately NOT done in the handoff window, each with blast-radius assessment + prerequisite + time estimate:
  - `REFUSAL_MARKERS` + `_looks_like_refusal` extraction (LOW blast, highest leverage — do in next session)
  - `api_relay_audit/client.py` 924-LOC split (HIGH blast, blocked on dual-distribution policy)
  - `scripts/audit.py` 1536-LOC → `steps/` subdir (MEDIUM-HIGH blast, same blocker)
  - `web/` → separate repo (backend LOW blast, deferred to frontend colleague day 1)

## Blast radius
- Zero code under `api_relay_audit/*` touched
- File move is tracked by git as a rename (96% similarity preserved)
- No test imports reference the archived script

## Test plan
- [x] `pytest tests/ -q` → 562 passed (unchanged from PR #10 base)
- [x] `grep -rn "verify_signature_schema"` → only self-reference in its own docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)