### PR TITLE
[codex] Gate community evidence publication

### DIFF
--- a/.github/ISSUE_TEMPLATE/audit-report.yml
+++ b/.github/ISSUE_TEMPLATE/audit-report.yml
@@ -1,5 +1,5 @@
-name: Submit Audit Report / 提交审计报告
-description: Submit a community audit result for a relay / 提交中转站社区审计结果
+name: Submit Audit Evidence / 提交审计证据
+description: Submit community audit evidence for a relay / 提交中转站社区审计证据
 title: "[Audit] "
 labels: ["audit-submission"]
 body:
@@ -32,6 +32,24 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: tool_commit
+    attributes:
+      label: Tool Commit / 工具提交
+      description: "The api-relay-audit git commit used for this run (7-40 hex chars)."
+      placeholder: "040676c"
+    validations:
+      required: true
+
+  - type: input
+    id: tested_at
+    attributes:
+      label: Tested At / 审计时间
+      description: "ISO date or datetime when the audit was run, e.g. 2026-06-01 or 2026-06-01T12:00:00Z."
+      placeholder: "2026-06-01T12:00:00Z"
+    validations:
+      required: true
+
   - type: dropdown
     id: overall_rating
     attributes:
@@ -56,12 +74,34 @@ body:
       required: true
 
   - type: textarea
+    id: report_artifact
+    attributes:
+      label: Report Artifact / 报告文件
+      description: |
+        Upload or link the redacted Markdown report artifact that the hash below was calculated from.
+        The screenshot is only a human-readable preview; this report artifact is the reviewable evidence.
+        上传或粘贴已脱敏 Markdown 报告文件链接。下面的哈希应从这个报告文件计算得出。
+        截图只作为人工预览；该报告文件才是可复核证据。
+      placeholder: "Upload report-redacted.md here, or paste an https://... link"
+    validations:
+      required: true
+
+  - type: input
+    id: report_hash
+    attributes:
+      label: Report Hash / 报告哈希
+      description: "SHA-256 of the redacted report artifact, optionally prefixed with sha256:."
+      placeholder: "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    validations:
+      required: true
+
+  - type: textarea
     id: red_flags
     attributes:
       label: Key Findings / 主要发现
       description: |
-        List the main red/yellow flags from the Risk Summary section.
-        列出风险摘要中的主要红/黄标记。
+        List observed red/yellow evidence signals from the Risk Summary section.
+        列出风险摘要中的红/黄证据信号。
       placeholder: |
         - 🔴 Token injection: +3200 tokens
         - 🟡 Prompt extraction: 2/6 methods succeeded

--- a/.github/ISSUE_TEMPLATE/audit-report.yml
+++ b/.github/ISSUE_TEMPLATE/audit-report.yml
@@ -27,7 +27,7 @@ body:
     id: tool_version
     attributes:
       label: Tool Version / 工具版本
-      description: "e.g. v2.3 — run `python audit.py --version` to check"
+      description: "e.g. v2.3 — use the version shown in the audit report header"
       placeholder: "v2.3"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/operator-response.yml
+++ b/.github/ISSUE_TEMPLATE/operator-response.yml
@@ -18,11 +18,10 @@ body:
       label: Domain Ownership Proof / 域名控制权证明
       description: |
         Add a DNS TXT record: `_relay-audit-verify=<this-issue-number>`
-        We may use this to link the response to a domain operator. This is not
-        a trusted-relay certification.
+        We may use this only to link the response to a domain operator.
 
         添加 DNS TXT 记录：`_relay-audit-verify=<本issue编号>`
-        我们可能用它确认回应者与域名的关系；这不是对中转站安全性的官方背书。
+        我们只用它确认回应者与域名的关联。
       placeholder: "I have added the TXT record _relay-audit-verify=123"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/operator-response.yml
+++ b/.github/ISSUE_TEMPLATE/operator-response.yml
@@ -1,5 +1,5 @@
-name: Operator Response / 运营商申诉
-description: Respond to audit findings as the relay operator / 作为中转站运营商回应审计结果
+name: Operator Response / 运营商回应
+description: Respond to community-submitted audit evidence / 回应社区提交的审计证据
 title: "[Operator] "
 labels: ["operator-response"]
 body:
@@ -18,10 +18,11 @@ body:
       label: Domain Ownership Proof / 域名控制权证明
       description: |
         Add a DNS TXT record: `_relay-audit-verify=<this-issue-number>`
-        We will verify via nslookup before marking you as verified-operator.
+        We may use this to link the response to a domain operator. This is not
+        a trusted-relay certification.
 
         添加 DNS TXT 记录：`_relay-audit-verify=<本issue编号>`
-        我们会通过 nslookup 验证后标记为 verified-operator。
+        我们可能用它确认回应者与域名的关系；这不是对中转站安全性的官方背书。
       placeholder: "I have added the TXT record _relay-audit-verify=123"
     validations:
       required: true
@@ -38,7 +39,7 @@ body:
     attributes:
       label: Statement / 回应内容
       description: |
-        Your response to the audit findings. Explain any context, mitigations,
+        Your response to the audit evidence. Explain any context, mitigations,
         or corrections you'd like to make public.
       placeholder: "We have addressed the token injection finding by..."
     validations:

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -1,4 +1,4 @@
-name: Process Audit Submission
+name: Process Audit Evidence Submission
 
 on:
   issues:
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 concurrency:
   group: process-submission
@@ -28,6 +29,34 @@ jobs:
 
       - name: Sync latest master
         run: git pull --ff-only origin master
+
+      - name: Ensure workflow labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              { name: 'shape-valid', color: '0E8A16', description: 'Submission shape is valid; publication still requires review.' },
+              { name: 'needs-review', color: 'FBCA04', description: 'Submission needs manual review before evidence PR generation.' },
+              { name: 'rate-limited', color: 'D93F0B', description: 'Submission hit the per-relay rate limit.' },
+              { name: 'validation-errors', color: 'B60205', description: 'Submission failed required shape validation.' },
+              { name: 'evidence-pr-created', color: '1D76DB', description: 'A draft evidence publication PR was created.' }
+            ];
+            for (const label of labels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ...label
+                });
+              }
+            }
 
       - name: Get author account age
         id: author
@@ -53,6 +82,18 @@ jobs:
         if: steps.process.outputs.status == 'ERROR' || steps.process.outputs.status == ''
         run: exit 1
 
+      - name: Label shape-valid
+        if: steps.process.outputs.status == 'SHAPE_VALID'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ['shape-valid']
+            });
+
       - name: Label needs-review
         if: steps.process.outputs.status == 'NEEDS_REVIEW'
         uses: actions/github-script@v7
@@ -68,7 +109,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: '⚠️ Auto-check: GitHub account is less than 30 days old. This submission requires manual review.\n\n⚠️ 自动检查：GitHub 账号注册不满 30 天，需人工审核。'
+              body: '⚠️ Auto-check: this submission needs manual review before any evidence publication PR is generated.\n\n⚠️ 自动检查：该提交需要人工复核，暂不会生成公开证据 PR。'
             });
 
       - name: Label rate-limited
@@ -94,37 +135,91 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ['validation-errors']
+            });
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: '❌ Submission has validation errors. Please check the required fields and resubmit.\n\n❌ 提交存在验证错误，请检查必填字段后重新提交。'
+              body: '❌ Submission has validation errors. Please check the required fields and resubmit.\n\n❌ 提交存在格式校验错误，请检查必填字段后重新提交。'
             });
 
-      - name: Commit and push
-        if: steps.process.outputs.status == 'OK'
+      - name: Open evidence review PR
+        id: evidence_pr
+        if: steps.process.outputs.status == 'SHAPE_VALID'
         env:
