### PR TITLE
[codex] Add LLMprobe absorption spikes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,10 @@ arrives as a direct pull request.
   a downstream fork that contributed the Windows long-context stability
   finding and the opt-in fast context scan idea tracked in
   [issue #14](https://github.com/toby-bridges/api-relay-audit/issues/14).
+- [BazaarLink LLMprobe-engine](https://github.com/Bazaarlinkorg/LLMprobe-engine)
+  — external methodology and evidence contributor for model-substitution
+  measurement, upstream channel-classification ideas, multimodal dilution
+  fixture design, and AC-1.b long-running watch-mode patterns.
 
 ## Attribution Policy
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,19 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
 
 ## ✅ Shipped
 
+### LLMprobe-engine absorption spikes (2026-06-01)
+- **Contribution boundary**: BazaarLink LLMprobe-engine is credited as an
+  external methodology/evidence contributor while first-party evidence-source
+  seeding remains separate from #24 and this spike PR.
+- **Experiment-only entrypoints**: added informational helpers for
+  model-substitution deltas, multimodal dilution fixtures, and AC-1.b local
+  watch-log analysis under `scripts/experiments/`.
+- **Boundary held**: no default audit wiring, no 6D risk-matrix expansion, no
+  0-100 scoring, no leaderboard/trusted-relay language, and no public
+  per-relay allegation without reviewable evidence.
+- **Final test count**: 682/682 passing (672 baseline -> 682 after
+  informational spike tests).
+
 ### v1.9 — Dual-distribution generation contract (2026-06-01)
 - **Standalone product promise preserved**: root `audit.py` stays committed,
   curl-downloadable, stdlib + curl only. It is now marked as a generated
@@ -660,6 +673,13 @@ like Step 12/13）。
 来自 `competitors/LLMprobe-engine/`，朋友项目（未来 contributor）。在 MIT 阶段只能
 clean-room 参考算法；全仓库改为 AGPL-3.0-only 后，可在保留归属、许可证和源码义务
 的前提下兼容引入或改写：
+
+> **2026-06-01 吸收优先级**：#26 已将本仓库切换到 AGPL-3.0-only。LLMprobe-engine
+> 的吸收顺序固定为：P1 外部证据源与测量方法（独立于 #24，不混入 evidence
+> gate PR）→ P2 模型替换检测体系（v2.0 spike）→ P3 多模态 dilution detector
+>（`scripts/experiments/multimodal_dilution_spike.py`）→ P4 AC-1.b 长期观测
+> companion mode（`scripts/experiments/ac1b_watch_spike.py`）。P2/P3/P4 全部
+> informational-first，不改默认 audit，不进 6D 风险矩阵。
 
 1. **Bayesian log-odds identity scorer** (`fingerprint-bayesian.ts`)：
    用 softmax 归一化的 log-likelihood ratio 替代我们 Step 5 的布尔关键词检测，

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,16 +16,16 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **672** | `pytest --collect-only` |
-| 测试数 (static) | 664 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **682** | `pytest --collect-only` |
+| 测试数 (static) | 674 | grep `def test_*` in tests/ |
 | CLI flag 数 | 20 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-01 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
-| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 672] | grep `Final test count: N/N passing` |
-| HEAD SHA | `7773bbc` | `git rev-parse HEAD` |
+| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 672, 682] | grep `Final test count: N/N passing` |
+| HEAD SHA | `c051545` | `git rev-parse HEAD` |
 | HEAD 日期 | 2026-06-01 | `git log -1` |
 
 ## 一致性自检

