### PR TITLE
docs: add star history section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,7 @@ python audit.py --key <YOUR_KEY> --url <BASE_URL> --profile web3 --output report
 ## License
 
 MIT
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=toby-bridges/api-relay-audit&type=Date)](https://www.star-history.com/#toby-bridges/api-relay-audit&Date)


### PR DESCRIPTION
## Summary

- add a Star History section under License in README
- link the chart to star-history.com for `toby-bridges/api-relay-audit`

## Validation

- `git diff --check`
