### PR TITLE
[codex] make Claude draft review advisory

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -17,7 +17,32 @@ jobs:
         with:
           fetch-depth: 0   # 让 Claude 能 diff 到 master
 
-      - uses: anthropics/claude-code-action@v1
+      - name: Check Claude draft-review gate
+        id: claude-gate
+        env:
+          CLAUDE_DRAFT_REVIEW_ENABLED: ${{ vars.CLAUDE_DRAFT_REVIEW_ENABLED }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        shell: bash
+        run: |
+          if [ "${CLAUDE_DRAFT_REVIEW_ENABLED}" != "true" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Claude draft review skipped. Set CLAUDE_DRAFT_REVIEW_ENABLED=true after refreshing CLAUDE_CODE_OAUTH_TOKEN."
+            exit 0
+          fi
+
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Claude draft review skipped because CLAUDE_CODE_OAUTH_TOKEN is not configured."
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Claude draft review
+        id: claude-review
+        if: steps.claude-gate.outputs.enabled == 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,3 +81,9 @@ jobs:
 
           claude_args: |
             --max-turns 12
+
+      - name: Report Claude draft-review advisory failure
+        if: steps.claude-review.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Claude draft review failed. Refresh CLAUDE_CODE_OAUTH_TOKEN; this advisory check is intentionally non-blocking."


### PR DESCRIPTION
## Summary

- Gate Claude draft PR review behind `CLAUDE_DRAFT_REVIEW_ENABLED=true` so bad or missing credentials do not create red advisory checks by default.
- Keep the Claude review action non-blocking when it is enabled but fails authentication.
- Emit explicit notices/warnings that tell maintainers to refresh `CLAUDE_CODE_OAUTH_TOKEN` before re-enabling the advisory review.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-pr-review.yml"); puts "yaml ok"'`
- `python3 scripts/collect-metrics.py --check`
- `python3 scripts/build-standalone.py --check`
