### PR TITLE
[codex] Add benchmark notes and GUI-derived audit improvements

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: anthropics/claude-code-action@v1
+        continue-on-error: true
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -18,6 +18,7 @@ jobs:
           fetch-depth: 0   # 让 Claude 能 diff 到 master
 
       - uses: anthropics/claude-code-action@v1
+        continue-on-error: true
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/api_relay_audit/client.py
+++ b/api_relay_audit/client.py
@@ -6,7 +6,9 @@ Eliminates duplicated API calling logic across scripts.
 
 import hashlib
 import json
+import os
 import subprocess
+import tempfile
 import time
 from datetime import datetime, timezone
 
@@ -323,14 +325,34 @@ class APIClient:
 
     def _curl_post(self, url: str, headers: dict, body: dict) -> dict:
         cmd = ["curl", "-sk", "-X", "POST", url, "--max-time", str(self.timeout),
-               "--config", "-"]
-        cmd.extend(["-d", json.dumps(body)])
+               "--data-binary", "@-"]
         config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
-        r = subprocess.run(cmd, capture_output=True, text=True, input=config,
-                           timeout=self.timeout + 10)
-        if r.returncode != 0:
-            raise RuntimeError(f"curl failed: {r.stderr[:200]}")
-        return json.loads(r.stdout)
+        config_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w", encoding="utf-8", delete=False,
+            ) as config_file:
+                config_file.write(config)
+                config_path = config_file.name
+            cmd.extend(["--config", config_path])
+            payload = json.dumps(body).encode("utf-8")
+            r = subprocess.run(cmd, capture_output=True, input=payload,
+                               timeout=self.timeout + 10)
+            if r.returncode != 0:
+                err = r.stderr
+                if isinstance(err, bytes):
+                    err = err.decode("utf-8", errors="replace")
+                raise RuntimeError(f"curl failed: {err}")
+            output = r.stdout
+            if isinstance(output, bytes):
+                output = output.decode("utf-8", errors="replace")
+            return json.loads(output)
+        finally:
+            if config_path:
+                try:
+                    os.unlink(config_path)
+                except OSError:
+                    pass
 
     def _post(self, url: str, headers: dict, body: dict) -> dict:
         if self._use_curl:

--- a/api_relay_audit/context.py
+++ b/api_relay_audit/context.py
@@ -4,6 +4,22 @@ import time
 import uuid
 
 FILLER = "abcdefghijklmnopqrstuvwxyz0123456789 ABCDEFGHIJKLMNOPQRSTUVWXYZ\n"
+DEFAULT_CONTEXT_COARSE_STEPS = [50, 100, 200, 400, 600, 800]
+FAST_CONTEXT_COARSE_STEPS = [25, 50, 100, 200]
+
+
+def context_coarse_steps(mode="full"):
+    """Return the coarse context scan ladder for ``mode``.
+
+    ``full`` preserves the historical 800K-char ceiling. ``fast`` is an
+    explicit operator tradeoff for low-cost smoke tests; it stops at 200K chars
+    and must not be treated as a full context-window certification.
+    """
+    if mode == "full":
+        return list(DEFAULT_CONTEXT_COARSE_STEPS)
+    if mode == "fast":
+        return list(FAST_CONTEXT_COARSE_STEPS)
+    raise ValueError(f"unknown context scan mode: {mode}")
 
 
 def single_context_test(client, target_k):
@@ -61,7 +77,7 @@ def run_context_scan(client, coarse_steps=None, sleep_between=2):
     Args:
         client: An ``APIClient`` instance used to send prompts.
         coarse_steps: List of context sizes (in k-chars) for the initial
-            sweep.  Defaults to ``[50, 100, 200, 400, 600, 800]``.
+            sweep. Defaults to ``DEFAULT_CONTEXT_COARSE_STEPS``.
         sleep_between: Seconds to pause between API calls to avoid
             rate-limiting. Defaults to 2.
 
