### PR TITLE
[codex] Add Hermes skill adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
   <a href="./FOR_JOHN.md"><strong>Engineering Diary</strong></a>
   ·
   <a href="./SKILL.md"><strong>OpenClaw Skill</strong></a>
+  ·
+  <a href="./skills/api-relay-audit/SKILL.md"><strong>Hermes Skill</strong></a>
 </p>
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: api-relay-audit
-description: "Audit third-party AI API relay/proxy services for security risks. Detects hidden prompt injection, prompt leakage, instruction override, identity hijacking (Chinese-market substitutes), jailbreak vulnerabilities, context truncation, tool-call package substitution (AC-1.a), error response header leakage (AC-2 adjacent), SSE-level stream integrity anomalies (AC-1 streaming), and Web3 prompt injection (SlowMist signature isolation). Use when: test relay, audit API, audit relay, detect injection, relay security, API relay audit, is this relay safe, does it inject prompts, test proxy API, check API key, 中转站安全, 测试中转站, 中转站审计."
+description: "Audit third-party AI API relay/proxy services for security risks. Detects hidden prompt injection, prompt leakage, instruction override, identity hijacking (Chinese-market substitutes), jailbreak vulnerabilities, context truncation, tool-call package substitution (AC-1.a), error response header leakage (AC-2 adjacent), SSE-level stream integrity anomalies (AC-1 streaming), Web3 prompt injection (SlowMist signature isolation), infrastructure fingerprinting, and latency variance anomalies. Use when: test relay, audit API, audit relay, detect injection, relay security, API relay audit, is this relay safe, does it inject prompts, test proxy API, check API key, 中转站安全, 测试中转站, 中转站审计."
 version: 2.3.0
 metadata: {"openclaw":{"requires":{"anyBins":["curl","python3","python"],"env":[]},"emoji":"🛡️","homepage":"https://github.com/toby-bridges/api-relay-audit"}}
 ---
 
 # API Relay Security Audit (API 中转站安全审计)
 
-A self-contained 11-step security audit for third-party AI API relay/proxy services (中转站). One script, zero config, full report. Threat taxonomy follows Liu et al., *Your Agent Is Mine*, arXiv:2604.08407.
+A self-contained 13-step security audit for third-party AI API relay/proxy services (中转站). One script, zero config, full report. Threat taxonomy follows Liu et al., *Your Agent Is Mine*, arXiv:2604.08407. Infrastructure fingerprinting and latency variance are sourced from Zhang et al., *Real Money, Fake Models*, arXiv:2603.01919.
 
 ## Quick Start (快速开始)
 
@@ -23,7 +23,7 @@ The script has zero dependencies beyond Python 3 + `curl`. All HTTP calls go thr
 
 ## What This Skill Does (功能概述)
 
-Runs an 11-step automated audit against any OpenAI-compatible or Anthropic-compatible API relay:
+Runs a 13-step automated audit against any OpenAI-compatible or Anthropic-compatible API relay:
 
 | Step | Test | What It Detects |
 |------|------|-----------------|
@@ -38,6 +38,8 @@ Runs an 11-step automated audit against any OpenAI-compatible or Anthropic-compa
 | 9 | Error response leakage (错误响应泄漏, AC-2 adjacent) | 7-8 deterministic broken requests (malformed JSON, invalid model, wrong content-type, missing fields, unknown endpoint, force_upstream_error, auth_probe, optional 256 KB oversized body); scans the error body and response headers for echoed credentials, upstream URLs, env var names, filesystem paths, stack traces, LiteLLM internal field leaks, and Bedrock guardrail PII echoes |
 | 10 | Stream integrity (流完整性, AC-1 SSE-level) | Opens an Anthropic streaming request with thinking enabled, captures every SSE event, and verifies 4 invariants: all event types are in the known set (ping/message_start/content_block_start/content_block_delta/content_block_stop/message_delta/message_stop); `output_tokens` is monotonically non-decreasing; `input_tokens` is consistent across message_start and message_delta; `signature_delta` events have non-empty signatures. Also checks `message_start.message.model` contains `claude`. Concept sourced from hvoy.ai `claude_detector.py`. |
 | 11 | Web3 prompt injection (Web3 注入, `--profile web3` only) | 3 SlowMist signature-isolation probes targeting wallet safety: ETH transfer guidance, sign-transaction refusal, private-key leak refusal. Safe-priority classifier with hard-injection override for contradictory responses. |
+| 12 | Infrastructure fingerprint (基础设施指纹) | Unauthenticated `GET /`, `/v1/models`, and nonexistent-endpoint probes classify known relay frameworks such as One API / New API, LobeChat, FastGPT, Cloudflare, nginx, and Caddy. Informational only. |
+| 13 | Latency variance (延迟方差指纹) | Repeated identical low-token requests measure latency distribution and flag variable or bimodal routing patterns that may suggest queue multiplexing or silent model/provider substitution. Informational only. |
 
 Output: a structured Markdown report with risk ratings per section and an overall verdict.
 