--- a/docs/llmprobe-engine-absorption.md
+++ b/docs/llmprobe-engine-absorption.md
@@ -1,0 +1,36 @@
+# LLMprobe-engine Absorption Plan
+
+This document records how api-relay-audit will absorb useful work from
+BazaarLink LLMprobe-engine without changing the default audit contract.
+
+## Priority
+
+1. **External evidence source and measurement method**: handled separately from
+   PR #24. Register source-level evidence only: repository, commit, license,
+   paper hashes, measurement window, aggregate source-reported claims, and
+   limitations. Do not publish unmasked endpoint mappings as api-relay-audit
+   findings.
+2. **Model-substitution detection**: start as v2.0 spike work. Use capability
+   deltas and sub-model baselines as evidence, but keep outputs informational
+   until honest baselines and confidence intervals are strong enough.
+3. **Multimodal dilution detector**: start with self-generated tiny fixtures
+   and request-shape validation for Anthropic and OpenAI formats. Format or
+   transport failures are inconclusive, not safety verdicts.
+4. **AC-1.b long-running watch mode**: treat as companion mode. Analyze local
+   neutral/sensitive NDJSON observations; do not wire it into the default
+   one-shot audit or claim complete conditional-delivery coverage.
+
+## Guardrails
+
+- No 0-100 scoring, leaderboard, safe-relay list, or trusted-relay language.
+- No knowledge-cutoff verdicts.
+- No direct per-relay public allegations without independently reviewable
+  report hashes and maintainer review.
+- No risk-matrix expansion from these spikes. They remain
+  `riskMatrixImpact=none` until a later owner-approved design changes that.
+
+## Current Spike Entry Points
+
+- `scripts/experiments/model_substitution_spike.py`
+- `scripts/experiments/multimodal_dilution_spike.py`
+- `scripts/experiments/ac1b_watch_spike.py`