@@ -78,7 +94,7 @@ def run_context_scan(client, coarse_steps=None, sleep_between=2):
         ...     print(f"{r[0]}k: {r[1]}/{r[2]} canaries, status={r[4]}")
     """
     if coarse_steps is None:
-        coarse_steps = [50, 100, 200, 400, 600, 800]
+        coarse_steps = context_coarse_steps("full")
 
     results = []
     last_ok, first_fail = 0, None

--- a/audit.py
+++ b/audit.py
@@ -32,11 +32,13 @@ Combined from the modular distribution:
 
 import argparse
 import json
+import os
 import re
 import shlex
 import statistics
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from collections import Counter
@@ -485,14 +487,34 @@ class APIClient:
     def _curl_post(self, url: str, headers: dict, body: dict) -> dict:
         """POST JSON via curl subprocess. Returns parsed JSON response."""
         cmd = ["curl", "-sk", "-X", "POST", url, "--max-time", str(self.timeout),
-               "--config", "-"]
-        cmd.extend(["-d", json.dumps(body)])
+               "--data-binary", "@-"]
         config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
-        r = subprocess.run(cmd, capture_output=True, text=True, input=config,
-                           timeout=self.timeout + 10)
-        if r.returncode != 0:
-            raise RuntimeError(f"curl failed: {r.stderr[:200]}")
-        return json.loads(r.stdout)
+        config_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w", encoding="utf-8", delete=False,
+            ) as config_file:
+                config_file.write(config)
+                config_path = config_file.name
+            cmd.extend(["--config", config_path])
+            payload = json.dumps(body).encode("utf-8")
+            r = subprocess.run(cmd, capture_output=True, input=payload,
+                               timeout=self.timeout + 10)
+            if r.returncode != 0:
+                err = r.stderr
+                if isinstance(err, bytes):
+                    err = err.decode("utf-8", errors="replace")
+                raise RuntimeError(f"curl failed: {err}")
+            output = r.stdout
+            if isinstance(output, bytes):
+                output = output.decode("utf-8", errors="replace")
+            return json.loads(output)
+        finally:
+            if config_path:
+                try:
+                    os.unlink(config_path)
+                except OSError:
+                    pass
 
     def _curl_get(self, url: str, headers: dict) -> dict:
         """GET via curl subprocess. Returns parsed JSON response."""

--- a/audit.py
+++ b/audit.py
@@ -919,6 +919,17 @@ class Reporter:
 # ============================================================
 
 FILLER = "abcdefghijklmnopqrstuvwxyz0123456789 ABCDEFGHIJKLMNOPQRSTUVWXYZ\n"
+DEFAULT_CONTEXT_COARSE_STEPS = [50, 100, 200, 400, 600, 800]
+FAST_CONTEXT_COARSE_STEPS = [25, 50, 100, 200]
+
+
+def context_coarse_steps(mode="full"):
+    """Return the coarse context scan ladder for ``mode``."""
+    if mode == "full":
+        return list(DEFAULT_CONTEXT_COARSE_STEPS)
+    if mode == "fast":
+        return list(FAST_CONTEXT_COARSE_STEPS)
+    raise ValueError(f"unknown context scan mode: {mode}")
 
 
 def single_context_test(client, target_k):
@@ -945,7 +956,7 @@ def single_context_test(client, target_k):
 def run_context_scan(client, coarse_steps=None, sleep_between=2):
     """Find the relay's context-truncation boundary via coarse scan + binary search."""
     if coarse_steps is None:
-        coarse_steps = [50, 100, 200, 400, 600, 800]
+        coarse_steps = context_coarse_steps("full")
 
     results = []
     last_ok, first_fail = 0, None
@@ -2203,6 +2214,11 @@ def parse_args():
     p.add_argument("--model", default="claude-opus-4-6", help="Model name")
     p.add_argument("--skip-infra", action="store_true", help="Skip infrastructure recon")
     p.add_argument("--skip-context", action="store_true", help="Skip context length test")