--- a/skills/api-relay-audit/SKILL.md
+++ b/skills/api-relay-audit/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: api-relay-audit
+description: Use when auditing third-party AI API relays, proxy APIs, or API-key resale services for hidden prompt injection, prompt leakage, instruction override, context truncation, tool-call substitution, error leakage, SSE stream anomalies, Web3 wallet-safety prompt injection, infrastructure fingerprints, and latency variance.
+version: 2.3.0
+author: Toby Bridges
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [security, red-teaming, ai-safety, api-relay, web3]
+    related_skills: []
+required_environment_variables:
+  - name: API_RELAY_AUDIT_KEY
+    prompt: API relay key
+    help: Use a temporary or low-scope key for the relay being tested.
+    required_for: Running relay audits without pasting secrets into chat
+---
+
+# API Relay Audit for Hermes Agent
+
+## Overview
+
+This skill runs `api-relay-audit`, a zero-dependency security audit for third-party AI API relays and proxy services. It checks whether the relay tampers with prompts, truncates context, rewrites package-install instructions, leaks upstream credentials or internal headers, corrupts Anthropic SSE streams, or injects unsafe Web3 wallet behavior.
+
+Use the standalone `audit.py` path by default. It only needs Python 3 and `curl`, which makes it suitable for local Hermes terminal sessions and sandboxed execution.
+
+## When to Use
+
+- The user asks whether an AI API relay, proxy API, resale key, or "API relay" is safe.
+- The user provides a relay base URL and wants an evidence-based risk report.
+- The user suspects hidden prompts, identity substitution, response tampering, context truncation, tool-call/package substitution, or stream anomalies.
+- The user wants to audit Web3/wallet safety behavior with `--profile web3` or `--profile full`.
+
+Do not use this skill for general model benchmarking, provider price comparison, or legal/security certification. The output is a technical audit report, not a guarantee that a service is safe.
+
+## Install or Share
+
+After this file is merged to the public repository, Hermes users can install it as a tap skill:
+
+```bash
+hermes skills tap add toby-bridges/api-relay-audit
+hermes skills install toby-bridges/api-relay-audit/api-relay-audit
+```
+
+For direct testing without adding the whole tap:
+
+```bash
+hermes skills install toby-bridges/api-relay-audit/skills/api-relay-audit
+```
+
+## Required Inputs
+
+| Input | How to provide it | Notes |
+|---|---|---|
+| Relay API key | Prefer `$API_RELAY_AUDIT_KEY` via Hermes secure env setup | Use a temporary or low-scope key when possible. |
+| Base URL | Ask the user or use `$API_RELAY_AUDIT_URL` if already set | Example: `https://relay.example.com/v1`. |
+| Model | Optional; default is `claude-opus-4-6` | Use the model the user plans to rely on. |
+| Profile | Optional; default is `general` | Use `web3` for wallet users, `full` for complete coverage. |
+
+Never print the raw API key in summaries, filenames, reports, shell traces, or GitHub comments. If the user pasted a key into chat, avoid repeating it and recommend rotating it after the audit if exposure matters.
+
+## Standard Workflow
+
+1. Confirm the target base URL, model, and profile.
+2. Ensure the key is available as `$API_RELAY_AUDIT_KEY`. If it is missing, ask the user to configure it through Hermes secure setup or local `.env`, not by committing it.
+3. Download the standalone script into a temporary directory unless the current repo already contains `audit.py`.
+4. Run the audit and write a Markdown report.
+5. Summarize only evidence from the generated report. Do not overstate safety or make policy promises.
+
+## One-Shot Audit Recipe
+
+Use this when the user provides a base URL and wants a normal audit:
+
+```bash
+set -euo pipefail
+
+: "${API_RELAY_AUDIT_KEY:?Set API_RELAY_AUDIT_KEY through Hermes secure env setup first}"
+: "${API_RELAY_AUDIT_URL:?Set API_RELAY_AUDIT_URL to the relay base URL}"
+
+MODEL="${API_RELAY_AUDIT_MODEL:-claude-opus-4-6}"
+PROFILE="${API_RELAY_AUDIT_PROFILE:-general}"
+WORKDIR="$(mktemp -d)"
+REPORT="$PWD/api-relay-audit-report.md"
+
+curl -fsSL \
+  https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py \
+  -o "$WORKDIR/audit.py"
+
+python3 "$WORKDIR/audit.py" \
+  --key "$API_RELAY_AUDIT_KEY" \
+  --url "$API_RELAY_AUDIT_URL" \
+  --model "$MODEL" \
+  --profile "$PROFILE" \
+  --output "$REPORT"
+
+printf 'Report written to %s\n' "$REPORT"
+```
+
+If the current working tree is the `api-relay-audit` repository and `audit.py` exists, prefer the local file:
+
+```bash
+python3 audit.py \
+  --key "$API_RELAY_AUDIT_KEY" \
+  --url "$API_RELAY_AUDIT_URL" \
+  --model "${API_RELAY_AUDIT_MODEL:-claude-opus-4-6}" \
+  --profile "${API_RELAY_AUDIT_PROFILE:-general}" \
+  --output api-relay-audit-report.md
+```
+
+## Profiles and Cost Controls
+
+| Scenario | Recommended flags |
+|---|---|
+| Fast first pass | `--skip-infra --skip-context --skip-latency-variance` |
+| Normal relay audit | `--profile general` |
+| Web3 or wallet relay | `--profile web3` |
+| Complete audit | `--profile full` |
+| Suspicious relay with request-count gating | `--warmup 5` to `--warmup 20` |
+| Avoid intentionally broken requests | `--skip-error-leakage` |
+| Avoid streaming checks | `--skip-stream-integrity` |
+
+Warn the user before enabling `--aggressive-error-probes` because oversized probes can create metered usage on pay-as-you-go relays.
+
+## What the 13 Steps Cover
+
+| Step | Area | Purpose |
+|---|---|---|
+| 1 | Infrastructure recon | DNS, WHOIS, SSL, HTTP headers, and panel hints. |
+| 2 | Model list | Available models, model count, and ownership fields. |
+| 3 | Token injection | Hidden system-prompt size via token delta. |
+| 4 | Prompt extraction | Direct attempts to extract hidden prompts. |
+| 5 | Instruction conflict and identity | Whether user instructions and identity settings are overridden. |
+| 6 | Jailbreak extraction | Indirect prompt-extraction attempts. |
+| 7 | Context length | Canary-based truncation detection. |
+| 8 | Tool-call substitution | Package-install command rewriting, AC-1.a. |
+| 9 | Error leakage | Credential, header, stack trace, path, and internal-field leakage. |
+| 10 | Stream integrity | SSE event whitelist, usage monotonicity, signatures, and stream model identity. |
+| 11 | Web3 prompt injection | Wallet-safety refusal probes, profile-gated. |
+| 12 | Infrastructure fingerprint | Known relay framework signatures, informational only. |
+| 13 | Latency variance | Bimodal or unstable routing hints, informational only. |
+
+## Report Summary Template
+
+After running the audit, summarize in this format:
+
+```markdown
+## Audit Result: <relay host>
+
+Overall risk: LOW / MEDIUM / HIGH
+
+- Token injection: <delta or unavailable>
+- Prompt extraction: <count or summary>
+- User control: <instruction/identity result>
+- Context length: <full/truncated/inconclusive>
+- Tool-call substitution: <clean/substituted/inconclusive>
+- Error leakage: <none/medium/high/critical/inconclusive>
+- Stream integrity: <clean/anomaly/inconclusive>
+- Web3 profile: <not run/clean/injected/inconclusive>
+- Informational: <infra fingerprint and latency variance highlights>
+
+Recommendation: <use / use with caution / do not use>, based only on the report evidence.
+```
+
+## Common Pitfalls
+
+1. Do not treat "no finding" as proof of safety. It only means these probes did not catch tampering.
+2. Do not paste or repeat API keys in chat. Prefer `API_RELAY_AUDIT_KEY`.
+3. Do not skip dual-distribution context when editing the project itself: changes to modular audit logic usually need root `audit.py` parity.
+4. Do not promise product timelines, vendor cooperation, or risk-policy changes from an audit result.
+5. If a relay is non-Anthropic or does not support thinking streams, Step 10 may be inconclusive rather than clean.
+
+## Verification Checklist
+
+- [ ] `SKILL.md` frontmatter has `name`, `description`, `version`, `author`, `license`, and `metadata.hermes.tags`.
+- [ ] Description is under 1024 characters and starts with "Use when".
+- [ ] The audit command uses `$API_RELAY_AUDIT_KEY`, not a literal key.
+- [ ] The report was generated as Markdown and the key was not echoed.
+- [ ] Any public reply or GitHub comment is grounded only in the report, README, ROADMAP, FOR_JOHN, or current code.


### PR DESCRIPTION
## Summary
- add a Hermes-compatible `skills/api-relay-audit/SKILL.md` adapter for api-relay-audit
- sync the root OpenClaw `SKILL.md` from 11-step to 13-step coverage
- link the Hermes skill from the README

## Verification
- `git diff --check`
- frontmatter sanity check: description starts with `Use when`, is under 1024 characters, and includes `required_environment_variables`

No runtime audit logic changed.