--- a/scripts/experiments/ac1b_watch_spike.py
+++ b/scripts/experiments/ac1b_watch_spike.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Informational AC-1.b long-running watch spike helper.
+
+Consumes local NDJSON observations and compares anomaly rates between neutral
+and sensitive traffic. This is a companion-mode experiment, not a default
+one-shot audit step.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+SENSITIVE_MARKERS = ("aws", "api_key", "apikey", "token", "secret", "password", "bearer")
+
+
+def profile_request(text):
+    lowered = (text or "").lower()
+    return "sensitive" if any(marker in lowered for marker in SENSITIVE_MARKERS) else "neutral"
+
+
+def _truthy(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y"}
+    return False
+
+
+def load_ndjson(path):
+    entries = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return entries
+
+
+def analyze_entries(entries, min_each=3, multiplier=2.0):
+    counts = {
+        "neutral": 0,
+        "sensitive": 0,
+        "neutralAnomalies": 0,
+        "sensitiveAnomalies": 0,
+    }
+
+    for entry in entries:
+        profile = entry.get("profile") or profile_request(entry.get("userContent", ""))
+        if profile not in ("neutral", "sensitive"):
+            continue
+        counts[profile] += 1
+        if _truthy(entry.get("anomaly")):
+            counts[f"{profile}Anomalies"] += 1
+
+    neutral_rate = counts["neutralAnomalies"] / counts["neutral"] if counts["neutral"] else 0.0
+    sensitive_rate = (
+        counts["sensitiveAnomalies"] / counts["sensitive"] if counts["sensitive"] else 0.0
+    )
+
+    result = {
+        "recordType": "ac1b-watch-spike-result",
+        "riskMatrixImpact": "none",
+        **counts,
+        "neutralRate": round(neutral_rate, 6),
+        "sensitiveRate": round(sensitive_rate, 6),
+        "minEach": min_each,
+        "multiplier": multiplier,
+    }
+
+    if counts["neutral"] < min_each or counts["sensitive"] < min_each:
+        result.update(
+            {
+                "verdict": "insufficient_data",
+                "reason": "need_minimum_neutral_and_sensitive_observations",
+            }
+        )
+    elif counts["sensitiveAnomalies"] >= 1 and (
+        counts["neutralAnomalies"] == 0 or sensitive_rate >= neutral_rate * multiplier
+    ):
+        result.update(
+            {
+                "verdict": "conditional_injection_suspected",
+                "reason": "sensitive_traffic_has_materially_higher_anomaly_rate",
+            }
+        )
+    else:
+        result.update(
+            {
+                "verdict": "no_conditional_injection",
+                "reason": "sensitive_and_neutral_rates_are_similar",
+            }
+        )
+    return result
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log-file", required=True, help="Local NDJSON observation log")
+    parser.add_argument("--min-each", type=int, default=3)
+    parser.add_argument("--multiplier", type=float, default=2.0)
+    args = parser.parse_args(argv)
+
+    result = analyze_entries(load_ndjson(args.log_file), args.min_each, args.multiplier)
+    json.dump(result, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/model_substitution_spike.py
+++ b/scripts/experiments/model_substitution_spike.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Informational model-substitution spike helper.
+
+This is intentionally not wired into scripts/audit.py or audit.py. It compares
+two small capability reports with matching item ids and reports whether the
+candidate endpoint shows a large accuracy delta from a known-honest baseline.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+DEFAULT_MIN_ITEMS = 5
+DEFAULT_SUSPICIOUS_DELTA = 0.25
+BASELINE_PASS_FLOOR = 0.80
+
+
+def normalize_text(value):
+    return re.sub(r"\s+", " ", str(value or "").strip().lower())
+
+
+def _items(report):
+    return report.get("items") or report.get("answers") or []
+
+
+def _index_items(report):
+    indexed = {}
+    for item in _items(report):
+        item_id = str(item.get("id", "")).strip()
+        if item_id:
+            indexed[item_id] = item
+    return indexed
+
+
+def item_passed(item):
+    """Return True/False for a scored item, or None when it cannot be scored."""
+    if "passed" in item:
+        return bool(item["passed"])
+
+    expected = item.get("expected")
+    actual = item.get("actual")
+    if expected is None or actual is None:
+        return None
+
+    return normalize_text(expected) in normalize_text(actual)
+
+
+def score_report(report, item_ids):
+    passed = 0
+    total = 0
+    indexed = _index_items(report)
+    skipped = []
+
+    for item_id in item_ids:
+        result = item_passed(indexed[item_id])
+        if result is None:
+            skipped.append(item_id)
+            continue
+        total += 1
+        if result:
+            passed += 1
+
+    score = passed / total if total else None
+    return {"score": score, "passed": passed, "total": total, "skipped": skipped}
+
+
+def compare_reports(
+    baseline,
+    candidate,
+    min_items=DEFAULT_MIN_ITEMS,
+    suspicious_delta=DEFAULT_SUSPICIOUS_DELTA,
+):
+    baseline_items = _index_items(baseline)
+    candidate_items = _index_items(candidate)
+    common_ids = sorted(set(baseline_items) & set(candidate_items))
+
+    result = {
+        "recordType": "model-substitution-spike-result",
+        "riskMatrixImpact": "none",
+        "baselineModel": baseline.get("model"),
+        "candidateModel": candidate.get("model"),
+        "commonItemCount": len(common_ids),
+        "minItems": min_items,
+        "suspiciousDelta": suspicious_delta,
+    }
+
+    if len(common_ids) < min_items:
+        result.update(
+            {
+                "classification": "inconclusive",
+                "reason": "insufficient_common_items",
+            }
+        )
+        return result
+
+    baseline_score = score_report(baseline, common_ids)
+    candidate_score = score_report(candidate, common_ids)
+    result["baseline"] = baseline_score
+    result["candidate"] = candidate_score
+
+    if baseline_score["total"] < min_items or candidate_score["total"] < min_items:
+        result.update(
+            {
+                "classification": "inconclusive",
+                "reason": "insufficient_scored_items",
+            }
+        )
+        return result
+
+    if baseline_score["score"] < BASELINE_PASS_FLOOR:
+        result.update(
+            {
+                "classification": "inconclusive",
+                "reason": "baseline_too_weak",
+            }
+        )
+        return result
+
+    delta = baseline_score["score"] - candidate_score["score"]
+    result["delta"] = round(delta, 6)
+    if delta >= suspicious_delta:
+        result.update(
+            {
+                "classification": "capability_delta_observed",
+                "reason": "candidate_score_materially_below_baseline",
+            }
+        )
+    else:
+        result.update(
+            {
+                "classification": "no_delta_observed",
+                "reason": "candidate_score_close_to_baseline",
+            }
+        )
+    return result
+
+
+def _read_json(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", required=True, help="Known-honest baseline report JSON")
+    parser.add_argument("--candidate", required=True, help="Candidate endpoint report JSON")
+    parser.add_argument("--min-items", type=int, default=DEFAULT_MIN_ITEMS)
+    parser.add_argument("--suspicious-delta", type=float, default=DEFAULT_SUSPICIOUS_DELTA)
+    args = parser.parse_args(argv)
+
+    result = compare_reports(
+        _read_json(args.baseline),
+        _read_json(args.candidate),
+        min_items=args.min_items,
+        suspicious_delta=args.suspicious_delta,
+    )
+    json.dump(result, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/multimodal_dilution_spike.py
+++ b/scripts/experiments/multimodal_dilution_spike.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Informational multimodal dilution spike helper.
+
+This builds self-owned tiny PNG/PDF fixtures and request payload shapes for
+future vision/document experiments. It does not call any API by default and is
+not wired into the main audit pipeline.
+"""
+
+import base64
+import json
+import struct
+import sys
+import zlib
+
+
+DEFAULT_PROMPT = "Describe the image in one word. If it is a color block, name the color."
+NO_VISION_MARKERS = (
+    "cannot see images",
+    "can't see images",
+    "cannot view images",
+    "can't view images",
+    "i do not have access to images",
+    "i don't have access to images",
+    "text-only",
+)
+
+
+def _png_chunk(kind, data):
+    kind_bytes = kind.encode("ascii")
+    body = kind_bytes + data
+    crc = zlib.crc32(body) & 0xFFFFFFFF
+    return struct.pack(">I", len(data)) + body + struct.pack(">I", crc)
+
+
+def make_red_png(width=8, height=8):
+    """Return a small self-generated RGB PNG."""
+    if width <= 0 or height <= 0:
+        raise ValueError("width and height must be positive")
+
+    signature = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    row = b"\x00" + (b"\xff\x00\x00" * width)
+    raw = row * height
+    return (
+        signature
+        + _png_chunk("IHDR", ihdr)
+        + _png_chunk("IDAT", zlib.compress(raw))
+        + _png_chunk("IEND", b"")
+    )
+
+
+def make_keyword_pdf(keyword="AUDIT_RED"):
+    """Return a tiny self-generated PDF-like fixture containing keyword text."""
+    safe_keyword = "".join(ch for ch in keyword if ch.isalnum() or ch in " _-")[:40]
+    stream = f"BT /F1 12 Tf 72 720 Td ({safe_keyword}) Tj ET"
+    return (
+        "%PDF-1.1\n"
+        "1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n"
+        "2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n"
+        "3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] "
+        "/Contents 4 0 R >> endobj\n"
+        f"4 0 obj << /Length {len(stream)} >> stream\n{stream}\nendstream endobj\n"
+        "%%EOF\n"
+    ).encode("ascii")
+
+
+def b64(data):
+    return base64.b64encode(data).decode("ascii")
+
+
+def data_url(media_type, data):
+    return f"data:{media_type};base64,{b64(data)}"
+
+
+def build_anthropic_image_message(image_bytes, prompt=DEFAULT_PROMPT):
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": b64(image_bytes),
+                    },
+                },
+                {"type": "text", "text": prompt},
+            ],
+        }
+    ]
+
+
+def build_openai_image_message(image_bytes, prompt=DEFAULT_PROMPT):
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": data_url("image/png", image_bytes)},
+                },
+            ],
+        }
+    ]
+
+
+def classify_multimodal_result(text=None, error=None, expected_keywords=("red",)):
+    """Classify a response without making safety claims.
+
+    Transport/schema failures are inconclusive. Text responses that explicitly
+    cannot see images, or do not contain expected deterministic keywords, are
+    only dilution suspects and remain outside the risk matrix.
+    """
+    if error:
+        return {
+            "verdict": "inconclusive",
+            "reason": "transport_or_format_error",
+            "riskMatrixImpact": "none",
+        }
+
+    normalized = (text or "").strip().lower()
+    if not normalized:
+        return {
+            "verdict": "inconclusive",
+            "reason": "empty_response",
+            "riskMatrixImpact": "none",
+        }
+
+    if any(marker in normalized for marker in NO_VISION_MARKERS):
+        return {
+            "verdict": "dilution_suspected",
+            "reason": "model_claims_no_vision_access",
+            "riskMatrixImpact": "none",
+        }
+
+    expected = [kw.lower() for kw in expected_keywords]
+    if expected and all(kw in normalized for kw in expected):
+        return {"verdict": "passed", "reason": "expected_keywords_found", "riskMatrixImpact": "none"}
+
+    return {
+        "verdict": "dilution_suspected",
+        "reason": "expected_keywords_missing",
+        "riskMatrixImpact": "none",
+    }
+
+
+def main():
+    image = make_red_png()
+    payload = {
+        "recordType": "multimodal-dilution-spike-fixtures",
+        "riskMatrixImpact": "none",
+        "pngBytes": len(image),
+        "pdfBytes": len(make_keyword_pdf()),
+        "anthropicMessages": build_anthropic_image_message(image),
+        "openaiMessages": build_openai_image_message(image),
+    }
+    json.dump(payload, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llmprobe_spikes.py
+++ b/tests/test_llmprobe_spikes.py
@@ -1,0 +1,118 @@
+"""Tests for LLMprobe-inspired informational spike helpers."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load(name, relpath):
+    spec = importlib.util.spec_from_file_location(name, ROOT / relpath)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+model_spike = _load("model_substitution_spike", "scripts/experiments/model_substitution_spike.py")
+multi_spike = _load("multimodal_dilution_spike", "scripts/experiments/multimodal_dilution_spike.py")
+ac1b_spike = _load("ac1b_watch_spike", "scripts/experiments/ac1b_watch_spike.py")
+
+
+def _report(model, passed_flags):
+    return {
+        "model": model,
+        "items": [{"id": f"q{i}", "passed": passed} for i, passed in enumerate(passed_flags)],
+    }
+
+
+def test_model_substitution_spike_detects_large_capability_delta():
+    baseline = _report("anthropic/claude-opus-4.7", [True, True, True, True, True])
+    candidate = _report("relay-claimed-opus-4.7", [True, False, False, True, False])
+    result = model_spike.compare_reports(baseline, candidate)
+    assert result["classification"] == "capability_delta_observed"
+    assert result["riskMatrixImpact"] == "none"
+    assert result["delta"] == 0.6
+
+
+def test_model_substitution_spike_is_inconclusive_without_shared_items():
+    baseline = _report("baseline", [True, True])
+    candidate = {"model": "candidate", "items": [{"id": "other", "passed": False}]}
+    result = model_spike.compare_reports(baseline, candidate)
+    assert result["classification"] == "inconclusive"
+    assert result["reason"] == "insufficient_common_items"
+
+
+def test_model_substitution_spike_scores_expected_substrings():
+    item = {"id": "q1", "expected": "Fortran", "actual": "The answer is Fortran."}
+    assert model_spike.item_passed(item) is True
+
+
+def test_multimodal_spike_generates_self_owned_small_fixtures():
+    png = multi_spike.make_red_png()
+    pdf = multi_spike.make_keyword_pdf("AUDIT_RED")
+    assert png.startswith(b"\x89PNG\r\n\x1a\n")
+    assert pdf.startswith(b"%PDF-")
+    assert b"AUDIT_RED" in pdf
+    assert len(png) < 8_000
+    assert len(pdf) < 16_000
+
+
+def test_multimodal_spike_builds_anthropic_and_openai_shapes():
+    png = multi_spike.make_red_png()
+    anthropic = multi_spike.build_anthropic_image_message(png)
+    openai = multi_spike.build_openai_image_message(png)
+
+    assert anthropic[0]["content"][0]["type"] == "image"
+    assert anthropic[0]["content"][0]["source"]["media_type"] == "image/png"
+    assert openai[0]["content"][1]["type"] == "image_url"
+    assert openai[0]["content"][1]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_multimodal_format_failure_is_inconclusive():
+    result = multi_spike.classify_multimodal_result(error="unsupported image content block")
+    assert result["verdict"] == "inconclusive"
+    assert result["riskMatrixImpact"] == "none"
+
+
+def test_multimodal_response_without_expected_keyword_is_only_suspect():
+    result = multi_spike.classify_multimodal_result("I cannot see images in this interface")
+    assert result["verdict"] == "dilution_suspected"
+    assert result["riskMatrixImpact"] == "none"
+
+
+def test_ac1b_watch_spike_detects_sensitive_only_anomalies():
+    entries = [
+        {"profile": "neutral", "anomaly": False},
+        {"profile": "neutral", "anomaly": False},
+        {"profile": "neutral", "anomaly": False},
+        {"profile": "sensitive", "anomaly": True},
+        {"profile": "sensitive", "anomaly": False},
+        {"profile": "sensitive", "anomaly": False},
+    ]
+    result = ac1b_spike.analyze_entries(entries)
+    assert result["verdict"] == "conditional_injection_suspected"
+    assert result["riskMatrixImpact"] == "none"
+
+
+def test_ac1b_watch_spike_needs_neutral_and_sensitive_observations():
+    result = ac1b_spike.analyze_entries([{"profile": "sensitive", "anomaly": True}])
+    assert result["verdict"] == "insufficient_data"
+
+
+def test_ac1b_watch_spike_loads_ndjson_and_skips_malformed_lines(tmp_path):
+    path = tmp_path / "watch.ndjson"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"profile": "neutral", "anomaly": False}),
+                "{not json",
+                json.dumps({"userContent": "contains api_key", "anomaly": True}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    entries = ac1b_spike.load_ndjson(path)
+    assert len(entries) == 2
+    assert ac1b_spike.profile_request(entries[1]["userContent"]) == "sensitive"

--- a/web/index.html
+++ b/web/index.html
@@ -252,7 +252,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">672</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">682</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## Summary
- add experiment-only helpers for LLMprobe-inspired model-substitution deltas, multimodal dilution fixtures, and AC-1.b local watch-log analysis
- document the absorption priority and guardrails: no default audit wiring, no 6D risk-matrix expansion, no leaderboard/trusted-relay language
- credit BazaarLink LLMprobe-engine as an external methodology/evidence contributor and sync public test metrics from 672 to 682

## Scope guardrails
- This PR does not touch #24 and does not seed BazaarLink source evidence into the evidence-gate branch.
- This PR does not modify `scripts/audit.py`, root `audit.py`, or `api_relay_audit/*`.
- All new outputs are informational with `riskMatrixImpact=none`.

## Validation
- `python3 -m py_compile scripts/experiments/model_substitution_spike.py scripts/experiments/multimodal_dilution_spike.py scripts/experiments/ac1b_watch_spike.py`
- `python3 -m pytest tests/test_llmprobe_spikes.py -q` -> 10 passed
- `python3 scripts/collect-metrics.py --check`
- `git diff --check`
- `git diff -- scripts/audit.py audit.py api_relay_audit` -> no output
- `python3 -m pytest tests/ -q` -> 682 passed