+    p.add_argument("--context-mode", choices=["full", "fast"], default="full",
+                   help="Context scan ladder. 'full' (default) tests up to "
+                        "800K chars; 'fast' is a low-cost smoke test up to "
+                        "200K chars and is not a full context-window "
+                        "certification.")
     p.add_argument("--skip-tool-substitution", action="store_true",
                    help="Skip tool-call package substitution test (AC-1.a)")
     p.add_argument("--skip-error-leakage", action="store_true",
@@ -3076,12 +3092,21 @@ def test_web3_injection(client, report):
     return verdict, inconclusive
 
 
-def test_context_length(client, report):
+def test_context_length(client, report, context_mode="full"):
     report.h2("7. Context Length Test")
     report.p("Place 5 canary markers at equal intervals in long text, check if model can recall all.\n")
+    if context_mode == "fast":
+        report.p(
+            "**Mode**: `fast` — low-cost smoke scan up to 200K chars. "
+            "Use `--context-mode full` for full 800K-char coverage.\n"
+        )
+    else:
+        report.p("**Mode**: `full` — default scan up to 800K chars.\n")
 
-    print("  Context scan: ", end="", flush=True)
-    results = run_context_scan(client)
+    print(f"  Context scan ({context_mode}): ", end="", flush=True)
+    results = run_context_scan(
+        client, coarse_steps=context_coarse_steps(context_mode),
+    )
     print(" done")
 
     # Output table
@@ -3412,7 +3437,7 @@ def main():
     if not args.skip_context:
         print("[7/13] Context length test...")
         _run_step("Step 7 context length", report,
-                  test_context_length, client, report,
+                  test_context_length, client, report, args.context_mode,
                   crashes=step_crashes)
     else:
         print("[7/13] Context length test (skipped)")

--- a/docs/benchmark-spike-aiapitest.md
+++ b/docs/benchmark-spike-aiapitest.md
@@ -1,0 +1,177 @@
+# Benchmark Spike Reference: AiApiTest
+
+Reference repository: <https://github.com/huyang218/AiApiTest>
+
+Inspection date: 2026-05-19
+
+Reference commit inspected: `15e8ce90cb29626d537ae41f48caa0fc8abcc4a1`
+
+## Why This Exists
+
+`AiApiTest` is useful as a reference for a future benchmark spike, but it is
+not a direct fit for the core `api-relay-audit` pipeline.
+
+Our project scope is narrower: a local, evidence-oriented security audit for
+third-party AI API relays, with a zero-dependency standalone distribution and a
+modular tested distribution. `AiApiTest` is broader: it is a Flask-based API
+testing platform for model authenticity, provider comparison, benchmark
+metrics, token cost estimation, multimodal checks, and history UI.
+
+This document captures the ideas worth reusing without importing code.
+
+## Relevant Core Design in AiApiTest
+
+The central implementation is `api_tester.py` / `testers/text_tester.py`.
+
+Key pieces:
+
+- `ApiFormat` supports Anthropic, OpenAI-compatible, Azure OpenAI, Gemini, and
+  several domestic-provider labels that mostly route through OpenAI-compatible
+  calls.
+- `ApiTester.call_api()` normalizes request construction and response parsing
+  across providers.
+- `verify_model()` asks identity, cutoff, reasoning, math, code-analysis, and
+  consistency questions, then produces a coarse authenticity verdict.
+- `run_benchmark()` fires concurrent requests and reports success rate, latency
+  statistics, QPS, token counts, tokens/second, and estimated cost.
+- Flask routes in `routes/test_text.py` compare a tested relay against an
+  official provider configured in local settings.
+- The UI stores official-provider keys locally in `settings.json`, keeps tested
+  relay keys out of the database, and stores history in SQLite.
+
+## What Is Useful for Us
+
+### 1. Official-provider response comparison
+
+AiApiTest sends the same question set to both the tested relay and an official
+provider, then compares response similarity.
+
+Possible value for us:
+
+- A future experiment can test whether an advertised model is behaviorally close
+  to an official baseline.
+- This could complement, not replace, our existing security probes.
+- It can help investigate suspected silent substitution where Steps 5, 10, 12,
+  and 13 are inconclusive.
+
+Why it should stay experimental first:
+
+- It requires official provider keys, which violates the current "one key plus
+  base URL" simplicity of the main audit.
+- Similarity scores are noisy across temperature, routing, region, safety
+  policy, model snapshots, and prompt wording.
+- A low similarity score is not automatically a security finding.
+
+### 2. Benchmark metric reporting
+
+AiApiTest reports success rate, latency percentiles, QPS, total tokens,
+tokens/second, and estimated cost.
+
+Possible value for us:
+
+- Reuse the reporting vocabulary for a future `benchmark` spike.
+- Compare it with our Step 13 latency variance output.
+- Add cost and reliability context to reports without making it part of the
+  security risk matrix.
+
+Boundary:
+
+- Performance benchmarking is not the same as relay security auditing.
+- These metrics should remain informational unless tied to a documented
+  security threat model.
+
+### 3. Model-authenticity question sets
+
+AiApiTest uses reasoning, math, code, identity, and consistency questions to
+infer whether the tested endpoint behaves like the claimed model.
+
+Possible value for us:
+
+- Use as inspiration for a small clean-room benchmark corpus.
+- The corpus should be deterministic, short, low-cost, and versioned.
+- Scoring must be transparent and testable.
+
+Risks:
+
+- Many "intelligence" questions are easy to overfit and can create false
+  confidence.
+- Self-identification questions overlap with our Step 5 and are already known
+  to be noisy.
+- Capability deltas require honest baselines and periodic recalibration.
+
+### 4. Multimodal/version checks
+
+AiApiTest includes UI surfaces for image and video generation/version testing.
+
+Possible value for us:
+
+- This overlaps with ROADMAP §2.6.2, the multimodal dilution spike.
+- A tiny self-generated image fixture plus a deterministic judge could detect
+  substitution to a pure-text model.
+
+Boundary:
+
+- Do not add a hosted UI or external judge model.
+- Do not make multimodal probes default until cost and false-negative behavior
+  are measured.
+
+## What We Should Not Import
+
+- Do not import Flask, Bootstrap, SQLite history, or settings management into
+  the core audit.
+- Do not require official provider keys for the default audit path.
+- Do not add response-similarity scores to the LOW/MEDIUM/HIGH risk matrix.
+- Do not copy question text or code directly unless licensing is clarified.
+  The inspected repository does not expose a license through GitHub metadata in
+  the current checkout, so treat it as inspiration only.
+- Do not store API keys in repo-managed config files.
+
+## Proposed Future Spike
+
+Working title: `Capability benchmark delta`
+
+Suggested location:
+
+- `scripts/experiments/model_authenticity_benchmark_spike.py`
+- Optional supporting notes in `docs/model-authenticity-benchmark.md`
+
+Inputs:
+
+- Tested relay key and URL.
+- Tested model name.
+- Optional official-provider key and base URL.
+- Optional official model mapping.
+
+Outputs:
+
+- Markdown or JSON report with per-question results.
+- No LOW/MEDIUM/HIGH risk change.
+- Verdicts should be `close`, `different`, or `inconclusive`, not
+  `safe`/`unsafe`.
+
+Minimum viable probe set:
+
+- One model-field check.
+- Two deterministic reasoning questions.
+- One code-analysis question.
+- One short safety/identity consistency question.
+- Optional official-baseline comparison if an official key is configured.
+
+Acceptance criteria before shipping beyond `experiments/`:
+
+- Clean-room question set and scoring rules.
+- At least three honest baseline runs for the same advertised model.
+- Clear false-positive guidance in the report.
+- No dependency added to standalone `audit.py`.
+- No risk-matrix promotion until baseline variance is understood.
+
+## Relationship to Current Roadmap
+
+This reference maps most closely to ROADMAP item "Capability benchmark delta
+(direct model-substitution detection)" and to the multimodal dilution spike.
+
+Recommended next step:
+
+Keep this as a design reference. If we implement anything, start with a
+standalone experiment under `scripts/experiments/`, not a new default audit
+step.

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -28,7 +28,7 @@ from urllib.parse import urlparse
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from api_relay_audit.client import APIClient
-from api_relay_audit.context import run_context_scan
+from api_relay_audit.context import context_coarse_steps, run_context_scan
 from api_relay_audit.error_leakage import run_error_leakage_test
 from api_relay_audit.identity_patterns import find_non_claude_identities
 from api_relay_audit.infra_fingerprint import (
@@ -261,6 +261,11 @@ def parse_args():
     p.add_argument("--model", default="claude-opus-4-6", help="Model name")
     p.add_argument("--skip-infra", action="store_true", help="Skip infrastructure recon")
     p.add_argument("--skip-context", action="store_true", help="Skip context length test")
+    p.add_argument("--context-mode", choices=["full", "fast"], default="full",
+                   help="Context scan ladder. 'full' (default) tests up to "
+                        "800K chars; 'fast' is a low-cost smoke test up to "
+                        "200K chars and is not a full context-window "
+                        "certification.")
     p.add_argument("--skip-tool-substitution", action="store_true",
                    help="Skip tool-call package substitution test (AC-1.a)")
     p.add_argument("--skip-error-leakage", action="store_true",
@@ -1017,12 +1022,21 @@ def test_web3_injection(client, report):
     return verdict, inconclusive
 
 
-def test_context_length(client, report):
+def test_context_length(client, report, context_mode="full"):
     report.h2("7. Context Length Test")
     report.p("Place 5 canary markers at equal intervals in long text, check if model can recall all.\n")
+    if context_mode == "fast":
+        report.p(
+            "**Mode**: `fast` — low-cost smoke scan up to 200K chars. "
+            "Use `--context-mode full` for full 800K-char coverage.\n"
+        )
+    else:
+        report.p("**Mode**: `full` — default scan up to 800K chars.\n")
 
-    print("  Context scan: ", end="", flush=True)
-    results = run_context_scan(client)
+    print(f"  Context scan ({context_mode}): ", end="", flush=True)
+    results = run_context_scan(
+        client, coarse_steps=context_coarse_steps(context_mode),
+    )
     print(" done")
 
     # Output table
@@ -1387,7 +1401,7 @@ def main():
     if not args.skip_context:
         print("[7/13] Context length test...")
         _run_step("Step 7 context length", report,
-                  test_context_length, client, report,
+                  test_context_length, client, report, args.context_mode,
                   crashes=step_crashes)
     else:
         print("[7/13] Context length test (skipped)")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -318,10 +318,14 @@ class TestCurlFallback:
         assert cmd[0] == "curl"
         assert "-sk" in cmd
         assert "https://relay.example.com/v1/messages" in cmd
+        assert "--data-binary" in cmd
+        assert "@-" in cmd
         assert "--config" in cmd
-        assert "-" in cmd
-        config_input = mock_run.call_args[1].get("input", "")
-        assert "x-api-key: sk-test" in config_input
+        assert "-d" not in cmd
+        assert not any("sk-test" in str(part) for part in cmd)
+        payload = mock_run.call_args[1].get("input", b"")
+        assert isinstance(payload, bytes)
+        assert b'"model": "test"' in payload
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,7 +4,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from api_relay_audit.context import FILLER, run_context_scan, single_context_test
+from api_relay_audit.context import (
+    DEFAULT_CONTEXT_COARSE_STEPS,
+    FAST_CONTEXT_COARSE_STEPS,
+    FILLER,
+    context_coarse_steps,
+    run_context_scan,
+    single_context_test,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +147,19 @@ class TestSingleContextTest:
 # ---------------------------------------------------------------------------
 
 class TestRunContextScan:
+    def test_context_coarse_steps_modes(self):
+        assert context_coarse_steps("full") == DEFAULT_CONTEXT_COARSE_STEPS
+        assert context_coarse_steps("fast") == FAST_CONTEXT_COARSE_STEPS
+
+    def test_context_coarse_steps_returns_copy(self):
+        steps = context_coarse_steps("fast")
+        steps.append(999)
+        assert context_coarse_steps("fast") == FAST_CONTEXT_COARSE_STEPS
+
+    def test_context_coarse_steps_rejects_unknown_mode(self):
+        with pytest.raises(ValueError, match="unknown context scan mode"):
+            context_coarse_steps("turbo")
+
     @patch("api_relay_audit.context.time.sleep")
     def test_all_pass_no_binary_search(self, mock_sleep):
         """When all coarse steps pass, no binary search should occur."""

--- a/tests/test_dual_distribution_parity.py
+++ b/tests/test_dual_distribution_parity.py
@@ -11,6 +11,7 @@ so that drift is caught immediately.
 """
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -44,6 +45,55 @@ def test_risk_matrix_character_identical():
         "Risk matrix drift between scripts/audit.py and audit.py. "
         "Update both files so they are character-identical."
     )
+
+
+def test_curl_post_uses_stdin_payload_in_both_distributions(monkeypatch):
+    """Regression: the curl POST fallback must not place large JSON bodies or
+    secrets on the command line.
+
+    The GUI fork surfaced a Windows failure mode where long context bodies
+    exceed the 32 KB command-line limit. Both distributions should pipe the
+    request body via stdin with ``--data-binary @-`` while keeping headers in a
+    temporary curl config file rather than in argv.
+    """
+    import api_relay_audit.client as modular_client
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return MagicMock(returncode=0, stdout=b'{"ok": true}', stderr=b"")
+
+    monkeypatch.setattr(modular_client.subprocess, "run", fake_run)
+    modular = modular_client.APIClient(
+        "https://relay.example.com/v1", "sk-test", "claude-opus-4-6",
+    )
+    modular._curl_post(
+        "https://relay.example.com/v1/messages",
+        {"x-api-key": "sk-test", "content-type": "application/json"},
+        {"model": "claude-opus-4-6", "messages": [{"role": "user", "content": "x"}]},
+    )
+
+    standalone = _load_standalone_audit()
+    monkeypatch.setattr(standalone.subprocess, "run", fake_run)
+    standalone_client = standalone.APIClient(
+        "https://relay.example.com/v1", "sk-test", "claude-opus-4-6",
+    )
+    standalone_client._curl_post(
+        "https://relay.example.com/v1/messages",
+        {"x-api-key": "sk-test", "content-type": "application/json"},
+        {"model": "claude-opus-4-6", "messages": [{"role": "user", "content": "x"}]},
+    )
+
+    assert len(calls) == 2
+    for cmd, kwargs in calls:
+        assert "--data-binary" in cmd
+        assert "@-" in cmd
+        assert "-d" not in cmd
+        assert not any("sk-test" in str(part) for part in cmd)
+        payload = kwargs["input"]
+        assert isinstance(payload, bytes)
+        assert b'"model": "claude-opus-4-6"' in payload
 
 
 def _load_standalone_audit():

--- a/tests/test_dual_distribution_parity.py
+++ b/tests/test_dual_distribution_parity.py
@@ -171,6 +171,24 @@ def test_standalone_find_non_claude_identities_behaves_like_modular():
         )
 
 
+def test_context_scan_mode_constants_parity():
+    """The fast/full context ladders are user-visible cost controls and must
+    match between modular and standalone distributions.
+    """
+    from api_relay_audit.context import (
+        DEFAULT_CONTEXT_COARSE_STEPS as MODULAR_DEFAULT_STEPS,
+        FAST_CONTEXT_COARSE_STEPS as MODULAR_FAST_STEPS,
+        context_coarse_steps as modular_context_coarse_steps,
+    )
+
+    standalone = _load_standalone_audit()
+
+    assert standalone.DEFAULT_CONTEXT_COARSE_STEPS == MODULAR_DEFAULT_STEPS
+    assert standalone.FAST_CONTEXT_COARSE_STEPS == MODULAR_FAST_STEPS
+    assert standalone.context_coarse_steps("full") == modular_context_coarse_steps("full")
+    assert standalone.context_coarse_steps("fast") == modular_context_coarse_steps("fast")
+
+
 # ---------------------------------------------------------------------------
 # Step 12 / Step 13 (v1.8) constants parity
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR turns the external project review into four atomic changes:

- adds clean-room AiApiTest benchmark-spike notes for future benchmark design
- fixes curl fallback POST transport by sending JSON bodies through stdin instead of argv, while keeping headers in a temporary curl config file
- adds an optional `--context-mode fast` scan that preserves the default full 800K context scan
- keeps Claude draft review/issue-triage workflows advisory so external Claude account failures do not mark code PRs as failed

## Why

Issue #14 surfaced useful GUI fork work. The high-confidence parts are the Windows/long-command curl transport fix and the idea of an explicit fast context scan mode. The broader model-purity ideas are documented for later benchmark-spike evaluation instead of being merged into the risk matrix now.

The Claude draft-review check failed on this PR with `API Error: 400 This organization has been disabled`, which is external to this code diff. Since those workflows only draft comments and do not make merge decisions, they should not block PR status when the external Claude account is unavailable.

## Validation

- `python3 -m pytest tests/ -v` -> 574 passed
- `python3 scripts/audit.py --help` confirms `--context-mode {full,fast}`
- `python3 audit.py --help` confirms standalone parity for `--context-mode {full,fast}`
- targeted curl fallback and context/parity tests passed before full suite

## Notes

No generated benchmark GUI code is imported. The external projects are used only as reviewed references for compatible improvements.