+          GH_TOKEN: ${{ github.token }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          RELAY_DOMAIN: ${{ steps.process.outputs.relay_domain }}
+          REPORT_HASH: ${{ steps.process.outputs.report_hash }}
+          REPORT_ARTIFACT_URL: ${{ steps.process.outputs.report_artifact_url }}
+          TOOL_COMMIT: ${{ steps.process.outputs.tool_commit }}
         run: |
+          set -euo pipefail
+          BRANCH="community/evidence-issue-${ISSUE_NUMBER}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add web/data/relays.json
+          git switch -c "${BRANCH}"
+          git add web/data/evidence.json
           if git diff --cached --quiet; then
-            echo "No relay data changes to commit."
+            echo "No evidence data changes to publish for review."
+            echo "pr_url=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git commit -m "Add community audit: ${ISSUE_AUTHOR} (#${ISSUE_NUMBER})"
-          git push origin HEAD:master
+          git commit -m "Add community evidence: ${RELAY_DOMAIN} (#${ISSUE_NUMBER})"
+          git push --force-with-lease origin "${BRANCH}"
+          cat > /tmp/evidence-pr-body.md <<EOF
+          ## Summary
 
-      - name: Comment success
-        if: steps.process.outputs.status == 'OK'
+          This PR publishes one community-submitted audit evidence record.
+
+          - Relay domain: \`${RELAY_DOMAIN}\`
+          - Source issue: #${ISSUE_NUMBER}
+          - Submitter: @${ISSUE_AUTHOR}
+          - Tool commit: \`${TOOL_COMMIT}\`
+          - Report artifact: ${REPORT_ARTIFACT_URL}
+          - Report hash: \`${REPORT_HASH}\`
+
+          ## Governance
+
+          This is not a trusted-relay certification, not a safety endorsement, and not a leaderboard ranking. It is a proposed entry in the Community Evidence Registry. Merge only after maintainer review confirms the submitted evidence shape and publication boundary.
+          EOF
+          if gh pr view "${BRANCH}" --json url --jq .url >/tmp/existing-pr-url 2>/dev/null; then
+            PR_URL="$(cat /tmp/existing-pr-url)"
+            gh pr edit "${BRANCH}" \
+              --title "Add community audit evidence: ${RELAY_DOMAIN} (#${ISSUE_NUMBER})" \
+              --body-file /tmp/evidence-pr-body.md
+          else
+            PR_URL="$(gh pr create \
+              --draft \
+              --base master \
+              --head "${BRANCH}" \
+              --title "Add community audit evidence: ${RELAY_DOMAIN} (#${ISSUE_NUMBER})" \
+              --body-file /tmp/evidence-pr-body.md)"
+          fi
+          echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment evidence PR created
+        if: steps.process.outputs.status == 'SHAPE_VALID' && steps.evidence_pr.outputs.pr_url != ''
         uses: actions/github-script@v7
         with:
           script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ['evidence-pr-created']
+            });
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: '✅ Audit submission processed and added to the leaderboard. Thank you!\n\n✅ 审计提交已处理并添加到排行榜，感谢贡献！'
+              body: `✅ Shape validation passed. A draft evidence-publication PR was created for maintainer review: ${process.env.PR_URL}\n\n✅ 格式校验通过。系统已创建待人工复核的证据发布 PR：${process.env.PR_URL}\n\nNote: this has not been published to master, is not a relay recommendation, and is not a trusted-relay certification or safety endorsement.`
             });
+        env:
+          PR_URL: ${{ steps.evidence_pr.outputs.pr_url }}

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -170,9 +170,10 @@ jobs:
           REPORT_HASH: ${{ steps.process.outputs.report_hash }}
           REPORT_ARTIFACT_URL: ${{ steps.process.outputs.report_artifact_url }}
           TOOL_COMMIT: ${{ steps.process.outputs.tool_commit }}
+          EVIDENCE_BRANCH: ${{ steps.process.outputs.evidence_branch }}
         run: |
           set -euo pipefail
-          BRANCH="community/evidence-${RELAY_DOMAIN}-issue-${ISSUE_NUMBER}"
+          BRANCH="${EVIDENCE_BRANCH}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git switch -c "${BRANCH}"
@@ -198,7 +199,7 @@ jobs:
 
           ## Governance
 
-          This is not a trusted-relay certification, not a safety endorsement, and not a leaderboard ranking. It is a proposed entry in the Community Evidence Registry. Merge only after maintainer review confirms the submitted evidence shape and publication boundary.
+          This is a proposed Community Evidence Registry record. Merge only after maintainer review confirms the submitted evidence shape, artifact/hash linkage, and publication boundary.
           EOF
           if gh pr view "${BRANCH}" --json url --jq .url >/tmp/existing-pr-url 2>/dev/null; then
             PR_URL="$(cat /tmp/existing-pr-url)"
@@ -230,7 +231,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `✅ Shape validation passed. A draft evidence-publication PR was created for maintainer review: ${process.env.PR_URL}\n\n✅ 格式校验通过。系统已创建待人工复核的证据发布 PR：${process.env.PR_URL}\n\nNote: this has not been published to master, is not a relay recommendation, and is not a trusted-relay certification or safety endorsement.`
+              body: `✅ Shape validation passed. A draft Community Evidence Registry publication PR was created for maintainer review: ${process.env.PR_URL}\n\n✅ 格式校验通过。系统已创建待人工复核的 Community Evidence Registry 发布 PR：${process.env.PR_URL}\n\nThis evidence has not been published to master; publication requires maintainer review and merge of that PR.`
             });
         env:
           PR_URL: ${{ steps.evidence_pr.outputs.pr_url }}

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -2,7 +2,7 @@ name: Process Audit Evidence Submission
 
 on:
   issues:
-    types: [labeled]
+    types: [opened, labeled]
 
 permissions:
   contents: write
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   process:
-    if: github.event.label.name == 'audit-submission'
+    if: contains(github.event.issue.labels.*.name, 'audit-submission')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -68,6 +68,16 @@ jobs:
             });
             core.setOutput('created_at', user.data.created_at);
 
+      - name: Collect pending evidence PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr list \
+            --state open \
+            --base master \
+            --json headRefName,createdAt,isCrossRepository \
+            > /tmp/pending-evidence-prs.json
+
       - name: Run submission processor
         id: process
         env:
@@ -75,6 +85,7 @@ jobs:
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           AUTHOR_CREATED_AT: ${{ steps.author.outputs.created_at }}
+          PENDING_EVIDENCE_PRS_FILE: /tmp/pending-evidence-prs.json
         run: python3 scripts/process_submission.py
         continue-on-error: true
 
@@ -161,7 +172,7 @@ jobs:
           TOOL_COMMIT: ${{ steps.process.outputs.tool_commit }}
         run: |
           set -euo pipefail
-          BRANCH="community/evidence-issue-${ISSUE_NUMBER}"
+          BRANCH="community/evidence-${RELAY_DOMAIN}-issue-${ISSUE_NUMBER}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git switch -c "${BRANCH}"

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -15,7 +15,11 @@ concurrency:
 
 jobs:
   process:
-    if: contains(github.event.issue.labels.*.name, 'audit-submission')
+    if: >
+      (github.event.action == 'opened' &&
+       contains(github.event.issue.labels.*.name, 'audit-submission')) ||
+      (github.event.action == 'labeled' &&
+       github.event.label.name == 'audit-submission')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -184,7 +188,14 @@ jobs:
             exit 0
           fi
           git commit -m "Add community evidence: ${RELAY_DOMAIN} (#${ISSUE_NUMBER})"
-          git push --force-with-lease origin "${BRANCH}"
+          REMOTE_SHA="$(git ls-remote --heads origin "${BRANCH}" | awk '{print $1}')"
+          if [ -n "${REMOTE_SHA}" ]; then
+            git push \
+              --force-with-lease="refs/heads/${BRANCH}:${REMOTE_SHA}" \
+              origin "HEAD:${BRANCH}"
+          else
+            git push --force-with-lease origin "HEAD:${BRANCH}"
+          fi
           cat > /tmp/evidence-pr-body.md <<EOF
           ## Summary
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,9 @@ item has a short rationale so future contributors (including future
 iterations of the author) can quickly reconstruct why a thing is or is not
 on the list.
 
-**Last updated**: 2026-06-01 (Phase 3 full standalone generation landed; standalone remains first-class curl-only artifact while modular source is the source of truth)
+**Last updated**: 2026-06-07 (roadmap hygiene pass: v1.9 follow-up test gaps,
+refusal/transport decouplings, and the protobuf-channel spike are no longer
+active near-term candidates)
 
 **Threat model anchor**: Liu et al., *Your Agent Is Mine: Measuring
 Malicious Intermediary Attacks on the LLM Supply Chain*, arXiv:2604.08407.
@@ -49,6 +51,12 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
 - **ROADMAP 2.4 coverage closed**: real-body `APIClient.ensure_format()`
   tests now cover modular and standalone behavior; argparse-level
   `--latency-probe-count` wiring is pinned on both distributions.
+- **ROADMAP 2.45 low-blast decouplings closed**: the Step 4/6 refusal
+  vocabulary/helpers now live in `api_relay_audit/refusal.py` with
+  compatibility re-exports, and low-level transport mechanics now live in
+  `api_relay_audit/_transport.py` behind the existing `APIClient` facade.
+  The archived thinking-signature investigation script remains under
+  `scripts/experiments/verify_signature_schema.py`.
 - **Issue #14 downstream-fork uptake**: credited
   [@liuwei71320](https://github.com/liuwei71320) in `CONTRIBUTORS.md` for
   `ai-relay-audit-gui`; upstreamed the Windows long-context stability
@@ -230,16 +238,17 @@ and deferred the other two to v1.9.
   implementation these fail loudly because the mocked client returns
   instantaneously (elapsed ≈ 0), whereas the fake `perf_counter`
   yields `elapsed = 1.0`. Both distributions pinned.
-- **#2 test gap — `ensure_format` only exercised via mock**: deferred
-  to v1.9 (see item 2.5 below). Current `test_ensure_format_called_
-  before_timing` proves the ordering contract but does not exercise
-  the real `APIClient.ensure_format()` body.
-- **#5 test gap — validator not tested at `parse_args()` level**:
-  deferred to v1.9. Unit tests on `validate_probe_count` + parity
-  test on the constants are both green; what is missing is an
-  end-to-end `parse_args(["--latency-probe-count", "0"])` test that
-  fails with `SystemExit(2)` proving the wiring inside `scripts/
-  audit.py` AND the standalone argparse actually uses the validator.
+- **#2 test gap — `ensure_format` only exercised via mock**: **fixed in
+  v1.9**. `tests/test_client.py::TestAutoDetection::test_ensure_format_
+  real_body_detects_anthropic` exercises the real modular method body, and
+  `tests/test_dual_distribution_parity.py::test_standalone_ensure_format_
+  real_body_detects_anthropic` mirrors the same coverage onto the generated
+  standalone artifact.
+- **#5 test gap — validator not tested at `parse_args()` level**: **fixed
+  in v1.9**. `tests/test_dual_distribution_parity.py::test_latency_probe_
+  count_argparse_wiring_rejects_invalid_values` proves both distributions
+  wire `validate_probe_count` into argparse and reject invalid values with
+  `SystemExit(2)`.
 - **Final test count**: 562/562 passing (560 → 562, +2 this round).
 
 ### v1.8.2 Identity consistency wording (shipped 2026-05-29)
@@ -266,6 +275,8 @@ answers to "what model are you" self-identified as Qwen/DeepSeek in 4 of
 
 Pick one of these to start the next session. Each is scoped to fit in a
 single session, has a clear spec, and does not require new infrastructure.
+Items marked ✅ closed or historical are retained for auditability only; do
+not pick them as new work unless new evidence reopens the decision.
 
 ### 0. v1.8.1 — app-layer vs edge-layer framework separation
 **Status**: deferred from v1.8 Codex review HIGH finding (2026-04-18)
@@ -313,83 +324,45 @@ SOL Token Program / ERC-20 transfer calldata / BTC bech32 address.
 **Cost of deferring further**: low — no new adversarial case reported
 since the original paper.
 
-### 2.4 v1.9 — test-coverage follow-ups from Codex review cycle #2 round 2
-**Status**: 2 deferred test-coverage gaps from 2026-04-20 Codex
-verification; code-side fixes already shipped in v1.8.1.
-**Scope**: ~40 LOC new tests, no product changes.
+### 2.4 v1.9 — test-coverage follow-ups from Codex review cycle #2 round 2 ✅ closed
+**Status**: shipped in v1.9. This item is kept only as historical context
+for why the tests exist.
 
-1. **`ensure_format` real-body integration test** — current
-   `test_ensure_format_called_before_timing` proves the call-ordering
-   contract via a mock but never runs the real
-   `api_relay_audit.client.APIClient.ensure_format()` body. A reviewer
-   could silently replace the real method with a no-op and all tests
-   would still pass. Add an integration-style test that constructs a
-   real `APIClient` (mocked HTTP transport), calls `ensure_format()`,
-   and asserts `_format` is set to a sentinel value afterwards. Mirror
-   into the standalone via the `_load_standalone_audit()` helper in
-   `test_dual_distribution_parity.py`.
-2. **`--latency-probe-count` parser-level wiring test** — current
-   `TestValidateProbeCount` class exercises the validator directly but
-   does not prove `scripts/audit.py`'s argparse AND the standalone
-   argparse both actually wire the validator. Add a test that invokes
-   each distribution's `parse_args` (or entry point with
-   `monkeypatch.setattr(sys, "argv", ...)`) with values `0`, `-1`,
-   `51` and asserts `SystemExit(2)`. Without this, someone could
-   accidentally drop `type=validate_probe_count` from the
-   `add_argument` call and all existing tests would still pass.
+1. **`ensure_format` real-body integration test** — fixed by
+   `tests/test_client.py::TestAutoDetection::test_ensure_format_real_body_
+   detects_anthropic` plus the generated-standalone mirror in
+   `tests/test_dual_distribution_parity.py::test_standalone_ensure_format_
+   real_body_detects_anthropic`.
+2. **`--latency-probe-count` parser-level wiring test** — fixed by
+   `tests/test_dual_distribution_parity.py::test_latency_probe_count_argparse_
+   wiring_rejects_invalid_values`, which drives both modular and standalone
+   `parse_args()` with invalid values and expects `SystemExit(2)`.
 
-**Cost of deferring further**: low. Both are "defence-in-depth"
-rather than real bugs — the v1.8.1 fixes themselves are correct,
-these tests just harden the regression guard. Revisit when the next
-feature cycle starts (same session that picks up 2.5 over-engineering
-prune is a natural fit).
+**Cost of deferring further**: none; there is no remaining action for this
+item unless a future CLI refactor changes argparse wiring again.
 
 ### 2.45 v1.9 — controlled-blast decouplings (handoff-prep triage, 2026-04-20)
 
-**Status**: audit done 2026-04-20 before front-end handoff.
-**Shipped in this audit**: Tier A archival — `scripts/verify_signature_
-schema.py` moved to `scripts/experiments/` (zero blast on imports, no
-module references the archived script). Codex review on the move
-caught one latent path-drift bug: `OUT_DIR = Path(__file__).parent.
-parent / "reports"` would have written to `scripts/reports/` rather
-than `<repo_root>/reports/` after the rename. Fixed in the same
-branch by bumping the anchor to `.parent.parent.parent`. Regression
-lesson: whenever a script moves deeper into the tree, `__file__`-
-relative paths inside it must be re-verified.
-**Deferred to v1.9**: four real decoupling candidates ranked by
-blast-radius vs. leverage.
+**Status**: partially shipped in v1.9. This section now tracks the remaining
+decouplings, not the low-blast work that already landed.
+**Shipped**:
+- Tier A archival — `scripts/verify_signature_schema.py` moved to
+  `scripts/experiments/` (zero blast on imports, no module references the
+  archived script). Codex review on the move caught one latent path-drift bug:
+  `OUT_DIR = Path(__file__).parent.parent / "reports"` would have written to
+  `scripts/reports/` after the rename. Fixed by bumping the anchor to
+  `.parent.parent.parent`.
+- Step 4/6 refusal vocabulary/helpers moved into `api_relay_audit/refusal.py`
+  with `scripts.audit` compatibility re-exports.
+- Phase 2a transport extraction landed as `api_relay_audit/_transport.py`
+  behind the existing `APIClient` facade.
 
-1. **Extract `REFUSAL_MARKERS` + `_looks_like_refusal`**
-   from `scripts/audit.py` (lines 81, 156-158) into a new module
-   `api_relay_audit/refusal.py`.
-   **Scope** (verified via grep, 2026-04-20 Codex review):
-   - 3 call sites of `_looks_like_refusal` in `scripts/audit.py`
-     (lines 178, 403, 559) — NOT 6 as initially stated
-   - `tests/test_refusal_detector.py` already imports
-     `modular._looks_like_refusal` directly; a re-export on
-     `scripts/audit.py` keeps the test untouched, a hard rename
-     does not
-   - `tests/test_clean_summary_flags.py` does not import the
-     helpers but does exercise Step 4/6 with a `CLEAN_REFUSAL`
-     fixture, so any behavior change in the helper surfaces here
-   - Standalone `audit.py` keeps its inline copy unchanged — the
-     existing `TestRefusalMarkerParity` parity test covers drift
-   **Blast radius**: LOW. Parity test is the regression guard; if
-   it stays green and the test suite passes, the extraction is
-   safe. Recommended approach: re-export on `scripts.audit` so
-   `tests/test_refusal_detector.py` needs zero changes.
-   **Why now-safe**: unlike a client.py / audit.py split, this
-   does NOT require a standalone refactor because the parity
-   strategy already treats refusal markers as "inline on
-   standalone, imported on modular" in principle — we just need
-   to complete that on the modular side.
-   **Prereq**: none.
-   **Time estimate**: 25-30 min.
-   **Why deferred past this handoff**: medium-value, not zero-
-   blast. A typo in an import path or a missed call site would
-   produce a silent refusal-detection regression; worth a
-   proper code review rather than a 30-min squeeze before
-   handoff.
+**Remaining decoupling candidates** are ranked by blast-radius vs. leverage.
+
+1. **Extract `REFUSAL_MARKERS` + `_looks_like_refusal`** — **closed in
+   v1.9**. The modular source now imports/re-exports helpers from
+   `api_relay_audit/refusal.py`; standalone keeps the generated inline copy,
+   with refusal-marker parity tests guarding drift.
 
 2. **Split `api_relay_audit/client.py` (924 LOC)**
    into `client/transport.py` + `client/format_detection.py` +
@@ -397,31 +370,20 @@ blast-radius vs. leverage.
 
    **Codex review follow-up (2026-04-20)**: my original "HIGH
    blast / blocked on dual-distribution policy" framing was over-
-   pessimistic. A cheaper incremental path exists:
+   pessimistic. A cheaper incremental path existed, and Phase 2a
+   has now landed: low-level httpx/curl mechanics live in internal
+   `api_relay_audit/_transport.py`, while `APIClient` remains the
+   public facade.
 
-     *Phase 2a — transport extraction only, facade-preserved.*
-     Move just the httpx-vs-curl transport code into an internal
-     `api_relay_audit/_transport.py` helper module and have
-     `api_relay_audit/client.py` import from it. `APIClient`
-     class stays in `client.py`; all public imports stay valid.
-     No test changes. Standalone `audit.py` stays flat because
-     modular's public API is unchanged — the parity constraint
-     does not care what's behind the facade. Blast radius: LOW.
-     Time estimate: 60-90 min.
-
-   After 2a lands and stabilizes, Phase 2b (stream extraction)
+   After 2a stabilizes, Phase 2b (stream extraction)
    and 2c (format-detection extraction) can follow the same
    pattern. Only Phase 2d ("promote the internal modules to
    public re-exports under `api_relay_audit.client.*`") needs
    the dual-distribution policy decision, because that is when
    the standalone flat copy starts diverging.
 
-   **Scope (Phase 2a only)**: ~300 LOC moved into internal
-   helper + ~30 LOC of import rewiring inside `client.py`. No
-   change to public import paths. No change to standalone.
-   **Blast radius (Phase 2a)**: LOW.
-   **Prereq (Phase 2a)**: none.
-   **Time estimate (Phase 2a)**: 60-90 min.
+   **Remaining scope**: Phase 2b/2c only. Keep them facade-preserved
+   unless there is a concrete user-facing reason to expose submodules.
 
    **Original full-split Phase 2d** (for reference): HIGH blast,
    blocked on dual-distribution policy (keep / deprecate /
@@ -477,10 +439,11 @@ blast-radius vs. leverage.
    README cross-links), NOT 1 hour.
 
 **Cost of deferring further**: moderate. The former #1 and the Phase-2a
-slice of #2 are now shipped, and Phase 3 generation removed the
+slice of #2 are shipped, and Phase 3 generation removed the old
 dual-distribution blocker. The next backend refactor can start with the
-`scripts/audit.py` step-orchestration split; #4 remains a front-end
-colleague conversation, not a backend task.
+`scripts/audit.py` step-orchestration split or a facade-preserved stream /
+format-detection extraction; #4 remains a front-end colleague conversation,
+not a backend task.
 
 ### 2.5 v1.9 — over-engineering prune (backlog, handoff-prep triage)
 **Status**: audit done 2026-04-20 before front-end handoff; no deletions
@@ -519,9 +482,12 @@ inert reference code. Revisit when next feature cycle starts.
 
 ### 2.6 v1.9 — cctest.ai 复查衍生候选 (2026-05-03)
 
-**Status**: Spike-only / 研究阶段。**禁止动 master**；任何实现尝试只能落到
-draft PR，给前端同事 (post-2026-04-20 handoff) 接管时一并审视后再决定是否
-合并。无 spike 结果之前不写产品代码、不动 6D 风险矩阵、不动双分发。
+**Status**: partially shipped. Step 14 upstream channel classifier shipped in
+v1.9 through the lower-risk header/id/body route. The old protobuf-signature
+reverse-engineering plan is now historical context, not an active near-term
+candidate. Remaining items in this section stay spike-only / research-only:
+no default audit wiring, no 6D risk-matrix change, and no public per-relay
+claims without reviewable evidence.
 
 **Source**: cctest.ai/zh + cctest.ai/zh/faq 复查 (2026-05-03)。Memory
 `reference_cctest_ai.md` 同步更新。变更点 vs 19 天前情报：
@@ -565,7 +531,7 @@ draft PR，给前端同事 (post-2026-04-20 handoff) 接管时一并审视后再
 > Spike 阶段先验证 header-based 方案是否已满足需求，再决定是否还需 protobuf。
 > 结果：header-based 已经足够，protobuf 方案弃了（见下面"原方案"段，留作历史档案）。
 
-**原 Protobuf 签名解析 (upstream channel ID)**
+**原 Protobuf 签名解析 (upstream channel ID) — historical, not active**
 
 **What cctest.ai claims to do**: 解析 Anthropic 流式响应里的 signature
 字段 (Protobuf 编码)，反推上游渠道 → 输出
@@ -573,10 +539,12 @@ draft PR，给前端同事 (post-2026-04-20 handoff) 接管时一并审视后再
 `windsurf` / `antigravity` 标签，再对签名做 replay 校验是否被篡改。
 这是他们公开宣称的"业界最专业"护城河，闭源不公开算法。
 
-**Why this is the only真新技术 worth spiking**: 我们目前只能通过响应体
-关键词 (v1.7.4) 推断渠道，无法对签名做结构化解析。如果协议可解析，可以
-新增一个 **D7 渠道维度**（与现有 D1-D6 正交），把"渠道身份"从软指标
-升级为硬指标。
+**Why this was worth considering**: before Step 14 shipped, we could only
+infer channel from response wording and infrastructure clues. A parseable
+signature protocol might have provided a harder channel signal. In practice,
+the cleaner header/id/body classifier delivered the useful part without
+reverse-engineering a brittle opaque signature protocol or expanding the
+risk matrix.
 
 **Spike scope (research-only, NO product code)**:
 1. 抓取 5-10 条真实 Claude 直连响应（通过本地 `--transparent-log`
@@ -591,6 +559,9 @@ draft PR，给前端同事 (post-2026-04-20 handoff) 接管时一并审视后再
 5. 写最小 PoC `scripts/experiments/signature_decode_spike.py`（类比
    v1.8 时期的 `verify_signature_schema.py`，进 `experiments/` 不进
    主 pipeline），输出可行性报告 → ROADMAP §2.6.1 状态更新
+
+Current decision: do not run this spike unless new field evidence shows
+header/id/body classification is materially insufficient.
 
 **Pre-conditions to ship as Step 14**:
 - Anthropic 官方未来不破坏 wire format 的合理把握（cctest 自己也吃这个
@@ -699,14 +670,15 @@ clean-room 参考算法；全仓库改为 AGPL-3.0-only 后，可在保留归属
 |---|---|
 | 直接抄 cctest.ai 的 signature 字段映射表 | 闭源 SaaS 无 license；必须 clean-room reimplementation 从真实样本反推 |
 | 把 cctest.ai 的渠道标签字符串复用 | 同上；用方独立命名（如 `channel: bedrock-likely` 而非 `aws-bedrock`） |
-| 在 spike 阶段就升级 6D → 7D 矩阵 | 矩阵升级是 Step 14 ship 的最后一步，不是 spike 阶段决策 |
+| 在 spike 阶段就升级 6D → 7D 矩阵 | Step 14 已作为 informational classifier ship；渠道身份仍不进入风险矩阵。 |
 | 引入第三方多模态裁判模型 | 破坏零依赖不变量；裁判用关键词 + token overlap 可解决 |
 | 在 §2.6 spike 通过前公开任何 cctest.ai 测试结果 | 数据外泄风险；任何对外发布需用户显式批准 |
 
-**Cost of deferring further**: 低-中。cctest.ai 是闭源 SaaS，他们改不改
-我们也跟不到；但如果中转站市场普遍意识到 protobuf 签名校验是新基线，
-我们没有这能力会显得跛脚。建议下一个 feature cycle 启动时先做
-§2.6.1 spike（拿真实样本判断可行性），通过再做 §2.6.2。
+**Cost of deferring further**: low. Step 14 already covers the practical
+channel-classification need without protobuf parsing. If future field reports
+show header/id/body signals are insufficient, reopen the protobuf spike from
+this historical plan; otherwise the next real research candidate here is
+§2.6.2 multimodal dilution, and only as an experiments-only spike.
 
 ---
 
@@ -967,9 +939,11 @@ When adding any new feature, verify these hold before committing:
 
 **Starting a new session**:
 1. Read the top "Shipped" section to know current state
-2. Read "Near-term candidates" — pick one based on available time
-3. If the session is short (< 1 hour), pick items 1, 3, or 4. If longer,
-   pick item 2 or 5.
+2. Read "Near-term candidates" — skip entries marked closed / historical,
+   then pick one based on available time and current field evidence
+3. If the session is short (< 1 hour), prefer validation / docs /
+   rebase-safe work. If longer, pick a feature candidate only after checking
+   the architectural invariants and current PR queue.
 
 **Completing a feature**:
 1. Move it from "Near-term" to "Shipped" with the commit hash

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,8 +16,8 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **714** | `pytest --collect-only` |
-| 测试数 (static) | 695 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **732** | `pytest --collect-only` |
+| 测试数 (static) | 713 | grep `def test_*` in tests/ |
 | CLI flag 数 | 20 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-01 | `ROADMAP.md` 头部 |
@@ -25,14 +25,14 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `0d87641` | recent reachable commit; `--check` allows follow-up metrics commits |
-| Recorded commit date | 2026-06-05 | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `7e8f008` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit date | 2026-06-06 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
-- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 714。要么 ROADMAP 漏更新，要么有未记录的新测试。
+- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 732。要么 ROADMAP 漏更新，要么有未记录的新测试。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -20,13 +20,13 @@
 | 测试数 (static) | 714 | grep `def test_*` in tests/ |
 | CLI flag 数 | 20 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
-| ROADMAP 上次更新 | 2026-06-01 | `ROADMAP.md` 头部 |
+| ROADMAP 上次更新 | 2026-06-07 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `a6ab628` | recent reachable commit; `--check` allows follow-up metrics commits |
-| Recorded commit date | 2026-06-06 | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `7925f1e` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit date | 2026-06-07 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 

--- a/scripts/process_submission.py
+++ b/scripts/process_submission.py
@@ -336,6 +336,40 @@ def build_evidence_record(fields, issue_author, issue_number, now=None):
     }
 
 
+def find_existing_evidence_index(evidence_data, entry):
+    """Find an existing candidate for the same issue or report artifact hash."""
+    entry_issue = entry.get("issueNumber")
+    entry_hash = entry.get("reportHash", "")
+    entry_domain = normalize_domain(entry.get("relayDomain", ""))
+    for idx, existing in enumerate(evidence_data):
+        if not isinstance(existing, dict):
+            continue
+        existing_issue = existing.get("issueNumber")
+        if (
+            entry_issue is not None
+            and existing_issue == entry_issue
+            and existing.get("source") == entry.get("source")
+        ):
+            return idx
+        if (
+            entry_hash
+            and existing.get("reportHash") == entry_hash
+            and normalize_domain(_entry_domain(existing)) == entry_domain
+        ):
+            return idx
+    return None
+
+
+def upsert_evidence_record(evidence_data, entry):
+    """Insert or replace one evidence record without duplicating reruns."""
+    existing_idx = find_existing_evidence_index(evidence_data, entry)
+    if existing_idx is None:
+        return [*evidence_data, entry], "created"
+    updated = list(evidence_data)
+    updated[existing_idx] = entry
+    return updated, "updated"
+
+
 def main():
     body = os.environ.get("ISSUE_BODY", "")
     author = os.environ.get("ISSUE_AUTHOR", "")
@@ -374,15 +408,17 @@ def main():
         os.environ.get("PENDING_EVIDENCE_PRS_FILE", "")
     )
 
-    domain = normalize_domain(fields["relay_domain"])
-    if check_rate_limit(domain, evidence_data + pending_evidence_data):
+    entry = build_evidence_record(fields, author, issue_number)
+    evidence_branch = build_evidence_branch_name(entry["relayDomain"], issue_number)
+    existing_idx = find_existing_evidence_index(evidence_data, entry)
+
+    domain = entry["relayDomain"]
+    if existing_idx is None and check_rate_limit(domain, evidence_data + pending_evidence_data):
         print(f"RATE_LIMITED: {domain} has >= {MAX_SUBMISSIONS_PER_RELAY_24H} submissions in 24h")
         _set_output("status", "RATE_LIMITED")
         sys.exit(4)
 
-    entry = build_evidence_record(fields, author, issue_number)
-    evidence_branch = build_evidence_branch_name(entry["relayDomain"], issue_number)
-    evidence_data.append(entry)
+    evidence_data, upsert_action = upsert_evidence_record(evidence_data, entry)
 
     EVIDENCE_JSON.parent.mkdir(parents=True, exist_ok=True)
     EVIDENCE_JSON.write_text(
@@ -396,7 +432,11 @@ def main():
     _set_output("report_artifact_url", entry["reportArtifactUrl"])
     _set_output("tool_commit", entry["toolCommit"])
     _set_output("evidence_branch", evidence_branch)
-    print(f"SHAPE_VALID: staged evidence for {domain} (#{issue_number}) by @{author}")
+    _set_output("evidence_action", upsert_action)
+    print(
+        f"SHAPE_VALID: {upsert_action} evidence for {domain} "
+        f"(#{issue_number}) by @{author}"
+    )
     print("Publication requires maintainer review via PR; no direct master push.")
 
 

--- a/scripts/process_submission.py
+++ b/scripts/process_submission.py
@@ -36,6 +36,7 @@ MAX_FLAG_LENGTH = 500
 MAX_IMAGES = 4
 MAX_VERSION_LENGTH = 20
 STALE_AFTER_DAYS = 90
+TESTED_AT_FUTURE_GRACE_SECONDS = 300
 
 HOSTNAME_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
 TOOL_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
@@ -120,6 +121,24 @@ def is_valid_hostname(hostname):
     return all(HOSTNAME_LABEL_RE.fullmatch(label) for label in labels)
 
 
+def evidence_needs_staleness_review(tested_at, now=None):
+    """Return True when submitted evidence is older than its review window."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    return parse_tested_at(tested_at) + timedelta(days=STALE_AFTER_DAYS) < now
+
+
+def build_evidence_branch_name(relay_domain, issue_number):
+    """Build the only branch shape used for draft evidence-publication PRs."""
+    domain = normalize_domain(relay_domain)
+    issue = str(issue_number or "").strip()
+    if not is_valid_hostname(domain):
+        raise ValueError(f"invalid evidence branch domain: {relay_domain!r}")
+    if not issue.isdecimal():
+        raise ValueError(f"invalid evidence branch issue number: {issue_number!r}")
+    return f"community/evidence-{domain}-issue-{int(issue)}"
+
+
 def validate_fields(fields):
     """Return list of error messages. Empty list = valid shape."""
     errors = []
@@ -159,9 +178,15 @@ def validate_fields(fields):
     tested_at = fields.get("tested_at", "")
     if tested_at:
         try:
-            parse_tested_at(tested_at)
+            parsed_tested_at = parse_tested_at(tested_at)
         except ValueError:
             errors.append(f"Invalid tested_at ISO date/datetime: {tested_at}")
+        else:
+            future_cutoff = datetime.now(timezone.utc) + timedelta(
+                seconds=TESTED_AT_FUTURE_GRACE_SECONDS
+            )
+            if parsed_tested_at > future_cutoff:
+                errors.append(f"tested_at cannot be in the future: {tested_at}")
 
     report_hash = fields.get("report_hash", "")
     if report_hash and not REPORT_HASH_RE.fullmatch(report_hash.strip()):
@@ -336,6 +361,11 @@ def main():
         _set_output("status", "NEEDS_REVIEW")
         sys.exit(3)
 
+    if evidence_needs_staleness_review(fields["tested_at"]):
+        print("NEEDS_REVIEW: evidence is older than the staleness review window")
+        _set_output("status", "NEEDS_REVIEW")
+        sys.exit(3)
+
     if EVIDENCE_JSON.exists():
         evidence_data = json.loads(EVIDENCE_JSON.read_text(encoding="utf-8"))
     else:
@@ -351,6 +381,7 @@ def main():
         sys.exit(4)
 
     entry = build_evidence_record(fields, author, issue_number)
+    evidence_branch = build_evidence_branch_name(entry["relayDomain"], issue_number)
     evidence_data.append(entry)
 
     EVIDENCE_JSON.parent.mkdir(parents=True, exist_ok=True)
@@ -364,6 +395,7 @@ def main():
     _set_output("report_hash", entry["reportHash"])
     _set_output("report_artifact_url", entry["reportArtifactUrl"])
     _set_output("tool_commit", entry["toolCommit"])
+    _set_output("evidence_branch", evidence_branch)
     print(f"SHAPE_VALID: staged evidence for {domain} (#{issue_number}) by @{author}")
     print("Publication requires maintainer review via PR; no direct master push.")
 

--- a/scripts/process_submission.py
+++ b/scripts/process_submission.py
@@ -16,6 +16,7 @@ Environment variables (set by the Action):
   ISSUE_AUTHOR      -- GitHub username of the submitter
   ISSUE_NUMBER      -- issue number
   AUTHOR_CREATED_AT -- ISO timestamp of the author's GitHub account creation
+  PENDING_EVIDENCE_PRS_FILE -- optional gh-pr-list JSON for open evidence PRs
   GITHUB_OUTPUT     -- path to output file (set by GitHub Actions runtime)
 """
 
@@ -41,6 +42,7 @@ TOOL_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
 REPORT_HASH_RE = re.compile(r"^(?:sha256:)?[0-9a-fA-F]{64}$")
 MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]\r\n]*\]\((https://[^\s)]+)\)")
 HTTPS_URL_RE = re.compile(r"https://[^\s<>)]+")
+PENDING_EVIDENCE_BRANCH_RE = re.compile(r"^community/evidence-(?P<domain>[^/]+)-issue-\d+$")
 
 
 def _set_output(key, value):
@@ -220,6 +222,33 @@ def check_rate_limit(domain, evidence_data):
     return count >= MAX_SUBMISSIONS_PER_RELAY_24H
 
 
+def load_pending_evidence_pr_entries(path):
+    """Load open evidence PR branch metadata as rate-limit entries."""
+    if not path:
+        return []
+    try:
+        items = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError) as exc:
+        print(f"WARNING: could not load pending evidence PRs: {exc}")
+        return []
+
+    entries = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("isCrossRepository"):
+            continue
+        match = PENDING_EVIDENCE_BRANCH_RE.fullmatch(item.get("headRefName", ""))
+        if not match:
+            continue
+        domain = normalize_domain(match.group("domain"))
+        created_at = item.get("createdAt", "")
+        if not created_at or not is_valid_hostname(domain):
+            continue
+        entries.append({"relayDomain": domain, "submittedAt": created_at})
+    return entries
+
+
 def extract_image_urls(text):
     """Extract strict HTTPS image URLs from markdown image syntax."""
     urls = []
@@ -311,9 +340,12 @@ def main():
         evidence_data = json.loads(EVIDENCE_JSON.read_text(encoding="utf-8"))
     else:
         evidence_data = []
+    pending_evidence_data = load_pending_evidence_pr_entries(
+        os.environ.get("PENDING_EVIDENCE_PRS_FILE", "")
+    )
 
     domain = normalize_domain(fields["relay_domain"])
-    if check_rate_limit(domain, evidence_data):
+    if check_rate_limit(domain, evidence_data + pending_evidence_data):
         print(f"RATE_LIMITED: {domain} has >= {MAX_SUBMISSIONS_PER_RELAY_24H} submissions in 24h")
         _set_output("status", "RATE_LIMITED")
         sys.exit(4)

--- a/scripts/process_submission.py
+++ b/scripts/process_submission.py
@@ -1,40 +1,46 @@
 #!/usr/bin/env python3
 """
-Process an audit-submission GitHub Issue and update the relay leaderboard data.
+Process a community audit-evidence GitHub Issue.
 
 Called by the process-submission.yml GitHub Action. Reads issue metadata from
-environment variables set by the action, validates the submission, and appends
-to web/data/relays.json. Writes status to $GITHUB_OUTPUT for workflow routing.
+environment variables, validates the submitted shape, and writes a candidate
+evidence record to web/data/evidence.json. The workflow must put that JSON diff
+behind a maintainer-reviewed PR; community issues never publish directly to
+master.
 
 Usage (by GitHub Action):
-  python scripts/process_submission.py
+  python3 scripts/process_submission.py
 
 Environment variables (set by the Action):
-  ISSUE_BODY        — full issue body text
-  ISSUE_AUTHOR      — GitHub username of the submitter
-  ISSUE_NUMBER      — issue number
-  ISSUE_CREATED_AT  — ISO timestamp of issue creation
-  AUTHOR_CREATED_AT — ISO timestamp of the author's GitHub account creation
-  GITHUB_OUTPUT     — path to output file (set by GitHub Actions runtime)
+  ISSUE_BODY        -- full issue body text
+  ISSUE_AUTHOR      -- GitHub username of the submitter
+  ISSUE_NUMBER      -- issue number
+  AUTHOR_CREATED_AT -- ISO timestamp of the author's GitHub account creation
+  GITHUB_OUTPUT     -- path to output file (set by GitHub Actions runtime)
 """
 
 import json
 import os
 import re
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
-RELAYS_JSON = Path(__file__).resolve().parent.parent / "web" / "data" / "relays.json"
+EVIDENCE_JSON = Path(__file__).resolve().parent.parent / "web" / "data" / "evidence.json"
 ACCOUNT_AGE_WARN_DAYS = 30
 MAX_SUBMISSIONS_PER_RELAY_24H = 10
 MAX_RED_FLAGS = 10
 MAX_FLAG_LENGTH = 500
 MAX_IMAGES = 4
 MAX_VERSION_LENGTH = 20
+STALE_AFTER_DAYS = 90
+
 HOSTNAME_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+TOOL_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+REPORT_HASH_RE = re.compile(r"^(?:sha256:)?[0-9a-fA-F]{64}$")
 MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]\r\n]*\]\((https://[^\s)]+)\)")
+HTTPS_URL_RE = re.compile(r"https://[^\s<>)]+")
 
 
 def _set_output(key, value):
@@ -53,9 +59,13 @@ def parse_issue_body(body):
         "relay_domain": r"### Relay Domain.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
         "profile": r"### Audit Profile.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
         "tool_version": r"### Tool Version.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
+        "tool_commit": r"### Tool Commit.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
+        "tested_at": r"### Tested At.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
         "overall_rating": r"### Overall Rating.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
+        "report_hash": r"### Report Hash.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
         "red_flags": r"### Key Findings.*?\n\n(.+?)(?:\n###|\Z)",
         "report_image": r"### Report Screenshot.*?\n\n(.+?)(?:\n###|\Z)",
+        "report_artifact": r"### Report Artifact.*?\n\n(.+?)(?:\n###|\Z)",
     }
 
     for key, pattern in patterns.items():
@@ -69,6 +79,28 @@ def parse_issue_body(body):
 def normalize_domain(domain):
     """Lowercase, strip whitespace and trailing dots."""
     return domain.lower().strip().rstrip(".")
+
+
+def normalize_report_hash(report_hash):
+    """Normalize a SHA-256 report hash to sha256:<lowercase-hex>."""
+    value = (report_hash or "").strip().lower()
+    if value.startswith("sha256:"):
+        return value
+    return f"sha256:{value}"
+
+
+def parse_tested_at(value):
+    """Parse an ISO date/datetime, returning an aware UTC datetime."""
+    if not value:
+        raise ValueError("empty tested_at")
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        parsed = datetime.fromisoformat(f"{normalized}T00:00:00+00:00")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def is_valid_hostname(hostname):
@@ -87,10 +119,20 @@ def is_valid_hostname(hostname):
 
 
 def validate_fields(fields):
-    """Return list of error messages. Empty list = valid."""
+    """Return list of error messages. Empty list = valid shape."""
     errors = []
 
-    required = ["relay_domain", "profile", "tool_version", "overall_rating", "report_image"]
+    required = [
+        "relay_domain",
+        "profile",
+        "tool_version",
+        "tool_commit",
+        "tested_at",
+        "overall_rating",
+        "report_hash",
+        "report_image",
+        "report_artifact",
+    ]
     for f in required:
         if not fields.get(f):
             errors.append(f"Missing required field: {f}")
@@ -108,6 +150,21 @@ def validate_fields(fields):
         elif not re.fullmatch(r"v?\d+\.\d+(?:\.\d+)?", version):
             errors.append(f"Invalid tool_version format: {version}")
 
+    tool_commit = fields.get("tool_commit", "")
+    if tool_commit and not TOOL_COMMIT_RE.fullmatch(tool_commit.strip()):
+        errors.append(f"Invalid tool_commit format: {tool_commit}")
+
+    tested_at = fields.get("tested_at", "")
+    if tested_at:
+        try:
+            parse_tested_at(tested_at)
+        except ValueError:
+            errors.append(f"Invalid tested_at ISO date/datetime: {tested_at}")
+
+    report_hash = fields.get("report_hash", "")
+    if report_hash and not REPORT_HASH_RE.fullmatch(report_hash.strip()):
+        errors.append("report_hash must be a SHA-256 hex digest, optionally prefixed with sha256:")
+
     domain = fields.get("relay_domain", "")
     if domain:
         canonical_domain = normalize_domain(domain)
@@ -117,6 +174,10 @@ def validate_fields(fields):
     report_image = fields.get("report_image", "")
     if report_image and not extract_image_urls(report_image):
         errors.append("report_image must contain at least one image URL (![alt](https://...))")
+
+    report_artifact = fields.get("report_artifact", "")
+    if report_artifact and not extract_artifact_url(report_artifact):
+        errors.append("report_artifact must contain an HTTPS report artifact URL")
 
     return errors
 
@@ -134,19 +195,25 @@ def check_account_age(author_created_at):
         return True
 
 
-def check_rate_limit(domain, relays_data):
+def _entry_domain(entry):
+    return entry.get("relayDomain") or entry.get("domain", "")
+
+
+def check_rate_limit(domain, evidence_data):
     """Return True if domain has >= MAX_SUBMISSIONS_PER_RELAY_24H in last 24h."""
     now = datetime.now(timezone.utc)
     count = 0
     canonical_domain = normalize_domain(domain)
-    for entry in relays_data:
-        if normalize_domain(entry.get("domain", "")) != canonical_domain:
+    for entry in evidence_data:
+        if normalize_domain(_entry_domain(entry)) != canonical_domain:
             continue
         try:
             submitted = datetime.fromisoformat(
                 entry.get("submittedAt", "2000-01-01").replace("Z", "+00:00")
             )
-            if (now - submitted).total_seconds() < 86400:
+            if submitted.tzinfo is None:
+                submitted = submitted.replace(tzinfo=timezone.utc)
+            if (now - submitted.astimezone(timezone.utc)).total_seconds() < 86400:
                 count += 1
         except (ValueError, TypeError):
             pass
@@ -164,20 +231,23 @@ def extract_image_urls(text):
     return urls
 
 
-def build_relay_entry(fields, issue_author, issue_number, now=None):
-    """Build a relay data entry from validated fields."""
-    rating_map = {"LOW": "green", "MEDIUM": "yellow", "HIGH": "red"}
-    rating_label_map = {
-        "LOW": "\U0001f7e2 Low Risk",
-        "MEDIUM": "\U0001f7e1 Medium Risk",
-        "HIGH": "\U0001f534 High Risk",
-    }
+def extract_artifact_url(text):
+    """Extract the first HTTPS URL from an uploaded or linked report artifact."""
+    for match in HTTPS_URL_RE.finditer(text or ""):
+        url = match.group(0).rstrip(".,;")
+        parsed = urlparse(url)
+        if parsed.scheme == "https" and parsed.netloc:
+            return url
+    return ""
 
+
+def build_evidence_record(fields, issue_author, issue_number, now=None):
+    """Build a community-submitted audit evidence record from validated fields."""
     if now is None:
         now = datetime.now(timezone.utc)
 
-    overall = fields["overall_rating"].upper()
-    image_urls = extract_image_urls(fields.get("report_image", ""))[:MAX_IMAGES]
+    tested_at = parse_tested_at(fields["tested_at"])
+    stale_after = tested_at + timedelta(days=STALE_AFTER_DAYS)
 
     red_flags = []
     if fields.get("red_flags"):
@@ -189,18 +259,26 @@ def build_relay_entry(fields, issue_author, issue_number, now=None):
                 break
 
     return {
-        "domain": normalize_domain(fields["relay_domain"]),
-        "rating": rating_map.get(overall, "yellow"),
-        "ratingLabel": rating_label_map.get(overall, overall),
-        "testDate": now.strftime("%Y-%m-%d"),
-        "submittedAt": now.isoformat(),
-        "submittedBy": issue_author,
-        "issueNumber": int(issue_number) if issue_number else None,
+        "schemaVersion": 1,
+        "recordType": "community-submitted-audit-evidence",
+        "relayDomain": normalize_domain(fields["relay_domain"]),
         "toolVersion": fields.get("tool_version", ""),
-        "profile": fields.get("profile", "general").lower(),
+        "toolCommit": fields["tool_commit"].strip().lower(),
+        "auditProfile": fields.get("profile", "general").lower(),
+        "toolReportedOverallRating": fields["overall_rating"].upper(),
+        "submittedAt": now.isoformat(),
+        "testedAt": tested_at.isoformat(),
+        "submitter": issue_author,
+        "issueNumber": int(issue_number) if issue_number else None,
+        "reportHash": normalize_report_hash(fields["report_hash"]),
+        "reportArtifactUrl": extract_artifact_url(fields["report_artifact"]),
+        "evidenceStatus": "accepted_unverified",
+        "reviewStatus": "unverified",
+        "disputeStatus": "none",
+        "staleAfter": stale_after.date().isoformat(),
         "redFlags": red_flags,
-        "reportImages": image_urls,
-        "source": "community",
+        "reportImages": extract_image_urls(fields.get("report_image", ""))[:MAX_IMAGES],
+        "source": "github-issue",
     }
 
 
@@ -229,29 +307,33 @@ def main():
         _set_output("status", "NEEDS_REVIEW")
         sys.exit(3)
 
-    if RELAYS_JSON.exists():
-        relays_data = json.loads(RELAYS_JSON.read_text(encoding="utf-8"))
+    if EVIDENCE_JSON.exists():
+        evidence_data = json.loads(EVIDENCE_JSON.read_text(encoding="utf-8"))
     else:
-        relays_data = []
+        evidence_data = []
 
     domain = normalize_domain(fields["relay_domain"])
-    if check_rate_limit(domain, relays_data):
+    if check_rate_limit(domain, evidence_data):
         print(f"RATE_LIMITED: {domain} has >= {MAX_SUBMISSIONS_PER_RELAY_24H} submissions in 24h")
         _set_output("status", "RATE_LIMITED")
         sys.exit(4)
 
-    entry = build_relay_entry(fields, author, issue_number)
-    relays_data.append(entry)
+    entry = build_evidence_record(fields, author, issue_number)
+    evidence_data.append(entry)
 
-    RELAYS_JSON.parent.mkdir(parents=True, exist_ok=True)
-    RELAYS_JSON.write_text(
-        json.dumps(relays_data, ensure_ascii=False, indent=2),
+    EVIDENCE_JSON.parent.mkdir(parents=True, exist_ok=True)
+    EVIDENCE_JSON.write_text(
+        json.dumps(evidence_data, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",
     )
 
-    _set_output("status", "OK")
-    print(f"OK: added {domain} (#{issue_number}) by @{author}")
-    print(f"Total entries: {len(relays_data)}")
+    _set_output("status", "SHAPE_VALID")
+    _set_output("relay_domain", entry["relayDomain"])
+    _set_output("report_hash", entry["reportHash"])
+    _set_output("report_artifact_url", entry["reportArtifactUrl"])
+    _set_output("tool_commit", entry["toolCommit"])
+    print(f"SHAPE_VALID: staged evidence for {domain} (#{issue_number}) by @{author}")
+    print("Publication requires maintainer review via PR; no direct master push.")
 
 
 if __name__ == "__main__":

--- a/tests/test_process_submission.py
+++ b/tests/test_process_submission.py
@@ -16,9 +16,11 @@ from process_submission import (  # noqa: E402
     evidence_needs_staleness_review,
     extract_artifact_url,
     extract_image_urls,
+    find_existing_evidence_index,
     load_pending_evidence_pr_entries,
     normalize_report_hash,
     parse_issue_body,
+    upsert_evidence_record,
     validate_fields,
 )
 
@@ -123,6 +125,35 @@ def test_build_evidence_record():
     assert len(entry["redFlags"]) == 2
     assert len(entry["reportImages"]) == 1
     assert entry["reportImages"][0] != entry["reportArtifactUrl"]
+
+
+def test_upsert_evidence_record_replaces_same_issue():
+    fields = parse_issue_body(SAMPLE_BODY)
+    original = build_evidence_record(fields, "testuser", "42")
+    updated_fields = parse_issue_body(_make_body(overall_rating="MEDIUM"))
+    updated = build_evidence_record(updated_fields, "testuser", "42")
+
+    data, action = upsert_evidence_record([original], updated)
+
+    assert action == "updated"
+    assert len(data) == 1
+    assert data[0]["issueNumber"] == 42
+    assert data[0]["toolReportedOverallRating"] == "MEDIUM"
+
+
+def test_upsert_evidence_record_replaces_same_domain_report_hash():
+    fields = parse_issue_body(SAMPLE_BODY)
+    original = build_evidence_record(fields, "testuser", "42")
+    duplicate_fields = parse_issue_body(_make_body(relay_domain="API.Example.COM."))
+    duplicate = build_evidence_record(duplicate_fields, "other-user", "99")
+
+    assert find_existing_evidence_index([original], duplicate) == 0
+    data, action = upsert_evidence_record([original], duplicate)
+
+    assert action == "updated"
+    assert len(data) == 1
+    assert data[0]["issueNumber"] == 99
+    assert data[0]["relayDomain"] == "api.example.com"
 
 
 def test_check_account_age():
@@ -532,6 +563,43 @@ def test_main_creates_evidence_json(tmp_path, monkeypatch):
     assert "report_artifact_url=https://github.com/user-attachments/files/123/report-redacted.md" in output
     assert "tool_commit=040676c" in output
     assert "evidence_branch=community/evidence-api.example.com-issue-1" in output
+    assert "evidence_action=created" in output
+
+
+def test_main_rerun_updates_existing_evidence_without_duplicate(tmp_path, monkeypatch):
+    import process_submission as mod
+
+    fake_evidence = tmp_path / "web" / "data" / "evidence.json"
+    output_file = tmp_path / "github-output.txt"
+    monkeypatch.setattr(mod, "EVIDENCE_JSON", fake_evidence)
+
+    old_fields = parse_issue_body(_make_body(overall_rating="HIGH"))
+    old_entry = build_evidence_record(old_fields, "testbot", "1")
+    fake_evidence.parent.mkdir(parents=True, exist_ok=True)
+    fake_evidence.write_text(
+        json.dumps([old_entry], ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv(
+        "ISSUE_BODY",
+        _make_body(
+            overall_rating="MEDIUM",
+            tested_at=datetime.now(timezone.utc).isoformat(),
+        ),
+    )
+    monkeypatch.setenv("ISSUE_AUTHOR", "testbot")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("AUTHOR_CREATED_AT", "2020-01-01T00:00:00Z")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    mod.main()
+
+    data = json.loads(fake_evidence.read_text(encoding="utf-8"))
+    assert len(data) == 1
+    assert data[0]["issueNumber"] == 1
+    assert data[0]["toolReportedOverallRating"] == "MEDIUM"
+    assert "evidence_action=updated" in output_file.read_text(encoding="utf-8")
 
 
 def test_main_routes_stale_evidence_to_review_without_writing(tmp_path, monkeypatch):
@@ -567,6 +635,12 @@ def test_workflow_uses_draft_evidence_pr_contract():
     assert "gh pr edit" in workflow
     assert "gh pr create" in workflow
     assert "--draft" in workflow
+    assert "github.event.action == 'opened'" in workflow
+    assert "github.event.action == 'labeled'" in workflow
+    assert "github.event.label.name == 'audit-submission'" in workflow
+    assert "contains(github.event.issue.labels.*.name, 'audit-submission')" in workflow
+    assert 'git ls-remote --heads origin "${BRANCH}"' in workflow
+    assert '--force-with-lease="refs/heads/${BRANCH}:${REMOTE_SHA}"' in workflow
     assert "web/data/evidence.json" in workflow
     assert "web/data/relays.json" not in workflow
     for forbidden in [

--- a/tests/test_process_submission.py
+++ b/tests/test_process_submission.py
@@ -5,11 +5,15 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from process_submission import (  # noqa: E402
+    build_evidence_branch_name,
     build_evidence_record,
     check_account_age,
     check_rate_limit,
+    evidence_needs_staleness_review,
     extract_artifact_url,
     extract_image_urls,
     load_pending_evidence_pr_entries,
@@ -380,6 +384,33 @@ def test_tested_at_date_or_datetime():
     assert [e for e in validate_fields(fields) if "tested_at" in e]
 
 
+def test_tested_at_future_is_rejected():
+    future = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+    fields = parse_issue_body(_make_body(tested_at=future))
+    errors = validate_fields(fields)
+    assert any("tested_at cannot be in the future" in e for e in errors)
+
+
+def test_stale_evidence_needs_review():
+    now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    assert evidence_needs_staleness_review("2026-03-01T00:00:00Z", now=now) is True
+    assert evidence_needs_staleness_review("2026-05-01T00:00:00Z", now=now) is False
+
+
+def test_evidence_branch_name_is_canonical():
+    assert (
+        build_evidence_branch_name("API.Example.COM.", "0042")
+        == "community/evidence-api.example.com-issue-42"
+    )
+    for domain, issue in [
+        ("api.example.com/path", "42"),
+        ("bad_domain.com", "42"),
+        ("api.example.com", "42;rm"),
+    ]:
+        with pytest.raises(ValueError):
+            build_evidence_branch_name(domain, issue)
+
+
 def test_build_entry_low_rating_preserves_tool_reported_rating():
     """LOW is a tool-reported result, not a platform safety endorsement."""
     fields = parse_issue_body(_make_body(overall_rating="LOW"))
@@ -476,13 +507,15 @@ def test_main_creates_evidence_json(tmp_path, monkeypatch):
     import process_submission as mod
 
     fake_evidence = tmp_path / "web" / "data" / "evidence.json"
+    output_file = tmp_path / "github-output.txt"
     assert not fake_evidence.exists()
     monkeypatch.setattr(mod, "EVIDENCE_JSON", fake_evidence)
 
-    monkeypatch.setenv("ISSUE_BODY", _make_body())
+    monkeypatch.setenv("ISSUE_BODY", _make_body(tested_at=datetime.now(timezone.utc).isoformat()))
     monkeypatch.setenv("ISSUE_AUTHOR", "testbot")
     monkeypatch.setenv("ISSUE_NUMBER", "1")
     monkeypatch.setenv("AUTHOR_CREATED_AT", "2020-01-01T00:00:00Z")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
 
     mod.main()
 
@@ -491,3 +524,56 @@ def test_main_creates_evidence_json(tmp_path, monkeypatch):
     assert len(data) == 1
     assert data[0]["relayDomain"] == "api.example.com"
     assert data[0]["evidenceStatus"] == "accepted_unverified"
+
+    output = output_file.read_text(encoding="utf-8")
+    assert "status=SHAPE_VALID" in output
+    assert "relay_domain=api.example.com" in output
+    assert f"report_hash=sha256:{REPORT_HASH}" in output
+    assert "report_artifact_url=https://github.com/user-attachments/files/123/report-redacted.md" in output
+    assert "tool_commit=040676c" in output
+    assert "evidence_branch=community/evidence-api.example.com-issue-1" in output
+
+
+def test_main_routes_stale_evidence_to_review_without_writing(tmp_path, monkeypatch):
+    import process_submission as mod
+
+    fake_evidence = tmp_path / "web" / "data" / "evidence.json"
+    output_file = tmp_path / "github-output.txt"
+    monkeypatch.setattr(mod, "EVIDENCE_JSON", fake_evidence)
+    monkeypatch.setenv("ISSUE_BODY", _make_body(tested_at="2000-01-01T00:00:00Z"))
+    monkeypatch.setenv("ISSUE_AUTHOR", "testbot")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("AUTHOR_CREATED_AT", "2020-01-01T00:00:00Z")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+    with pytest.raises(SystemExit) as exc:
+        mod.main()
+
+    assert exc.value.code == 3
+    assert not fake_evidence.exists()
+    assert "status=NEEDS_REVIEW" in output_file.read_text(encoding="utf-8")
+
+
+def test_workflow_uses_draft_evidence_pr_contract():
+    workflow = (
+        Path(__file__).resolve().parent.parent
+        / ".github"
+        / "workflows"
+        / "process-submission.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "EVIDENCE_BRANCH: ${{ steps.process.outputs.evidence_branch }}" in workflow
+    assert 'BRANCH="${EVIDENCE_BRANCH}"' in workflow
+    assert "gh pr edit" in workflow
+    assert "gh pr create" in workflow
+    assert "--draft" in workflow
+    assert "web/data/evidence.json" in workflow
+    assert "web/data/relays.json" not in workflow
+    for forbidden in [
+        "leaderboard",
+        "trusted-relay",
+        "certification",
+        "safety endorsement",
+        "relay recommendation",
+    ]:
+        assert forbidden not in workflow

--- a/tests/test_process_submission.py
+++ b/tests/test_process_submission.py
@@ -1,21 +1,25 @@
-"""Unit tests for scripts/process_submission.py"""
+"""Unit tests for scripts/process_submission.py."""
 
+import json
 import sys
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
-from process_submission import (
+from process_submission import (  # noqa: E402
+    build_evidence_record,
+    check_account_age,
+    check_rate_limit,
+    extract_artifact_url,
+    extract_image_urls,
+    normalize_report_hash,
     parse_issue_body,
     validate_fields,
-    build_relay_entry,
-    check_account_age,
-    extract_image_urls,
-    check_rate_limit,
 )
 
-SAMPLE_BODY = """### Relay Domain / 中转站域名
+
+REPORT_HASH = "a" * 64
+SAMPLE_BODY = f"""### Relay Domain / 中转站域名
 
 api.example.com
 
@@ -27,6 +31,14 @@ full
 
 v2.3
 
+### Tool Commit / 工具提交
+
+040676c
+
+### Tested At / 审计时间
+
+2026-06-01T12:00:00Z
+
 ### Overall Rating / 总体评级
 
 HIGH
@@ -34,6 +46,14 @@ HIGH
 ### Report Screenshot / 报告截图
 
 ![report](https://user-images.githubusercontent.com/123/report.png)
+
+### Report Artifact / 报告文件
+
+[report-redacted.md](https://github.com/user-attachments/files/123/report-redacted.md)
+
+### Report Hash / 报告哈希
+
+sha256:{REPORT_HASH}
 
 ### Key Findings / 主要发现
 
@@ -51,30 +71,53 @@ def test_parse_issue_body():
     assert fields["relay_domain"] == "api.example.com"
     assert fields["profile"] == "full"
     assert fields["tool_version"] == "v2.3"
+    assert fields["tool_commit"] == "040676c"
+    assert fields["tested_at"] == "2026-06-01T12:00:00Z"
     assert fields["overall_rating"] == "HIGH"
+    assert fields["report_hash"] == f"sha256:{REPORT_HASH}"
     assert "report.png" in fields["report_image"]
+    assert "report-redacted.md" in fields["report_artifact"]
 
 
 def test_validate_fields_valid():
     fields = parse_issue_body(SAMPLE_BODY)
-    errors = validate_fields(fields)
-    assert errors == []
+    assert validate_fields(fields) == []
 
 
 def test_validate_fields_rejects_bad():
-    bad = {"relay_domain": "", "profile": "xxx", "overall_rating": "MAYBE"}
+    bad = {
+        "relay_domain": "",
+        "profile": "xxx",
+        "overall_rating": "MAYBE",
+        "tool_commit": "not-a-commit",
+        "tested_at": "yesterday",
+        "report_hash": "nope",
+    }
     errors = validate_fields(bad)
     assert len(errors) > 0
 
 
-def test_build_relay_entry():
+def test_build_evidence_record():
     fields = parse_issue_body(SAMPLE_BODY)
-    entry = build_relay_entry(fields, "testuser", "42")
-    assert entry["domain"] == "api.example.com"
-    assert entry["rating"] == "red"
-    assert entry["source"] == "community"
+    entry = build_evidence_record(fields, "testuser", "42")
+    assert entry["recordType"] == "community-submitted-audit-evidence"
+    assert entry["relayDomain"] == "api.example.com"
+    assert entry["toolCommit"] == "040676c"
+    assert entry["auditProfile"] == "full"
+    assert entry["toolReportedOverallRating"] == "HIGH"
+    assert entry["reportHash"] == f"sha256:{REPORT_HASH}"
+    assert (
+        entry["reportArtifactUrl"]
+        == "https://github.com/user-attachments/files/123/report-redacted.md"
+    )
+    assert entry["evidenceStatus"] == "accepted_unverified"
+    assert entry["reviewStatus"] == "unverified"
+    assert entry["disputeStatus"] == "none"
+    assert entry["staleAfter"] == "2026-08-30"
+    assert entry["source"] == "github-issue"
     assert len(entry["redFlags"]) == 2
     assert len(entry["reportImages"]) == 1
+    assert entry["reportImages"][0] != entry["reportArtifactUrl"]
 
 
 def test_check_account_age():
@@ -90,9 +133,21 @@ def test_extract_image_urls():
     assert len(extract_image_urls("![a](https://a.com/1.png) ![b](https://b.com/2.jpg)")) == 2
 
 
+def test_extract_artifact_url():
+    assert (
+        extract_artifact_url("[report.md](https://github.com/user-attachments/files/1/report.md)")
+        == "https://github.com/user-attachments/files/1/report.md"
+    )
+    assert extract_artifact_url("https://example.com/report-redacted.md") == (
+        "https://example.com/report-redacted.md"
+    )
+    assert extract_artifact_url("http://example.com/report.md") == ""
+    assert extract_artifact_url("no link") == ""
+
+
 def test_check_rate_limit():
     now_iso = datetime.now(timezone.utc).isoformat()
-    fake_data = [{"domain": "test.com", "submittedAt": now_iso} for _ in range(10)]
+    fake_data = [{"relayDomain": "test.com", "submittedAt": now_iso} for _ in range(10)]
     assert check_rate_limit("test.com", fake_data) is True
     assert check_rate_limit("other.com", fake_data) is False
     assert check_rate_limit("test.com", []) is False
@@ -101,12 +156,8 @@ def test_check_rate_limit():
 def test_empty_body_rejected():
     fields = parse_issue_body("")
     errors = validate_fields(fields)
-    assert len(errors) >= 4
+    assert len(errors) >= 9
 
-
-# ---------------------------------------------------------------------------
-# Edge-case tests (appended)
-# ---------------------------------------------------------------------------
 
 def _make_body(**overrides):
     """Build a valid issue body, then override specific field values."""
@@ -114,8 +165,14 @@ def _make_body(**overrides):
         "relay_domain": "api.example.com",
         "profile": "full",
         "tool_version": "v2.3",
+        "tool_commit": "040676c",
+        "tested_at": "2026-06-01T12:00:00Z",
         "overall_rating": "HIGH",
         "report_image": "![report](https://user-images.githubusercontent.com/123/report.png)",
+        "report_artifact": (
+            "[report-redacted.md](https://github.com/user-attachments/files/123/report-redacted.md)"
+        ),
+        "report_hash": f"sha256:{REPORT_HASH}",
         "red_flags": "- \U0001f534 Token injection: +3200 tokens",
         "notes": "Test submission",
     }
@@ -124,8 +181,12 @@ def _make_body(**overrides):
         f"### Relay Domain / 中转站域名\n\n{defaults['relay_domain']}\n\n"
         f"### Audit Profile / 审计配置\n\n{defaults['profile']}\n\n"
         f"### Tool Version / 工具版本\n\n{defaults['tool_version']}\n\n"
+        f"### Tool Commit / 工具提交\n\n{defaults['tool_commit']}\n\n"
+        f"### Tested At / 审计时间\n\n{defaults['tested_at']}\n\n"
         f"### Overall Rating / 总体评级\n\n{defaults['overall_rating']}\n\n"
         f"### Report Screenshot / 报告截图\n\n{defaults['report_image']}\n\n"
+        f"### Report Artifact / 报告文件\n\n{defaults['report_artifact']}\n\n"
+        f"### Report Hash / 报告哈希\n\n{defaults['report_hash']}\n\n"
         f"### Key Findings / 主要发现\n\n{defaults['red_flags']}\n\n"
         f"### Additional Notes / 补充说明\n\n{defaults['notes']}\n"
     )
@@ -134,21 +195,19 @@ def _make_body(**overrides):
 def test_domain_with_path_traversal():
     """relay_domain containing '../' or '/' should be rejected by validation."""
     for bad_domain in ["../etc/passwd", "foo/bar", "a\\b"]:
-        body = _make_body(relay_domain=bad_domain)
-        fields = parse_issue_body(body)
+        fields = parse_issue_body(_make_body(relay_domain=bad_domain))
         errors = validate_fields(fields)
         domain_errors = [e for e in errors if "relay_domain" in e and "hostname" in e]
-        assert len(domain_errors) > 0, f"Expected hostname error for domain {bad_domain!r}"
+        assert domain_errors, f"Expected hostname error for domain {bad_domain!r}"
 
 
 def test_domain_with_special_chars():
     """relay_domain with spaces, unicode, angle brackets should be rejected."""
     for bad_domain in ["has space.com", "domäin.ü.com", "<script>alert(1)</script>"]:
-        body = _make_body(relay_domain=bad_domain)
-        fields = parse_issue_body(body)
+        fields = parse_issue_body(_make_body(relay_domain=bad_domain))
         errors = validate_fields(fields)
         domain_errors = [e for e in errors if "relay_domain" in e and "hostname" in e]
-        assert len(domain_errors) > 0, f"Expected hostname error for domain {bad_domain!r}"
+        assert domain_errors, f"Expected hostname error for domain {bad_domain!r}"
 
 
 def test_domain_must_be_canonical_hostname():
@@ -162,35 +221,29 @@ def test_domain_must_be_canonical_hostname():
         "api..example.com",
     ]
     for bad_domain in bad_domains:
-        body = _make_body(relay_domain=bad_domain)
-        fields = parse_issue_body(body)
+        fields = parse_issue_body(_make_body(relay_domain=bad_domain))
         errors = validate_fields(fields)
         domain_errors = [e for e in errors if "relay_domain" in e and "hostname" in e]
-        assert len(domain_errors) > 0, f"Expected hostname error for domain {bad_domain!r}"
+        assert domain_errors, f"Expected hostname error for domain {bad_domain!r}"
 
 
 def test_domain_allows_case_and_trailing_dot():
     """Case and trailing dot are canonicalized before hostname validation."""
-    body = _make_body(relay_domain="API.Example.COM.")
-    fields = parse_issue_body(body)
+    fields = parse_issue_body(_make_body(relay_domain="API.Example.COM."))
     errors = validate_fields(fields)
-    domain_errors = [e for e in errors if "relay_domain" in e]
-    assert domain_errors == []
-    entry = build_relay_entry(fields, "tester", "100")
-    assert entry["domain"] == "api.example.com"
+    assert [e for e in errors if "relay_domain" in e] == []
+    entry = build_evidence_record(fields, "tester", "100")
+    assert entry["relayDomain"] == "api.example.com"
 
 
 def test_massive_body():
     """A very large issue body (>100 KB) should not crash parse_issue_body."""
-    huge_notes = "x" * 120_000
-    body = _make_body(notes=huge_notes)
+    body = _make_body(notes="x" * 120_000)
     assert len(body.encode("utf-8")) > 100_000
     fields = parse_issue_body(body)
-    # Should still parse the structured fields correctly
     assert fields["relay_domain"] == "api.example.com"
     assert fields["overall_rating"] == "HIGH"
-    errors = validate_fields(fields)
-    assert errors == []
+    assert validate_fields(fields) == []
 
 
 def test_multiple_images():
@@ -201,9 +254,8 @@ def test_multiple_images():
         "![c](https://img.com/3.png) "
         "![d](https://img.com/4.jpg)"
     )
-    body = _make_body(report_image=multi_img)
-    fields = parse_issue_body(body)
-    entry = build_relay_entry(fields, "tester", "99")
+    fields = parse_issue_body(_make_body(report_image=multi_img))
+    entry = build_evidence_record(fields, "tester", "99")
     assert len(entry["reportImages"]) == 4
     assert "https://img.com/3.png" in entry["reportImages"]
 
@@ -218,8 +270,7 @@ def test_report_images_must_be_https_without_markdown_title():
         "![x](http://img.com/a.png)",
         "![x](https://img.com/a.png title)",
     ]:
-        body = _make_body(report_image=bad_image)
-        fields = parse_issue_body(body)
+        fields = parse_issue_body(_make_body(report_image=bad_image))
         errors = validate_fields(fields)
         image_errors = [e for e in errors if "report_image" in e]
         assert image_errors, f"Expected report_image error for {bad_image!r}"
@@ -231,61 +282,114 @@ def test_missing_report_image():
         "relay_domain": "api.example.com",
         "profile": "full",
         "tool_version": "v2.3",
+        "tool_commit": "040676c",
+        "tested_at": "2026-06-01",
         "overall_rating": "HIGH",
-        # report_image intentionally omitted
+        "report_hash": f"sha256:{REPORT_HASH}",
+        "report_artifact": "https://example.com/report-redacted.md",
     }
     errors = validate_fields(fields)
     image_errors = [e for e in errors if "report_image" in e]
-    assert len(image_errors) > 0
+    assert image_errors
+
+
+def test_missing_report_artifact():
+    """Missing report_artifact should produce a validation error."""
+    fields = {
+        "relay_domain": "api.example.com",
+        "profile": "full",
+        "tool_version": "v2.3",
+        "tool_commit": "040676c",
+        "tested_at": "2026-06-01",
+        "overall_rating": "HIGH",
+        "report_hash": f"sha256:{REPORT_HASH}",
+        "report_image": "![report](https://user-images.githubusercontent.com/123/report.png)",
+    }
+    errors = validate_fields(fields)
+    artifact_errors = [e for e in errors if "report_artifact" in e]
+    assert artifact_errors
+
+
+def test_report_artifact_must_be_https():
+    """The report artifact is the hashable evidence object and must be HTTPS."""
+    for bad_artifact in ["report-redacted.md", "http://example.com/report.md"]:
+        fields = parse_issue_body(_make_body(report_artifact=bad_artifact))
+        errors = validate_fields(fields)
+        artifact_errors = [e for e in errors if "report_artifact" in e]
+        assert artifact_errors, f"Expected report_artifact error for {bad_artifact!r}"
+
+
+def test_report_artifact_written_separately_from_screenshot():
+    fields = parse_issue_body(
+        _make_body(
+            report_image="![report](https://example.com/report.png)",
+            report_artifact="https://example.com/report-redacted.md",
+        )
+    )
+    entry = build_evidence_record(fields, "tester", "101")
+    assert entry["reportImages"] == ["https://example.com/report.png"]
+    assert entry["reportArtifactUrl"] == "https://example.com/report-redacted.md"
+    assert entry["reportImages"][0] != entry["reportArtifactUrl"]
 
 
 def test_version_formats():
     """Valid version strings should pass; invalid ones should fail."""
     valid_versions = ["v2.3", "2.3", "v10.0.1"]
     for ver in valid_versions:
-        body = _make_body(tool_version=ver)
-        fields = parse_issue_body(body)
+        fields = parse_issue_body(_make_body(tool_version=ver))
         errors = validate_fields(fields)
-        ver_errors = [e for e in errors if "tool_version" in e]
-        assert ver_errors == [], f"Version {ver!r} should be valid but got: {ver_errors}"
+        assert [e for e in errors if "tool_version" in e] == []
 
     invalid_versions = ["abc"]
     for ver in invalid_versions:
-        body = _make_body(tool_version=ver)
-        fields = parse_issue_body(body)
+        fields = parse_issue_body(_make_body(tool_version=ver))
         errors = validate_fields(fields)
-        ver_errors = [e for e in errors if "tool_version" in e]
-        assert len(ver_errors) > 0, f"Version {ver!r} should be invalid"
-
-    # Empty version triggers "Missing required field" instead of format error
-    fields_empty = {
-        "relay_domain": "api.example.com",
-        "profile": "full",
-        "tool_version": "",
-        "overall_rating": "HIGH",
-        "report_image": "![r](https://img.com/r.png)",
-    }
-    errors = validate_fields(fields_empty)
-    missing_errors = [e for e in errors if "Missing" in e and "tool_version" in e]
-    assert len(missing_errors) > 0, "Empty version should trigger missing-field error"
+        assert [e for e in errors if "tool_version" in e]
 
 
-def test_build_entry_low_rating():
-    """LOW overall rating should map to green."""
-    body = _make_body(overall_rating="LOW")
-    fields = parse_issue_body(body)
-    entry = build_relay_entry(fields, "user1", "10")
-    assert entry["rating"] == "green"
-    assert "Low Risk" in entry["ratingLabel"]
+def test_tool_commit_required_and_validated():
+    fields = parse_issue_body(_make_body(tool_commit="040676c"))
+    assert [e for e in validate_fields(fields) if "tool_commit" in e] == []
+
+    fields = parse_issue_body(_make_body(tool_commit="not-a-commit"))
+    assert [e for e in validate_fields(fields) if "tool_commit" in e]
 
 
-def test_build_entry_medium_rating():
-    """MEDIUM overall rating should map to yellow."""
-    body = _make_body(overall_rating="MEDIUM")
-    fields = parse_issue_body(body)
-    entry = build_relay_entry(fields, "user2", "20")
-    assert entry["rating"] == "yellow"
-    assert "Medium Risk" in entry["ratingLabel"]
+def test_report_hash_required_and_normalized():
+    assert normalize_report_hash(REPORT_HASH) == f"sha256:{REPORT_HASH}"
+    assert normalize_report_hash(f"sha256:{REPORT_HASH.upper()}") == f"sha256:{REPORT_HASH}"
+
+    fields = parse_issue_body(_make_body(report_hash=REPORT_HASH))
+    assert [e for e in validate_fields(fields) if "report_hash" in e] == []
+    entry = build_evidence_record(fields, "tester", "12")
+    assert entry["reportHash"] == f"sha256:{REPORT_HASH}"
+
+    fields = parse_issue_body(_make_body(report_hash="abc"))
+    assert [e for e in validate_fields(fields) if "report_hash" in e]
+
+
+def test_tested_at_date_or_datetime():
+    for value in ["2026-06-01", "2026-06-01T12:00:00Z"]:
+        fields = parse_issue_body(_make_body(tested_at=value))
+        assert [e for e in validate_fields(fields) if "tested_at" in e] == []
+
+    fields = parse_issue_body(_make_body(tested_at="last week"))
+    assert [e for e in validate_fields(fields) if "tested_at" in e]
+
+
+def test_build_entry_low_rating_preserves_tool_reported_rating():
+    """LOW is a tool-reported result, not a platform safety endorsement."""
+    fields = parse_issue_body(_make_body(overall_rating="LOW"))
+    entry = build_evidence_record(fields, "user1", "10")
+    assert entry["toolReportedOverallRating"] == "LOW"
+    assert "rating" not in entry
+    assert "ratingLabel" not in entry
+
+
+def test_build_entry_medium_rating_preserves_tool_reported_rating():
+    fields = parse_issue_body(_make_body(overall_rating="MEDIUM"))
+    entry = build_evidence_record(fields, "user2", "20")
+    assert entry["toolReportedOverallRating"] == "MEDIUM"
 
 
 def test_rate_limit_old_entries():
@@ -296,52 +400,50 @@ def test_rate_limit_old_entries():
     old_time = (now - timedelta(hours=25)).isoformat()
     recent_time = now.isoformat()
 
-    # 10 old entries (>24h) — should NOT trigger rate limit
-    old_data = [{"domain": "test.com", "submittedAt": old_time} for _ in range(15)]
-    assert check_rate_limit("test.com", old_data) is False, (
-        "Old entries (>24h) should not count toward rate limit"
-    )
+    old_data = [{"relayDomain": "test.com", "submittedAt": old_time} for _ in range(15)]
+    assert check_rate_limit("test.com", old_data) is False
 
-    # Mix: 9 recent + 15 old — should NOT trigger (only 9 within window)
     mixed_data = old_data + [
-        {"domain": "test.com", "submittedAt": recent_time} for _ in range(9)
+        {"relayDomain": "test.com", "submittedAt": recent_time} for _ in range(9)
     ]
     assert check_rate_limit("test.com", mixed_data) is False
 
-    # Mix: 10 recent + 15 old — SHOULD trigger (10 within window)
     mixed_data_trigger = old_data + [
-        {"domain": "test.com", "submittedAt": recent_time} for _ in range(10)
+        {"relayDomain": "test.com", "submittedAt": recent_time} for _ in range(10)
     ]
     assert check_rate_limit("test.com", mixed_data_trigger) is True
 
 
 def test_rate_limit_normalizes_existing_domains():
-    """Legacy/manual relays.json domains should be normalized before comparison."""
+    """Legacy/manual evidence domains should be normalized before comparison."""
+    now_iso = datetime.now(timezone.utc).isoformat()
+    fake_data = [{"relayDomain": "TEST.com.", "submittedAt": now_iso} for _ in range(10)]
+    assert check_rate_limit("test.com", fake_data) is True
+
+
+def test_rate_limit_accepts_legacy_domain_key():
     now_iso = datetime.now(timezone.utc).isoformat()
     fake_data = [{"domain": "TEST.com.", "submittedAt": now_iso} for _ in range(10)]
     assert check_rate_limit("test.com", fake_data) is True
 
 
-def test_concurrent_json_write_safety(tmp_path, monkeypatch):
-    """If relays.json does not exist yet, the script should create it."""
-    import json as _json
-
-    fake_relays = tmp_path / "web" / "data" / "relays.json"
-    assert not fake_relays.exists()
-
-    # Monkeypatch the module-level constant so main() writes to tmp_path
+def test_main_creates_evidence_json(tmp_path, monkeypatch):
+    """If evidence.json does not exist yet, the script should create it."""
     import process_submission as mod
-    monkeypatch.setattr(mod, "RELAYS_JSON", fake_relays)
 
-    body = _make_body()
-    monkeypatch.setenv("ISSUE_BODY", body)
+    fake_evidence = tmp_path / "web" / "data" / "evidence.json"
+    assert not fake_evidence.exists()
+    monkeypatch.setattr(mod, "EVIDENCE_JSON", fake_evidence)
+
+    monkeypatch.setenv("ISSUE_BODY", _make_body())
     monkeypatch.setenv("ISSUE_AUTHOR", "testbot")
     monkeypatch.setenv("ISSUE_NUMBER", "1")
     monkeypatch.setenv("AUTHOR_CREATED_AT", "2020-01-01T00:00:00Z")
 
     mod.main()
 
-    assert fake_relays.exists(), "relays.json should have been created"
-    data = _json.loads(fake_relays.read_text(encoding="utf-8"))
+    assert fake_evidence.exists(), "evidence.json should have been created"
+    data = json.loads(fake_evidence.read_text(encoding="utf-8"))
     assert len(data) == 1
-    assert data[0]["domain"] == "api.example.com"
+    assert data[0]["relayDomain"] == "api.example.com"
+    assert data[0]["evidenceStatus"] == "accepted_unverified"

--- a/tests/test_process_submission.py
+++ b/tests/test_process_submission.py
@@ -12,6 +12,7 @@ from process_submission import (  # noqa: E402
     check_rate_limit,
     extract_artifact_url,
     extract_image_urls,
+    load_pending_evidence_pr_entries,
     normalize_report_hash,
     parse_issue_body,
     validate_fields,
@@ -425,6 +426,47 @@ def test_rate_limit_accepts_legacy_domain_key():
     now_iso = datetime.now(timezone.utc).isoformat()
     fake_data = [{"domain": "TEST.com.", "submittedAt": now_iso} for _ in range(10)]
     assert check_rate_limit("test.com", fake_data) is True
+
+
+def test_pending_evidence_prs_count_toward_rate_limit(tmp_path):
+    now_iso = datetime.now(timezone.utc).isoformat()
+    pending_prs = [
+        {
+            "headRefName": f"community/evidence-test.com-issue-{i}",
+            "createdAt": now_iso,
+        }
+        for i in range(10)
+    ]
+    pending_file = tmp_path / "pending-prs.json"
+    pending_file.write_text(json.dumps(pending_prs), encoding="utf-8")
+
+    entries = load_pending_evidence_pr_entries(str(pending_file))
+
+    assert len(entries) == 10
+    assert check_rate_limit("test.com", entries) is True
+
+
+def test_pending_evidence_pr_parser_ignores_unrelated_branches(tmp_path):
+    now_iso = datetime.now(timezone.utc).isoformat()
+    pending_prs = [
+        {"headRefName": "community/evidence-other.com-issue-1", "createdAt": now_iso},
+        {"headRefName": "community/evidence-issue-2", "createdAt": now_iso},
+        {"headRefName": "community/evidence-bad_domain.com-issue-3", "createdAt": now_iso},
+        {"headRefName": "feature/test", "createdAt": now_iso},
+        {"headRefName": "community/evidence-test.com-issue-4", "createdAt": ""},
+        {
+            "headRefName": "community/evidence-test.com-issue-5",
+            "createdAt": now_iso,
+            "isCrossRepository": True,
+        },
+    ]
+    pending_file = tmp_path / "pending-prs.json"
+    pending_file.write_text(json.dumps(pending_prs), encoding="utf-8")
+
+    entries = load_pending_evidence_pr_entries(str(pending_file))
+
+    assert entries == [{"relayDomain": "other.com", "submittedAt": now_iso}]
+    assert check_rate_limit("test.com", entries) is False
 
 
 def test_main_creates_evidence_json(tmp_path, monkeypatch):

--- a/tests/test_process_submission.py
+++ b/tests/test_process_submission.py
@@ -2,7 +2,7 @@
 
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
@@ -122,8 +122,10 @@ def test_build_evidence_record():
 
 
 def test_check_account_age():
-    assert check_account_age("2026-05-29T00:00:00Z") is True
-    assert check_account_age("2020-01-01T00:00:00Z") is False
+    young = datetime.now(timezone.utc) - timedelta(days=3)
+    old = datetime.now(timezone.utc) - timedelta(days=60)
+    assert check_account_age(young.isoformat()) is True
+    assert check_account_age(old.isoformat()) is False
     assert check_account_age("") is True
     assert check_account_age(None) is True
 

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">714</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">732</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## Summary

Corrects the #23 community submission pipeline so community data no longer publishes directly to master.

- Reframes submissions as Community Evidence Registry records instead of relay leaderboard entries.
- Requires provenance fields: `toolCommit`, `testedAt`, `reportHash`, and `reportArtifactUrl`.
- Writes candidate records to `web/data/evidence.json` with evidence/review/dispute/staleness metadata.
- Changes the workflow from direct `git push origin HEAD:master` to draft evidence-publication PR creation.
- Adds labels/comments for `shape-valid`, `needs-review`, `rate-limited`, `validation-errors`, and `evidence-pr-created`.
- Hardens reruns: the workflow only runs on issue open with `audit-submission` or when that exact label is added, and the processor updates existing evidence records instead of duplicating the same issue/report hash.

## Governance Boundary

Issue is the raw evidence intake. The generated PR is the review gate. `master` should contain only maintainer-reviewed evidence index changes.

This is not a trusted-relay certification, not a safety endorsement, and not a public leaderboard.

## Validation

- `python3 -m py_compile scripts/process_submission.py`
- `python3 -m pytest tests/test_process_submission.py -q` -> 40 passed
- `python3 -m pytest tests/ -q` -> 732 passed
- `python3 scripts/collect-metrics.py --check` -> passed
- `git diff --check`

## Owner Review Required

Do not merge this PR without explicit owner double-check. This PR changes the governance semantics of community-submitted evidence and the workflow that creates draft evidence-publication PRs.
