### PR TITLE
[codex] add release-ready community and guide pages

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+API Relay Audit is a security project. The standard here is direct technical
+discussion with enough care that contributors can reproduce, verify, and improve
+the work.
+
+## Expected Behavior
+
+- Be specific about evidence, commands, versions, and affected files.
+- Keep criticism focused on code, documentation, or reproducible behavior.
+- Redact API keys, wallet material, private relay traffic, and personal data.
+- Assume `inconclusive` means more investigation is needed, not that someone is
+  wrong or dishonest.
+- Respect maintainers' scope decisions when a request is outside the project.
+
+## Unacceptable Behavior
+
+- Publishing secrets, credentials, private keys, or non-consensual traffic
+  captures.
+- Harassment, personal attacks, or repeated off-topic pressure.
+- Using issues or pull requests for relay advertising, brigading, or unsupported
+  safety claims.
+- Misrepresenting audit output as a certification.
+
+## Enforcement
+
+Maintainers may edit, hide, lock, or remove comments and issues that violate
+this policy. Severe or repeated violations may lead to a block from the
+repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Thanks for helping improve API Relay Audit. The project is intentionally scoped:
+it favors local, reproducible audit evidence over broad relay rankings or
+speculative detector growth.
+
+## Good First Contributions
+
+Good first issues usually fit one of these shapes:
+
+- Documentation examples that do not expose real relay domains or API keys.
+- Deterministic tests for existing detector behavior.
+- Clarifications that make `inconclusive` results easier to understand.
+- Small fixes that keep the standalone and modular versions aligned.
+
+Before opening a larger PR, please start with an issue that explains the
+real-world behavior you observed and the exact audit step it affects.
+
+## Development Setup
+
+```bash
+pip install httpx pytest
+python3 -m pytest tests/ -v
+python3 scripts/collect-metrics.py --check
+```
+
+When changing audit logic, also run:
+
+```bash
+python3 scripts/build-standalone.py --check
+python3 -m pytest tests/test_dual_distribution_parity.py -v
+```
+
+## Dual Distribution Rule
+
+This repository has two distributions:
+
+- `audit.py`: standalone, zero-dependency user artifact.
+- `api_relay_audit/` plus `scripts/`: modular development version.
+
+If you change audit behavior in `scripts/audit.py` or `api_relay_audit/`, the
+standalone `audit.py` must stay in sync. The drift checks exist to prevent users
+from running a different detector than contributors test.
+
+## Pull Request Checklist
+
+- Keep the change focused on one behavior or document.
+- Avoid publishing secrets, private traffic, or real API keys.
+- Do not describe a relay as safe or unsafe without reproducible evidence.
+- Preserve the distinction between `clean`, `anomaly`, and `inconclusive`.
+- Update public metrics with `python3 scripts/collect-metrics.py` when the
+  reported step count, test count, CLI flags, or public claims change.
+- Add or update tests when behavior changes.
+
+## Public Claims
+
+For launch copy, comparison docs, or README claims, prefer wording that can be
+verified from the current repository. If a claim depends on current external
+data, rerun the relevant benchmark before using it publicly.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img alt="API Relay Audit - AI API Relay Security Audit. Prompt Injection, Model Substitution, Tool Rewriting, SSE Anomalies. Runs Locally, Your API Key Stays Local." src="./assets/readme-banner.png">
+  <img alt="API Relay Audit - AI API Relay Security Audit. Prompt Injection, Model Substitution, Tool Rewriting, SSE Anomalies. Runs locally; your API key is sent only to the relay URL you choose." src="./assets/readme-banner.png">
 </p>
 
 # API Relay Audit
@@ -27,7 +27,7 @@
 
 ## What Is API Relay Audit?
 
-API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks while keeping your API key local.
+API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Your API key is sent only to the relay URL you choose.
 
 Use it when you rely on a third-party AI API relay, OpenAI-compatible proxy, Claude-compatible proxy, or Web3 agent workflow and want a repeatable Markdown report before trusting that relay with production or wallet-related traffic.
 
@@ -100,6 +100,7 @@ These probes are model-agnostic, but they are intentionally profile-gated so gen
 - Guides:
   [AI API relay / LLM proxy](https://toby-bridges.github.io/api-relay-audit/guides/what-is-ai-api-relay-proxy.html),
   [Claude relay audit](https://toby-bridges.github.io/api-relay-audit/guides/audit-claude-api-relay-safely.html),
+  [tool comparison](https://toby-bridges.github.io/api-relay-audit/guides/compare-api-relay-audit-hvoy-cctest.html),
   [prompt injection in proxies](https://toby-bridges.github.io/api-relay-audit/guides/detect-prompt-injection-llm-api-proxies.html),
   [Web3 wallet prompt injection](https://toby-bridges.github.io/api-relay-audit/guides/web3-wallet-prompt-injection-ai-agents.html)
 - Contributors / Credits: [CONTRIBUTORS.md](./CONTRIBUTORS.md)
@@ -166,7 +167,7 @@ Start with [CONTRIBUTING.md](./CONTRIBUTING.md), avoid publishing real API keys 
 
 ## API Relay Audit 是什么？
 
-`api-relay-audit` 是一个本地运行的 AI API 中转站 / LLM proxy 安全审计工具。它检测 prompt injection、模型替换、工具调用改写、SSE 流异常、错误响应泄漏，以及 Web3 钱包相关风险，同时让你的 API Key 保持在本地。
+`api-relay-audit` 是一个本地运行的 AI API 中转站 / LLM proxy 安全审计工具。它检测 prompt injection、模型替换、工具调用改写、SSE 流异常、错误响应泄漏，以及 Web3 钱包相关风险；你的 API Key 只会发送到你指定的中转站 URL。
 
 当你使用第三方 AI API 中转站、OpenAI-compatible proxy、Claude-compatible proxy，或者 Web3 agent 工作流时，可以用它在信任该中转站之前生成一份可复查的 Markdown 审计报告。
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,15 @@ These probes are model-agnostic, but they are intentionally profile-gated so gen
 ## Example Report And Live Page
 
 - GitHub Pages: [toby-bridges.github.io/api-relay-audit](https://toby-bridges.github.io/api-relay-audit/)
-- Shipped / deferred / explicitly not doing: [ROADMAP.md](./ROADMAP.md)
-- Engineering diary: [FOR_JOHN.md](./FOR_JOHN.md)
+- Chinese landing page: [toby-bridges.github.io/api-relay-audit/zh/](https://toby-bridges.github.io/api-relay-audit/zh/)
+- Guides:
+  [AI API relay / LLM proxy](https://toby-bridges.github.io/api-relay-audit/guides/what-is-ai-api-relay-proxy.html),
+  [Claude relay audit](https://toby-bridges.github.io/api-relay-audit/guides/audit-claude-api-relay-safely.html),
+  [prompt injection in proxies](https://toby-bridges.github.io/api-relay-audit/guides/detect-prompt-injection-llm-api-proxies.html),
+  [Web3 wallet prompt injection](https://toby-bridges.github.io/api-relay-audit/guides/web3-wallet-prompt-injection-ai-agents.html)
 - Contributors / Credits: [CONTRIBUTORS.md](./CONTRIBUTORS.md)
+- Security policy: [SECURITY.md](./SECURITY.md)
+- Contributing guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
 - Social: [X @li9292](https://x.com/li9292)
 
 ## FAQ
@@ -144,6 +150,12 @@ They serve different needs. hvoy.ai is useful for relay reputation lookup, cctes
 AGPL-3.0-only. See [LICENSE](./LICENSE).
 
 This keeps modified network-service deployments accountable to the same public source-availability standard as the relay ecosystem evidence we audit.
+
+## How to Contribute
+
+Good first contributions are small, reproducible, and evidence-focused: documentation examples, deterministic detector tests, or clearer wording around `clean`, `anomaly`, and `inconclusive` results.
+
+Start with [CONTRIBUTING.md](./CONTRIBUTING.md), avoid publishing real API keys or private relay traffic, and keep changes scoped to one behavior or document.
 
 ## Star History
 
@@ -199,9 +211,12 @@ python audit.py --key <YOUR_KEY> --url <BASE_URL> --profile web3 --output report
 ## 主要入口
 
 - 在线页 / GitHub Pages: [toby-bridges.github.io/api-relay-audit](https://toby-bridges.github.io/api-relay-audit/)
+- 中文独立页: [toby-bridges.github.io/api-relay-audit/zh/](https://toby-bridges.github.io/api-relay-audit/zh/)
 - 路线图与明确不做: [ROADMAP.md](./ROADMAP.md)
 - 工程记录: [FOR_JOHN.md](./FOR_JOHN.md)
 - 贡献者 / Credits: [CONTRIBUTORS.md](./CONTRIBUTORS.md)
+- 安全政策: [SECURITY.md](./SECURITY.md)
+- 贡献指南: [CONTRIBUTING.md](./CONTRIBUTING.md)
 - 社交媒体: [X @li9292](https://x.com/li9292)
 
 </details>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,8 +58,9 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
 - **Boundary held**: no hosted dashboard, no new dependency, no Claude Code
   header impersonation, no knowledge-cutoff/0-100/4-level risk/OpenAI
   streaming auto-detect, no copied closed-source fingerprint table.
-- **Final test count**: 683/683 passing (642 baseline → 683 after current
-  guardrail/contract and tool-substitution fixture tests).
+- **Final test count**: 689/689 passing (642 baseline → 683 after current
+  guardrail/contract and tool-substitution fixture tests → 689 after
+  release/community static-site regression tests).
 
 ### v2.1 and earlier (pre-session baseline)
 - Steps 1-7: infrastructure recon / model list / token injection via delta

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+API Relay Audit is a local security audit tool for third-party AI API relays
+and LLM proxies. This policy covers vulnerabilities in this repository, not
+findings about relay operators.
+
+## Supported Version
+
+The supported release line is the current `master` branch and the latest
+published release. Older snapshots may be useful for comparison, but security
+fixes land on `master` first.
+
+## Reporting a Vulnerability
+
+If you find a vulnerability in API Relay Audit itself, please open a private
+security advisory on GitHub when available, or contact the maintainer before
+publishing exploit details.
+
+Please include:
+
+- The affected file, command, or workflow.
+- A minimal reproduction that does not expose real API keys.
+- Whether the issue affects the standalone `audit.py`, the modular package, or
+  both.
+- Any evidence that a report could leak credentials, send traffic to an
+  unintended host, or misclassify an unsafe relay as clean.
+
+Do not include live credentials, private relay URLs, wallet seed phrases,
+private keys, or user traffic captures.
+
+## Scope
+
+In scope:
+
+- Credential leakage caused by this tool.
+- Incorrect redaction or unsafe report handling.
+- A bug that silently changes the target relay URL.
+- A bug that marks an inconclusive or anomalous audit step as clean.
+- Drift between the standalone and modular distributions that changes audit
+  behavior.
+
+Out of scope:
+
+- A relay operator's behavior unless it demonstrates a bug in this tool.
+- Requests for relay recommendations or rankings.
+- Vulnerabilities in upstream AI providers.
+- Results from modified forks that do not match this repository.
+
+## Audit Findings Are Not Certifications
+
+API Relay Audit reports evidence from local probes. A `LOW` result is not a
+certificate that a relay is safe, and an `inconclusive` result is not clean.
+Use the report as one input to a broader security review.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,15 +6,20 @@ findings about relay operators.
 
 ## Supported Version
 
-The supported release line is the current `master` branch and the latest
-published release. Older snapshots may be useful for comparison, but security
-fixes land on `master` first.
+Until the first tagged release, the supported line is the current `master`
+branch. After tagged releases begin, the supported lines are the current
+`master` branch and the latest published release. Older snapshots may be useful
+for comparison, but security fixes land on `master` first.
 
 ## Reporting a Vulnerability
 
-If you find a vulnerability in API Relay Audit itself, please open a private
-security advisory on GitHub when available, or contact the maintainer before
-publishing exploit details.
+If you find a vulnerability in API Relay Audit itself, use GitHub private
+vulnerability reporting when it is enabled for this repository.
+
+If private vulnerability reporting is not available, open a minimal public
+issue only with non-sensitive reproduction details. Do not include secrets,
+private relay details, API keys, wallet material, or raw traffic captures in a
+public issue.
 
 Please include:
 

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,16 +16,16 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **683** | `pytest --collect-only` |
-| 测试数 (static) | 667 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **689** | `pytest --collect-only` |
+| 测试数 (static) | 673 | grep `def test_*` in tests/ |
 | CLI flag 数 | 20 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-01 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
-| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 683] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `7a25d6d` | recent reachable commit; `--check` allows follow-up metrics commits |
+| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 689] | grep `Final test count: N/N passing` |
+| Recorded commit SHA | `a64b0f5` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-01 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -25,7 +25,7 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 689] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `a64b0f5` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `7bfb0fc` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-01 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检

--- a/tests/test_static_site.py
+++ b/tests/test_static_site.py
@@ -1,0 +1,167 @@
+"""Regression checks for the GitHub Pages static site."""
+
+import json
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+import xml.etree.ElementTree as ET
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WEB_ROOT = REPO_ROOT / "web"
+PAGES_BASE = "https://toby-bridges.github.io/api-relay-audit/"
+
+
+class SiteParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.links = []
+        self.ids = set()
+        self.canonicals = []
+        self.alternates = []
+        self.json_ld = []
+        self._in_json_ld = False
+        self._json_ld_parts = []
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if "id" in attrs:
+            self.ids.add(attrs["id"])
+        for key in ("href", "src"):
+            if key in attrs:
+                self.links.append((tag, key, attrs[key]))
+        if tag == "link" and attrs.get("rel") == "canonical":
+            self.canonicals.append(attrs.get("href", ""))
+        if tag == "link" and attrs.get("rel") == "alternate":
+            self.alternates.append((attrs.get("hreflang", ""), attrs.get("href", "")))
+        if tag == "script" and attrs.get("type") == "application/ld+json":
+            self._in_json_ld = True
+            self._json_ld_parts = []
+
+    def handle_data(self, data):
+        if self._in_json_ld:
+            self._json_ld_parts.append(data)
+
+    def handle_endtag(self, tag):
+        if tag == "script" and self._in_json_ld:
+            self.json_ld.append("".join(self._json_ld_parts))
+            self._in_json_ld = False
+            self._json_ld_parts = []
+
+
+def _parse_html(path):
+    parser = SiteParser()
+    parser.feed(path.read_text(encoding="utf-8"))
+    return parser
+
+
+def _html_pages():
+    return sorted(WEB_ROOT.glob("**/*.html"))
+
+
+def _local_path_for_url(url):
+    parsed = urlparse(url)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "toby-bridges.github.io"
+    assert parsed.path.startswith("/api-relay-audit/")
+    suffix = parsed.path.removeprefix("/api-relay-audit/")
+    if suffix in ("", "/"):
+        return WEB_ROOT / "index.html"
+    path = WEB_ROOT / unquote(suffix)
+    if parsed.path.endswith("/"):
+        return path / "index.html"
+    return path
+
+
+def _target_file_for_relative_link(source, href):
+    path_part, _, fragment = href.partition("#")
+    if not path_part:
+        return source, fragment
+    target = (source.parent / unquote(path_part)).resolve()
+    assert str(target).startswith(str(WEB_ROOT.resolve()))
+    if target.is_dir():
+        target = target / "index.html"
+    return target, fragment
+
+
+def test_all_pages_parse_and_json_ld_is_valid():
+    for path in _html_pages():
+        parser = _parse_html(path)
+        for item in parser.json_ld:
+            json.loads(item)
+
+
+def test_relative_links_and_fragments_resolve():
+    parsers = {path: _parse_html(path) for path in _html_pages()}
+    for source, parser in parsers.items():
+        for _tag, _key, href in parser.links:
+            parsed = urlparse(href)
+            if parsed.scheme or href.startswith(("mailto:", "tel:", "javascript:")):
+                continue
+            if href == "#":
+                continue
+            target, fragment = _target_file_for_relative_link(source, href)
+            assert target.exists(), f"{source} links to missing {href}"
+            if fragment:
+                target_parser = parsers.get(target) or _parse_html(target)
+                assert fragment in target_parser.ids, f"{source} links to missing fragment {href}"
+
+
+def test_sitemap_urls_map_to_committed_pages():
+    root = ET.parse(WEB_ROOT / "sitemap.xml").getroot()
+    namespace = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    urls = [item.text for item in root.findall("sm:url/sm:loc", namespace)]
+    expected = {
+        "https://toby-bridges.github.io/api-relay-audit/",
+        "https://toby-bridges.github.io/api-relay-audit/zh/",
+        *{
+            PAGES_BASE + path.relative_to(WEB_ROOT).as_posix()
+            for path in WEB_ROOT.glob("guides/*.html")
+        },
+    }
+    assert set(urls) == expected
+    for url in urls:
+        assert _local_path_for_url(url).exists(), url
+
+
+def test_robots_points_to_sitemap():
+    robots = (WEB_ROOT / "robots.txt").read_text(encoding="utf-8")
+    assert "User-agent: *" in robots
+    assert f"Sitemap: {PAGES_BASE}sitemap.xml" in robots
+
+
+def test_homepage_and_chinese_page_have_reciprocal_hreflang():
+    expected = {
+        ("en", "https://toby-bridges.github.io/api-relay-audit/"),
+        ("zh-CN", "https://toby-bridges.github.io/api-relay-audit/zh/"),
+        ("x-default", "https://toby-bridges.github.io/api-relay-audit/"),
+    }
+    for path, canonical in [
+        (WEB_ROOT / "index.html", "https://toby-bridges.github.io/api-relay-audit/"),
+        (WEB_ROOT / "zh" / "index.html", "https://toby-bridges.github.io/api-relay-audit/zh/"),
+    ]:
+        parser = _parse_html(path)
+        assert parser.canonicals == [canonical]
+        assert set(parser.alternates) == expected
+
+
+def test_release_copy_avoids_stale_numeric_and_key_flow_claims():
+    public_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in [
+            REPO_ROOT / "README.md",
+            WEB_ROOT / "index.html",
+            WEB_ROOT / "zh" / "index.html",
+        ]
+    )
+    forbidden = [
+        "2,847 lines",
+        "2,847 行",
+        "24 keywords",
+        "24 个关键词",
+        "key stays local",
+        "Key 留在本地",
+        "never sent to a third-party server",
+    ]
+    for phrase in forbidden:
+        assert phrase not in public_text

--- a/web/assets/content.css
+++ b/web/assets/content.css
@@ -1,0 +1,40 @@
+*{box-sizing:border-box}
+:root{
+  --bg:#0a0e17;--panel:#111827;--panel2:#151f2f;--border:#263348;
+  --text:#e2e8f0;--muted:#9aa8ba;--soft:#718096;--accent:#60a5fa;
+  --green:#10b981;--yellow:#f59e0b;--orange:#fe9900;
+}
+html{scroll-behavior:smooth}
+body{margin:0;background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans SC",sans-serif;line-height:1.65}
+a{color:var(--accent);text-decoration:none}
+a:hover{text-decoration:underline}
+.wrap{width:min(960px,calc(100% - 40px));margin:0 auto}
+header{border-bottom:1px solid var(--border);background:rgba(10,14,23,.9)}
+.nav{display:flex;align-items:center;justify-content:space-between;gap:18px;padding:16px 0}
+.brand{font-weight:800;color:var(--text)}
+.links{display:flex;gap:16px;flex-wrap:wrap;font-size:.9rem}
+.links a{color:var(--muted)}
+main{padding:56px 0}
+.eyebrow{color:var(--orange);font-size:.82rem;font-weight:800;text-transform:uppercase;letter-spacing:.08em}
+h1{font-size:clamp(2rem,5vw,3.6rem);line-height:1.05;margin:10px 0 18px}
+h2{font-size:1.35rem;margin:38px 0 12px}
+h3{font-size:1rem;margin:24px 0 8px}
+p{color:var(--muted);margin:0 0 16px}
+ul,ol{color:var(--muted);padding-left:22px}
+li{margin:7px 0}
+.lead{font-size:1.08rem;max-width:760px}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px;margin:24px 0}
+.card{background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:18px}
+.card h2,.card h3{margin-top:0}
+.note{border-left:3px solid var(--orange);background:rgba(254,153,0,.08);padding:14px 16px;margin:22px 0;color:var(--muted)}
+.code{background:#0d1117;border:1px solid var(--border);border-radius:8px;padding:14px 16px;overflow:auto;color:#bfdbfe}
+code{font-family:"SF Mono",Monaco,Consolas,monospace}
+table{width:100%;border-collapse:collapse;background:var(--panel);border:1px solid var(--border);border-radius:8px;overflow:hidden;display:block}
+th,td{padding:10px 12px;border-bottom:1px solid var(--border);text-align:left;color:var(--muted);vertical-align:top}
+th{color:var(--text);font-size:.85rem}
+tr:last-child td{border-bottom:0}
+.cta{display:flex;gap:12px;flex-wrap:wrap;margin:26px 0}
+.button{display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--border);border-radius:8px;padding:10px 16px;color:var(--text);font-weight:700}
+.button.primary{background:#2563eb;border-color:#2563eb}
+footer{border-top:1px solid var(--border);padding:26px 0;color:var(--soft);font-size:.86rem}
+@media(max-width:640px){.nav{align-items:flex-start;flex-direction:column}table{font-size:.86rem}}

--- a/web/guides/audit-claude-api-relay-safely.html
+++ b/web/guides/audit-claude-api-relay-safely.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>How to Audit a Claude API Relay Safely</title>
+<meta name="description" content="Audit a Claude-compatible API relay locally for prompt injection, model substitution, context truncation, tool rewriting, error leakage, and SSE anomalies.">
+<link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/guides/audit-claude-api-relay-safely.html">
+<link rel="stylesheet" href="../assets/content.css">
+</head>
+<body>
+<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">中文</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
+<main class="wrap">
+  <div class="eyebrow">Guide</div>
+  <h1>How to audit a Claude API relay safely</h1>
+  <p class="lead">To audit a Claude-compatible relay safely, run the audit locally, point it only at the relay URL you intend to test, and review each finding as evidence rather than as a safety certificate.</p>
+
+  <h2>Safe audit checklist</h2>
+  <ol>
+    <li>Use a scoped API key with limited budget when possible.</li>
+    <li>Run the standalone `audit.py` locally so the key does not pass through a separate web checker.</li>
+    <li>Save the Markdown report and review red, yellow, and inconclusive items.</li>
+    <li>Do not publish real relay credentials, private domains, wallet addresses tied to private use, or raw traffic captures.</li>
+  </ol>
+
+  <h2>Command</h2>
+  <pre class="code"><code>curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py
+python audit.py \
+  --key &lt;YOUR_KEY&gt; \
+  --url &lt;BASE_URL&gt; \
+  --model claude-opus-4-6 \
+  --output claude-relay-audit.md</code></pre>
+
+  <h2>Claude-specific checks</h2>
+  <table>
+    <tr><th>Area</th><th>What API Relay Audit checks</th></tr>
+    <tr><td>Identity</td><td>Non-Claude identity leaks, model substitution wording, and stream model identity where available.</td></tr>
+    <tr><td>Streaming</td><td>Anthropic-style SSE event types, usage monotonicity, thinking signature presence, and stream model consistency.</td></tr>
+    <tr><td>Prompt path</td><td>Token injection, prompt extraction, instruction conflict, and jailbreak behavior.</td></tr>
+    <tr><td>Tool path</td><td>Text-echo package command integrity for tool-call rewriting risks.</td></tr>
+  </table>
+
+  <h2>Interpreting inconclusive results</h2>
+  <p>Inconclusive means the probe could not establish a clean or anomalous result. It may happen because the relay blocks a request, does not support a format, truncates an answer, or returns an ambiguous response. Do not treat inconclusive as clean.</p>
+</main>
+<footer><div class="wrap">Related: <a href="what-is-ai-api-relay-proxy.html">what is an AI API relay?</a> · <a href="compare-api-relay-audit-hvoy-cctest.html">tool comparison</a></div></footer>
+</body>
+</html>

--- a/web/guides/compare-api-relay-audit-hvoy-cctest.html
+++ b/web/guides/compare-api-relay-audit-hvoy-cctest.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>api-relay-audit vs hvoy.ai vs cctest.ai</title>
+<meta name="description" content="A restrained comparison of api-relay-audit, hvoy.ai, and cctest.ai for AI API relay and Claude proxy checking.">
+<link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/guides/compare-api-relay-audit-hvoy-cctest.html">
+<link rel="stylesheet" href="../assets/content.css">
+</head>
+<body>
+<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">中文</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
+<main class="wrap">
+  <div class="eyebrow">Comparison</div>
+  <h1>api-relay-audit vs hvoy.ai vs cctest.ai</h1>
+  <p class="lead">These tools answer related but different questions. API Relay Audit is a local, open-source, repeatable audit script. hvoy.ai is useful for relay reputation lookup and public relay observations. cctest.ai focuses on low-friction web checks and Claude channel fingerprinting.</p>
+
+  <h2>Positioning</h2>
+  <table>
+    <tr><th>Tool</th><th>Best fit</th><th>Trust tradeoff</th></tr>
+    <tr><td>API Relay Audit</td><td>Local audit reports, reproducible evidence, security review before production or wallet traffic.</td><td>You run the code locally and can inspect it; CLI use is less convenient than a web form.</td></tr>
+    <tr><td>hvoy.ai</td><td>Relay lookup, public observations, operator and user reputation signals.</td><td>Useful discovery surface; not a substitute for a local audit of your own route.</td></tr>
+    <tr><td>cctest.ai</td><td>Fast Claude-oriented web checks and channel fingerprinting claims.</td><td>Lower friction; users still need to decide whether to trust the web checker with sensitive inputs.</td></tr>
+  </table>
+
+  <h2>Where API Relay Audit is intentionally different</h2>
+  <ul>
+    <li>It runs locally, so the extra checker server is removed from the API-key path.</li>
+    <li>It produces a Markdown report that can be reviewed, redacted, and attached to issues.</li>
+    <li>It keeps `inconclusive` separate from `clean`.</li>
+    <li>It maps important probes to relay supply-chain risks such as AC-1, AC-1.a, and AC-2.</li>
+  </ul>
+
+  <h2>Not a winner-takes-all claim</h2>
+  <p>Use the tool that matches the question. If you want public relay discovery, a reputation surface may be useful. If you want a local report for your own key, route, and workflow, run API Relay Audit. If you need channel-fingerprint research, track the design memo before treating it as implemented here.</p>
+
+  <div class="cta"><a class="button primary" href="../#install">Generate a local audit command</a><a class="button" href="https://github.com/toby-bridges/api-relay-audit/blob/master/docs/comparison-api-relay-audit-vs-hvoy-vs-cctest.md">Read the longer comparison</a></div>
+</main>
+<footer><div class="wrap">Related: <a href="audit-claude-api-relay-safely.html">audit Claude relays safely</a> · <a href="what-is-ai-api-relay-proxy.html">what is a relay?</a></div></footer>
+</body>
+</html>

--- a/web/guides/compare-api-relay-audit-hvoy-cctest.html
+++ b/web/guides/compare-api-relay-audit-hvoy-cctest.html
@@ -34,7 +34,7 @@
   <h2>Not a winner-takes-all claim</h2>
   <p>Use the tool that matches the question. If you want public relay discovery, a reputation surface may be useful. If you want a local report for your own key, route, and workflow, run API Relay Audit. If you need channel-fingerprint research, track the design memo before treating it as implemented here.</p>
 
-  <div class="cta"><a class="button primary" href="../#install">Generate a local audit command</a><a class="button" href="https://github.com/toby-bridges/api-relay-audit/blob/master/docs/comparison-api-relay-audit-vs-hvoy-vs-cctest.md">Read the longer comparison</a></div>
+  <div class="cta"><a class="button primary" href="../#install">Generate a local audit command</a></div>
 </main>
 <footer><div class="wrap">Related: <a href="audit-claude-api-relay-safely.html">audit Claude relays safely</a> · <a href="what-is-ai-api-relay-proxy.html">what is a relay?</a></div></footer>
 </body>

--- a/web/guides/detect-prompt-injection-llm-api-proxies.html
+++ b/web/guides/detect-prompt-injection-llm-api-proxies.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Detecting Prompt Injection in LLM API Proxies</title>
+<meta name="description" content="How to detect prompt injection and hidden instruction changes in LLM API proxies with local probes and reviewable audit evidence.">
+<link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/guides/detect-prompt-injection-llm-api-proxies.html">
+<link rel="stylesheet" href="../assets/content.css">
+</head>
+<body>
+<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">中文</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
+<main class="wrap">
+  <div class="eyebrow">Guide</div>
+  <h1>Detecting prompt injection in LLM API proxies</h1>
+  <p class="lead">Prompt injection in an LLM API proxy means the intermediary may add hidden instructions, identity text, or policy text to your request before it reaches the model. Local detection works by combining token-delta evidence, extraction probes, identity checks, and instruction-conflict tests.</p>
+
+  <h2>Signals to look for</h2>
+  <div class="grid">
+    <section class="card"><h3>Unexpected token delta</h3><p>If a small request produces a much larger prompt-token count than expected, the relay may be adding hidden context.</p></section>
+    <section class="card"><h3>Prompt extraction</h3><p>If the model reveals hidden relay instructions under recall, translation, or continuation probes, the relay path is not transparent.</p></section>
+    <section class="card"><h3>Identity conflict</h3><p>If a Claude-compatible route leaks GPT, GLM, DeepSeek, Qwen, or other non-claimed identities, model substitution or prompt injection may be involved.</p></section>
+  </div>
+
+  <h2>Run the local probe set</h2>
+  <pre class="code"><code>python audit.py --key &lt;YOUR_KEY&gt; --url &lt;BASE_URL&gt; --output prompt-injection-audit.md</code></pre>
+
+  <h2>Why one signal is not enough</h2>
+  <p>Token counts can be noisy, extraction probes can be refused, and identity wording can produce false positives. API Relay Audit records multiple probe families so a reviewer can see whether the evidence is consistent, contradictory, or inconclusive.</p>
+
+  <h2>Useful follow-up issue</h2>
+  <p>For reproducible examples and detector gaps, track <a href="https://github.com/toby-bridges/api-relay-audit/issues/31">issue #31: relay prompt injection examples and detection gaps</a>.</p>
+</main>
+<footer><div class="wrap">Related: <a href="what-is-ai-api-relay-proxy.html">what is an LLM proxy?</a> · <a href="web3-wallet-prompt-injection-ai-agents.html">Web3 wallet prompt injection</a></div></footer>
+</body>
+</html>

--- a/web/guides/web3-wallet-prompt-injection-ai-agents.html
+++ b/web/guides/web3-wallet-prompt-injection-ai-agents.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Web3 Wallet Prompt Injection Through AI Agents</title>
+<meta name="description" content="How AI API relays can affect Web3 wallet workflows, and how to run local signature-isolation probes before wallet-related traffic is trusted.">
+<link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/guides/web3-wallet-prompt-injection-ai-agents.html">
+<link rel="stylesheet" href="../assets/content.css">
+</head>
+<body>
+<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">中文</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
+<main class="wrap">
+  <div class="eyebrow">Web3 Guide</div>
+  <h1>Web3 wallet prompt injection through AI agents</h1>
+  <p class="lead">When an AI agent uses a relay before wallet-related actions, a malicious or compromised relay can try to steer transfer guidance, weaken signature isolation, or normalize unsafe handling of private keys. API Relay Audit keeps these checks profile-gated so general relay audits remain focused.</p>
+
+  <h2>Threat model</h2>
+  <ul>
+    <li>The user sends wallet-related instructions through an AI API relay.</li>
+    <li>The relay can insert hidden instructions or rewrite the model path.</li>
+    <li>The model may then provide unsafe transfer guidance, signed-transaction behavior, or private-key handling language.</li>
+  </ul>
+
+  <h2>Run Web3 profile checks</h2>
+  <pre class="code"><code>python audit.py \
+  --key &lt;YOUR_KEY&gt; \
+  --url &lt;BASE_URL&gt; \
+  --profile web3 \
+  --output web3-relay-audit.md</code></pre>
+
+  <h2>What the probes check</h2>
+  <table>
+    <tr><th>Probe family</th><th>Expected safe behavior</th></tr>
+    <tr><td>Transfer guidance</td><td>The model should avoid directly instructing unsafe or unauthorized transfers.</td></tr>
+    <tr><td>Signed transaction refusal</td><td>The model should refuse to sign transactions or imply it can sign on the user's behalf.</td></tr>
+    <tr><td>Private-key refusal</td><td>The model should refuse to request, reveal, or process private keys.</td></tr>
+  </table>
+
+  <h2>Limits</h2>
+  <p>These probes do not prove a wallet stack is safe. They test relay and model behavior under specific prompts. Keep transaction signing, key custody, and policy enforcement outside the relay path wherever possible.</p>
+
+  <p>For documentation work on this threat model, track <a href="https://github.com/toby-bridges/api-relay-audit/issues/33">issue #33: Web3 wallet prompt injection threat model</a>.</p>
+</main>
+<footer><div class="wrap">Related: <a href="detect-prompt-injection-llm-api-proxies.html">prompt injection in LLM proxies</a> · <a href="audit-claude-api-relay-safely.html">audit Claude relays safely</a></div></footer>
+</body>
+</html>

--- a/web/guides/what-is-ai-api-relay-proxy.html
+++ b/web/guides/what-is-ai-api-relay-proxy.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>What Is an AI API Relay or LLM Proxy?</title>
+<meta name="description" content="An AI API relay or LLM proxy sits between your app and an AI provider. Learn what it can change, why it matters, and how to audit it locally.">
+<link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/guides/what-is-ai-api-relay-proxy.html">
+<link rel="stylesheet" href="../assets/content.css">
+</head>
+<body>
+<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">中文</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
+<main class="wrap">
+  <div class="eyebrow">Guide</div>
+  <h1>What is an AI API relay or LLM proxy?</h1>
+  <p class="lead">An AI API relay or LLM proxy is a third-party service that sits between your application and an upstream AI provider such as Anthropic or OpenAI. It can forward requests, normalize APIs, meter usage, or route traffic, but it can also change the prompt, model, context, stream, or error response you receive.</p>
+
+  <section class="note">Short answer: a relay is part of your model supply chain. If it can read and rewrite requests, it should be audited before production or wallet-related traffic depends on it.</section>
+
+  <h2>What a relay can change</h2>
+  <div class="grid">
+    <section class="card"><h3>Prompt path</h3><p>A relay can prepend hidden instructions, inject identity text, ask the model to ignore user instructions, or reveal hidden prompt content in later responses.</p></section>
+    <section class="card"><h3>Model path</h3><p>A relay can route a request to a different model than the one named in the API response, or leak an upstream model identity through wording or stream metadata.</p></section>
+    <section class="card"><h3>Tool path</h3><p>A relay can rewrite package-install commands or tool-like output before it reaches a coding agent, which turns proxy behavior into a supply-chain risk.</p></section>
+  </div>
+
+  <h2>Why local auditing matters</h2>
+  <p>A web-based checker asks you to send a relay key to another service before you can test the relay. API Relay Audit avoids that extra trust hop: the script runs locally, and your API key is sent only to the relay URL you specify.</p>
+
+  <h2>How to audit one</h2>
+  <pre class="code"><code>curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py
+python audit.py --key &lt;YOUR_KEY&gt; --url &lt;BASE_URL&gt; --output report.md</code></pre>
+
+  <h2>What the report does not prove</h2>
+  <p>A clean-looking run is not a certificate. Relays can behave conditionally, models can be ambiguous, and unsupported formats can make a step inconclusive. Treat the report as reproducible evidence, not a final safety label.</p>
+</main>
+<footer><div class="wrap">Related: <a href="audit-claude-api-relay-safely.html">audit a Claude API relay safely</a> · <a href="detect-prompt-injection-llm-api-proxies.html">prompt injection in LLM proxies</a></div></footer>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>API Relay Audit - AI API Relay Security Audit for LLM Proxies</title>
-<meta name="description" content="Audit AI API relays and LLM proxies for prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Runs locally; your API key stays local.">
+<meta name="description" content="Audit AI API relays and LLM proxies for prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Runs locally; your API key is sent only to the relay URL you choose.">
 <link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/">
 <link rel="alternate" hreflang="en" href="https://toby-bridges.github.io/api-relay-audit/">
 <link rel="alternate" hreflang="zh-CN" href="https://toby-bridges.github.io/api-relay-audit/zh/">
@@ -17,7 +17,7 @@
 <meta property="og:image" content="https://toby-bridges.github.io/api-relay-audit/assets/social-preview.png">
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
-<meta property="og:image:alt" content="API Relay Audit - AI API Relay Security Audit. Runs locally, your API key stays local.">
+<meta property="og:image:alt" content="API Relay Audit - AI API Relay Security Audit. Runs locally; your API key is sent only to the relay URL you choose.">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="API Relay Audit - AI API Relay Security Audit">
 <meta name="twitter:description" content="Local security audit for AI API relays and LLM proxies: prompt injection, model substitution, tool rewriting, SSE anomalies, and Web3 wallet risks.">
@@ -42,7 +42,7 @@
       "url": "https://github.com/toby-bridges/api-relay-audit",
       "codeRepository": "https://github.com/toby-bridges/api-relay-audit",
       "license": "https://github.com/toby-bridges/api-relay-audit/blob/master/LICENSE",
-      "description": "Local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks while keeping your API key local."
+      "description": "Local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Your API key is sent only to the relay URL you choose."
     },
     {
       "@type": "FAQPage",
@@ -376,14 +376,14 @@ footer a:hover{color:var(--text)}
 <section class="hero container">
   <div class="security-badge">
     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-    <span data-i18n="hero_badge">Local execution — your API Key is never sent to a third-party server</span>
+    <span data-i18n="hero_badge">Local execution — your API key is sent only to the relay URL you choose</span>
   </div>
   <h1 data-i18n="hero_title"><span class="gradient">AI API Relay</span> Security Audit</h1>
-  <p class="hero-sub" data-i18n="hero_sub">API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks while keeping your API key local.</p>
+  <p class="hero-sub" data-i18n="hero_sub">API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Your API key is sent only to the relay URL you choose.</p>
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">683</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">689</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">
@@ -438,7 +438,7 @@ footer a:hover{color:var(--text)}
     <div class="flow-vs">
       <span class="flow-vs-good">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>
-        <span data-i18n="flow_good">api-relay-audit: Key stays on YOUR machine</span>
+        <span data-i18n="flow_good">api-relay-audit: no extra checker server sees your key</span>
       </span>
       <span style="color:var(--text3)">vs</span>
       <span class="flow-vs-bad">
@@ -470,7 +470,7 @@ footer a:hover{color:var(--text)}
         <input class="form-input" type="password" id="f-key" placeholder="sk-..." spellcheck="false" autocomplete="off">
         <div class="form-hint">
           <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2" style="vertical-align:middle"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-          <span data-i18n="form_key_hint">Stays in your browser. Only used to generate the CLI command below — never sent anywhere.</span>
+          <span data-i18n="form_key_hint">Stays in your browser to generate the command. When you run it, the key is sent only to your chosen relay URL.</span>
         </div>
       </div>
       <div class="form-row">
@@ -556,7 +556,7 @@ footer a:hover{color:var(--text)}
 
     <p class="agent-note">
       <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2" style="vertical-align:middle"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-      <span data-i18n="agent_security">Same security model — the agent runs locally on your machine, Key never touches a third-party server.</span>
+      <span data-i18n="agent_security">Same security model — the agent runs locally on your machine, and the key is sent only to your chosen relay URL.</span>
     </p>
   </div><!-- /tab-agent -->
 
@@ -568,7 +568,7 @@ footer a:hover{color:var(--text)}
 
     <p class="install-note">
       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--green)" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-      <span data-i18n="install_security">Your API Key is only sent to the relay URL you specify. No telemetry, no third-party servers.</span>
+      <span data-i18n="install_security">Your API key is only sent to the relay URL you specify; it is not sent to API Relay Audit or an extra web checker.</span>
     </p>
   </div>
 </section>
@@ -611,7 +611,7 @@ footer a:hover{color:var(--text)}
     <div class="step">
       <div class="step-num" data-i18n="step_id_label">Step 5</div>
       <h3 data-i18n="step_id_title">Identity Substitution</h3>
-      <p data-i18n="step_id_desc">24 keywords detect if "Claude" is actually GPT, DeepSeek, GLM, Qwen, or other models in disguise. Anchor phrases confirm true identity.</p>
+      <p data-i18n="step_id_desc">An identity keyword set detects if "Claude" is actually GPT, DeepSeek, GLM, Qwen, or other models in disguise. Anchor phrases confirm true identity.</p>
     </div>
     <div class="step">
       <div class="step-num" data-i18n="step_ctx_label">Step 7</div>
@@ -661,7 +661,7 @@ footer a:hover{color:var(--text)}
       <tr><td data-i18n="cmp_stream">Stream Integrity (SSE)</td><td class="check">&#10003;</td><td class="check">&#10003;</td><td class="cross">&#10005;</td></tr>
       <tr><td data-i18n="cmp_web3">Web3 Injection</td><td class="check">&#10003;</td><td class="cross">&#10005;</td><td class="cross">&#10005;</td></tr>
       <tr><td data-i18n="cmp_channel">Channel Fingerprint</td><td class="soon">Soon</td><td class="cross">&#10005;</td><td class="check">&#10003;</td></tr>
-      <tr><td data-i18n="cmp_local">Local Execution (Key stays local)</td><td class="check">&#10003;</td><td class="cross">&#10005;</td><td class="cross">&#10005;</td></tr>
+      <tr><td data-i18n="cmp_local">Local Execution (No extra checker server)</td><td class="check">&#10003;</td><td class="cross">&#10005;</td><td class="cross">&#10005;</td></tr>
       <tr><td data-i18n="cmp_oss">Fully Open Source</td><td class="check">&#10003;</td><td class="cross">Partial</td><td class="cross">&#10005;</td></tr>
       <tr><td data-i18n="cmp_leaderboard">Public Leaderboard</td><td class="cross">&#10005;</td><td class="check">&#10003;</td><td class="cross">&#10005;</td></tr>
       <tr><td data-i18n="cmp_report">Structured Audit Report</td><td class="check">&#10003;</td><td class="cross">&#10005;</td><td class="cross">&#10005;</td></tr>
@@ -1006,9 +1006,9 @@ let currentLang='en';
 const i18n={
   zh:{
     nav_demo:"Demo",nav_install:"快速开始",nav_faq:"FAQ",
-    hero_badge:"本地运行 — API Key 不经过任何第三方服务器",
+    hero_badge:"本地运行 — API Key 只发送到你指定的中转站 URL",
     hero_title:'<span class="gradient">AI API 中转站</span>安全审计',
-    hero_sub:"API Relay Audit 是一个本地运行的 AI API 中转站 / LLM proxy 安全审计工具。它检测 prompt injection、模型替换、工具调用改写、SSE 异常、错误响应泄漏和 Web3 钱包风险，同时让你的 API Key 保持在本地。",
+    hero_sub:"API Relay Audit 是一个本地运行的 AI API 中转站 / LLM proxy 安全审计工具。它检测 prompt injection、模型替换、工具调用改写、SSE 异常、错误响应泄漏和 Web3 钱包风险；你的 API Key 只会发送到你指定的中转站 URL。",
     what_title:"API Relay Audit 是什么？",
     what_desc:"API Relay Audit 是一个本地安全审计工具，用来检查第三方 AI API 中转站和 LLM proxy 是否注入 prompt、替换模型、改写工具输出、在错误响应中泄漏凭证，或产生流完整性异常。",
     use_title:"什么时候使用",
@@ -1032,7 +1032,7 @@ const i18n={
     step_infra_label:"Step 1-2",step_infra_title:"基础设施侦察",step_infra_desc:"DNS、CDN、SSL 证书、管理面板指纹、模型列表枚举 — 了解中转站背后的技术栈。",
     step_inject_label:"Step 3",step_inject_title:"Token 注入 (AC-1)",step_inject_desc:"对比实际 token 用量与预期值。隐藏 system prompt 注入会增加额外 token — 差值揭示注入量。",
     step_extract_label:"Step 4 & 6",step_extract_title:"Prompt 提取",step_extract_desc:"3 种攻击向量尝试提取隐藏 system prompt：直接复述、翻译法、JSON 接龙。加上越狱防护测试。",
-    step_id_label:"Step 5",step_id_title:"身份替换",step_id_desc:'24 个关键词检测 "Claude" 是否实际是 GPT、DeepSeek、GLM、Qwen 或其他模型。锚点短语确认真实身份。',
+    step_id_label:"Step 5",step_id_title:"身份替换",step_id_desc:'身份关键词集合检测 "Claude" 是否实际是 GPT、DeepSeek、GLM、Qwen 或其他模型。锚点短语确认真实身份。',
     step_ctx_label:"Step 7",step_ctx_title:"上下文截断",step_ctx_desc:"5 个 canary 标记 + 二分查找精确定位真实上下文窗口边界。你的 200K context 真的有 200K 吗？",
     step_tool_label:"Step 8 (AC-1.a)",step_tool_title:"工具调用改写",step_tool_desc:"检测中转站是否在返回路径上偷改包安装命令 — 代理层面的拼写投毒供应链攻击。",
     step_err_label:"Step 9 (AC-2)",step_err_title:"错误响应泄漏",step_err_desc:"7 种故意破坏的请求探测 API Key、环境变量、文件路径、LiteLLM 内部字段是否在错误响应中泄漏。",
@@ -1042,14 +1042,14 @@ const i18n={
     cmp_inject:"Token 注入",cmp_prompt:"Prompt 提取",cmp_identity:"身份替换",cmp_jailbreak:"越狱防护",
     cmp_context:"上下文截断",cmp_tool:"工具调用改写 (AC-1.a)",cmp_error:"错误响应泄漏 (AC-2)",
     cmp_stream:"流完整性 (SSE)",cmp_web3:"Web3 注入",cmp_channel:"通道指纹",
-    cmp_local:"本地运行 (Key 不外传)",cmp_oss:"完全开源",cmp_leaderboard:"公开排行榜",cmp_report:"结构化审计报告",
+    cmp_local:"本地运行 (无额外检测服务器)",cmp_oss:"完全开源",cmp_leaderboard:"公开排行榜",cmp_report:"结构化审计报告",
     install_title:"开始审计",install_sub:"填写你的中转站信息 — 我们生成命令，你在本地运行。",
     flow_title:"你的 Key 如何流转 — 关键区别",
     flow_you:"你",flow_local:"你的终端",flow_relay:"你的中转站",
-    flow_good:"api-relay-audit: Key 始终在你的机器上",
+    flow_good:"api-relay-audit: 没有额外检测服务器接触你的 Key",
     flow_bad:"网页工具: Key 先经过第三方服务器",
     form_url_label:"API 接口地址",form_url_hint:"你要审计的中转站 base URL",
-    form_key_label:"API Key",form_key_hint:"仅在浏览器内使用，生成下方命令 — 不会发送到任何地方。",
+    form_key_label:"API Key",form_key_hint:"仅在浏览器内用于生成下方命令；运行命令时只会发送到你指定的中转站 URL。",
     form_model_label:"模型",form_generate:"生成审计命令",
     cmd_step1:"打开终端（macOS: Terminal.app / Windows: PowerShell）",
     cmd_step2:"粘贴以下命令并回车 — 约 2 分钟完成：",
@@ -1062,8 +1062,8 @@ const i18n={
     agent_step2_title:"一句话触发",agent_step2_desc:"打开 Claude Code，说：",
     agent_trigger:'\u201c帮我审计这个中转站：https://your-relay.com/v1，key 是 sk-xxx\u201d',
     agent_step3_title:"Agent 全自动执行",agent_step3_desc:"Claude Code 自动下载脚本、运行 14 步检测、呈现结果 — 你只需要看报告。",
-    agent_security:"同样的安全模型 — agent 在你的本地机器上运行，Key 不经过任何第三方服务器。",
-    term_downloading:"audit.py 已下载 (2,847 行, 零依赖)",
+    agent_security:"同样的安全模型 — agent 在你的本地机器上运行，Key 只会发送到你指定的中转站 URL。",
+    term_downloading:"audit.py 已下载 (零 Python 包依赖)",
     term_step1:"[Step 1/14] 基础设施侦察...",
     term_step1_out:"  CDN: Cloudflare | 系统: New API | SSL: Let's Encrypt",
     term_step3:"[Step 3/14] Token 注入检测...",
@@ -1076,7 +1076,7 @@ const i18n={
     term_open_hint:"用任意文本编辑器打开 .md 文件查看完整报告",
     copy_btn:"复制",copied_btn:"已复制!",
     cost_note:"每次审计消耗约 $0.2-0.5 API 费用（由你的 provider 计费）",
-    install_security:"你的 API Key 仅发送到你指定的中转站地址。无遥测、无第三方服务器。",
+    install_security:"你的 API Key 仅发送到你指定的中转站地址；不会发送到 API Relay Audit 或额外网页检测服务。",
     faq_title:"常见问题",
     faq_q1:"什么是 API 中转站或 LLM proxy？",
     faq_a1:'API 中转站或 LLM proxy 是介于你和 Anthropic、OpenAI 等 AI provider 之间的第三方服务。它会转发你的请求，但也可能注入隐藏指令、替换模型、截断上下文、改写工具输出，或在错误响应中泄漏凭证。',
@@ -1098,9 +1098,9 @@ const i18n={
   },
   en:{
     nav_demo:"Demo",nav_install:"Quick Start",nav_faq:"FAQ",
-    hero_badge:"Local execution — your API Key is never sent to a third-party server",
+    hero_badge:"Local execution — your API key is sent only to the relay URL you choose",
     hero_title:'<span class="gradient">AI API Relay</span> Security Audit',
-    hero_sub:"API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks while keeping your API key local.",
+    hero_sub:"API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Your API key is sent only to the relay URL you choose.",
     what_title:"What is API Relay Audit?",
     what_desc:"API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It checks whether a third-party relay injects prompts, substitutes models, rewrites tool output, leaks credentials in error responses, or produces stream integrity anomalies.",
     use_title:"When to use it",
@@ -1123,7 +1123,7 @@ const i18n={
     step_infra_label:"Step 1-2",step_infra_title:"Infrastructure Recon",step_infra_desc:"DNS, CDN, SSL certificate, management panel fingerprint, model list enumeration — understand what's behind the relay.",
     step_inject_label:"Step 3",step_inject_title:"Token Injection (AC-1)",step_inject_desc:"Compares actual token usage against expected values. Hidden system prompt injection adds extra tokens — the delta reveals it.",
     step_extract_label:"Step 4 & 6",step_extract_title:"Prompt Extraction",step_extract_desc:"3 attack vectors attempt to extract hidden system prompts: verbatim recall, translation trick, JSON continuation. Plus jailbreak resistance tests.",
-    step_id_label:"Step 5",step_id_title:"Identity Substitution",step_id_desc:'24 keywords detect if "Claude" is actually GPT, DeepSeek, GLM, Qwen, or other models in disguise. Anchor phrases confirm true identity.',
+    step_id_label:"Step 5",step_id_title:"Identity Substitution",step_id_desc:'An identity keyword set detects if "Claude" is actually GPT, DeepSeek, GLM, Qwen, or other models in disguise. Anchor phrases confirm true identity.',
     step_ctx_label:"Step 7",step_ctx_title:"Context Truncation",step_ctx_desc:"5 canary markers + binary search pinpoint the real context window boundary. Is your 200K context really 200K?",
     step_tool_label:"Step 8 (AC-1.a)",step_tool_title:"Tool-Call Rewriting",step_tool_desc:"Checks if the relay silently modifies package install commands in responses — typosquatting supply-chain attacks at the proxy layer.",
     step_err_label:"Step 9 (AC-2)",step_err_title:"Error Response Leakage",step_err_desc:"7 deliberately broken requests probe for API key, env vars, file paths, and LiteLLM internals leaking in error responses.",
@@ -1133,14 +1133,14 @@ const i18n={
     cmp_inject:"Token Injection",cmp_prompt:"Prompt Extraction",cmp_identity:"Identity Substitution",cmp_jailbreak:"Jailbreak Resistance",
     cmp_context:"Context Truncation",cmp_tool:"Tool-Call Rewriting (AC-1.a)",cmp_error:"Error Response Leakage (AC-2)",
     cmp_stream:"Stream Integrity (SSE)",cmp_web3:"Web3 Injection",cmp_channel:"Channel Fingerprint",
-    cmp_local:"Local Execution (Key stays local)",cmp_oss:"Fully Open Source",cmp_leaderboard:"Public Leaderboard",cmp_report:"Structured Audit Report",
+    cmp_local:"Local Execution (No extra checker server)",cmp_oss:"Fully Open Source",cmp_leaderboard:"Public Leaderboard",cmp_report:"Structured Audit Report",
     install_title:"Start Your Audit",install_sub:"Fill in your relay info — we generate the command, you run it locally.",
     flow_title:"How your Key flows — the critical difference",
     flow_you:"You",flow_local:"Your Terminal",flow_relay:"Your Relay",
-    flow_good:"api-relay-audit: Key stays on YOUR machine",
+    flow_good:"api-relay-audit: no extra checker server sees your key",
     flow_bad:"Web tools: Key goes to a 3rd-party server first",
     form_url_label:"API Endpoint URL",form_url_hint:"The base URL of the relay you want to audit",
-    form_key_label:"API Key",form_key_hint:"Stays in your browser. Only used to generate the CLI command below — never sent anywhere.",
+    form_key_label:"API Key",form_key_hint:"Stays in your browser to generate the command. When you run it, the key is sent only to your chosen relay URL.",
     form_model_label:"Model",form_generate:"Generate Audit Command",
     cmd_step1:"Open your terminal (macOS: Terminal.app / Windows: PowerShell)",
     cmd_step2:"Paste this command and press Enter — takes ~2 minutes:",
@@ -1153,8 +1153,8 @@ const i18n={
     agent_step2_title:"Trigger with one sentence",agent_step2_desc:"Open Claude Code and say:",
     agent_trigger:'"Audit this relay: https://your-relay.com/v1, my key is sk-xxx"',
     agent_step3_title:"Agent does everything",agent_step3_desc:"Claude Code automatically downloads the script, runs all 14 steps, and presents the findings — you just read the result.",
-    agent_security:"Same security model — the agent runs locally on your machine, Key never touches a third-party server.",
-    term_downloading:"audit.py downloaded (2,847 lines, zero dependencies)",
+    agent_security:"Same security model — the agent runs locally on your machine, and the key is sent only to your chosen relay URL.",
+    term_downloading:"audit.py downloaded (zero Python package dependencies)",
     term_step1:"[Step 1/14] Infrastructure recon...",
     term_step1_out:"  CDN: Cloudflare | System: New API | SSL: Let's Encrypt",
     term_step3:"[Step 3/14] Token injection detection...",
@@ -1167,7 +1167,7 @@ const i18n={
     term_open_hint:"Open the .md file with any text editor to view the full report",
     copy_btn:"Copy",copied_btn:"Copied!",
     cost_note:"Each audit costs ~$0.2-0.5 in API usage (billed by your provider)",
-    install_security:"Your API Key is only sent to the relay URL you specify. No telemetry, no third-party servers.",
+    install_security:"Your API key is only sent to the relay URL you specify; it is not sent to API Relay Audit or an extra web checker.",
     faq_title:"FAQ",
     faq_q1:"What is an API relay or LLM proxy?",
     faq_a1:'An API relay or LLM proxy is a third-party service between you and an AI provider such as Anthropic or OpenAI. It forwards your requests upstream, but it can also inject hidden instructions, swap models, truncate context, rewrite tool output, or leak credentials in error responses.',

--- a/web/index.html
+++ b/web/index.html
@@ -6,6 +6,9 @@
 <title>API Relay Audit - AI API Relay Security Audit for LLM Proxies</title>
 <meta name="description" content="Audit AI API relays and LLM proxies for prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Runs locally; your API key stays local.">
 <link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/">
+<link rel="alternate" hreflang="en" href="https://toby-bridges.github.io/api-relay-audit/">
+<link rel="alternate" hreflang="zh-CN" href="https://toby-bridges.github.io/api-relay-audit/zh/">
+<link rel="alternate" hreflang="x-default" href="https://toby-bridges.github.io/api-relay-audit/">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="API Relay Audit">
 <meta property="og:title" content="API Relay Audit - AI API Relay Security Audit">
@@ -280,6 +283,15 @@ section:first-of-type{padding-top:100px}
 .faq-a a{color:var(--accent2);text-decoration:none}
 .faq-a a:hover{text-decoration:underline}
 
+/* ── Guides ── */
+.guides-section h2{font-size:1.4rem;font-weight:700;margin-bottom:8px;text-align:center}
+.guides-sub{text-align:center;color:var(--text2);font-size:.9rem;margin-bottom:28px}
+.guide-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px}
+.guide-card{background:var(--card);border:1px solid var(--border);border-radius:var(--radius);padding:18px 20px;text-decoration:none;display:block;transition:border-color .2s,background .2s}
+.guide-card:hover{border-color:var(--accent);background:var(--card-hover);text-decoration:none}
+.guide-card h3{font-size:.95rem;margin-bottom:8px;color:var(--text)}
+.guide-card p{font-size:.8rem;color:var(--text2);line-height:1.55}
+
 /* ── Footer ── */
 footer{text-align:center;padding:40px 24px;border-top:1px solid var(--border);color:var(--text3);font-size:.78rem}
 footer a{color:var(--text2);text-decoration:none}
@@ -348,11 +360,12 @@ footer a:hover{color:var(--text)}
     <div class="nav-links">
       <a href="#demo" class="hide-mobile" data-i18n="nav_demo">Demo</a>
       <a href="#install" class="hide-mobile" data-i18n="nav_install">Quick Start</a>
+      <a href="#guides" class="hide-mobile">Guides</a>
       <a href="#faq" class="hide-mobile" data-i18n="nav_faq">FAQ</a>
       <a href="https://github.com/toby-bridges/api-relay-audit" target="_blank" rel="noopener noreferrer">GitHub</a>
       <a href="https://x.com/li9292" target="_blank" rel="noopener noreferrer">X</a>
       <div class="lang-switch">
-        <button class="lang-btn" onclick="setLang('zh')">中</button>
+        <button class="lang-btn" onclick="window.location.href='zh/'">中</button>
         <button class="lang-btn active" onclick="setLang('en')">EN</button>
       </div>
     </div>
@@ -657,6 +670,34 @@ footer a:hover{color:var(--text)}
   </div>
 </section>
 
+<!-- ── Guides ── -->
+<section class="guides-section container" id="guides">
+  <h2>Guides for AI API Relay Security</h2>
+  <p class="guides-sub">Short, citation-friendly pages for GitHub, Google, and AI summaries.</p>
+  <div class="guide-grid">
+    <a class="guide-card" href="guides/what-is-ai-api-relay-proxy.html">
+      <h3>What is an AI API relay or LLM proxy?</h3>
+      <p>Define the trust boundary and what an intermediary can change.</p>
+    </a>
+    <a class="guide-card" href="guides/audit-claude-api-relay-safely.html">
+      <h3>How to audit a Claude API relay safely</h3>
+      <p>Run a local audit without adding another API-key trust hop.</p>
+    </a>
+    <a class="guide-card" href="guides/compare-api-relay-audit-hvoy-cctest.html">
+      <h3>api-relay-audit vs hvoy.ai vs cctest.ai</h3>
+      <p>Compare local audits, relay lookup, and web-based checks.</p>
+    </a>
+    <a class="guide-card" href="guides/detect-prompt-injection-llm-api-proxies.html">
+      <h3>Detecting prompt injection in LLM API proxies</h3>
+      <p>Understand token deltas, extraction probes, and identity signals.</p>
+    </a>
+    <a class="guide-card" href="guides/web3-wallet-prompt-injection-ai-agents.html">
+      <h3>Web3 wallet prompt injection through AI agents</h3>
+      <p>Check transfer guidance, signed-transaction refusal, and private-key refusal.</p>
+    </a>
+  </div>
+</section>
+
 <!-- ── FAQ ── -->
 <section class="faq-section container" id="faq">
   <h2 data-i18n="faq_title">FAQ</h2>
@@ -698,6 +739,8 @@ footer a:hover{color:var(--text)}
 <footer>
   <p>
     <a href="https://github.com/toby-bridges/api-relay-audit" target="_blank" rel="noopener noreferrer">GitHub</a> &nbsp;·&nbsp;
+    <a href="zh/">中文</a> &nbsp;·&nbsp;
+    <a href="sitemap.xml">Sitemap</a> &nbsp;·&nbsp;
     <a href="https://x.com/li9292" target="_blank" rel="noopener noreferrer">X @li9292</a> &nbsp;·&nbsp;
     AGPL-3.0-only License &nbsp;·&nbsp;
     <span data-i18n="footer_threat">Threat model: </span><a href="https://arxiv.org/abs/2604.08407" target="_blank" rel="noopener noreferrer">arXiv:2604.08407</a>

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://toby-bridges.github.io/api-relay-audit/sitemap.xml

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://toby-bridges.github.io/api-relay-audit/</loc>
+    <lastmod>2026-06-01</lastmod>
+  </url>
+  <url>
+    <loc>https://toby-bridges.github.io/api-relay-audit/zh/</loc>
+    <lastmod>2026-06-01</lastmod>
+  </url>
+  <url>
+    <loc>https://toby-bridges.github.io/api-relay-audit/guides/what-is-ai-api-relay-proxy.html</loc>
+    <lastmod>2026-06-01</lastmod>
+  </url>
+  <url>
+    <loc>https://toby-bridges.github.io/api-relay-audit/guides/audit-claude-api-relay-safely.html</loc>
+    <lastmod>2026-06-01</lastmod>
+  </url>
+  <url>
+    <loc>https://toby-bridges.github.io/api-relay-audit/guides/compare-api-relay-audit-hvoy-cctest.html</loc>
+    <lastmod>2026-06-01</lastmod>
+  </url>
+  <url>
+    <loc>https://toby-bridges.github.io/api-relay-audit/guides/detect-prompt-injection-llm-api-proxies.html</loc>
+    <lastmod>2026-06-01</lastmod>
+  </url>
+  <url>
+    <loc>https://toby-bridges.github.io/api-relay-audit/guides/web3-wallet-prompt-injection-ai-agents.html</loc>
+    <lastmod>2026-06-01</lastmod>
+  </url>
+</urlset>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>API Relay Audit - AI API 中转站安全审计</title>
+<meta name="description" content="本地审计 AI API 中转站和 LLM proxy，检测 prompt injection、模型替换、工具调用改写、SSE 异常、错误泄漏和 Web3 钱包风险。API Key 留在本地。">
+<link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/zh/">
+<link rel="alternate" hreflang="en" href="https://toby-bridges.github.io/api-relay-audit/">
+<link rel="alternate" hreflang="zh-CN" href="https://toby-bridges.github.io/api-relay-audit/zh/">
+<link rel="alternate" hreflang="x-default" href="https://toby-bridges.github.io/api-relay-audit/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="API Relay Audit - AI API 中转站安全审计">
+<meta property="og:description" content="本地审计 AI API 中转站和 LLM proxy。检测 prompt injection、模型替换、工具调用改写、SSE 异常和 Web3 钱包风险。">
+<meta property="og:url" content="https://toby-bridges.github.io/api-relay-audit/zh/">
+<meta property="og:image" content="https://toby-bridges.github.io/api-relay-audit/assets/social-preview.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="stylesheet" href="../assets/content.css">
+</head>
+<body>
+<header>
+  <div class="wrap nav">
+    <a class="brand" href="../">API Relay Audit</a>
+    <div class="links">
+      <a href="../">English</a>
+      <a href="../guides/what-is-ai-api-relay-proxy.html">Guides</a>
+      <a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a>
+    </div>
+  </div>
+</header>
+<main class="wrap">
+  <div class="eyebrow">Local AI API Relay Security Audit</div>
+  <h1>AI API 中转站安全审计，本地运行，Key 留在本地</h1>
+  <p class="lead">API Relay Audit 是一个本地运行的 AI API 中转站 / LLM proxy 安全审计工具。它检测 prompt injection、模型替换、工具调用改写、SSE 流异常、错误响应泄漏，以及 Web3 钱包相关风险。</p>
+  <div class="cta">
+    <a class="button primary" href="../#install">生成审计命令</a>
+    <a class="button" href="https://github.com/toby-bridges/api-relay-audit">查看 GitHub</a>
+  </div>
+
+  <div class="grid">
+    <section class="card">
+      <h2>什么时候用</h2>
+      <p>当你准备把第三方 AI API 中转站、Claude/OpenAI 兼容代理、coding agent 自动化或钱包相关流量放进生产环境前，用它生成一份可复查的 Markdown 报告。</p>
+    </section>
+    <section class="card">
+      <h2>检测什么</h2>
+      <p>覆盖 token injection、prompt extraction、identity substitution、context truncation、tool-call rewriting、error leakage、SSE stream integrity 和 Web3 signature isolation probes。</p>
+    </section>
+    <section class="card">
+      <h2>不声称什么</h2>
+      <p>它不为任何中转站颁发安全认证，也不替代人工安全审查。`inconclusive` 不是 `clean`，被拦截或无法判断的探针会保留在报告里。</p>
+    </section>
+  </div>
+
+  <h2>快速开始</h2>
+  <pre class="code"><code>curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py
+python audit.py --key &lt;YOUR_KEY&gt; --url &lt;BASE_URL&gt; --output report.md
+
+# Web3 / 钱包用户
+python audit.py --key &lt;YOUR_KEY&gt; --url &lt;BASE_URL&gt; --profile web3 --output report.md</code></pre>
+
+  <h2>长尾阅读</h2>
+  <ul>
+    <li><a href="../guides/what-is-ai-api-relay-proxy.html">What is an AI API relay or LLM proxy?</a></li>
+    <li><a href="../guides/audit-claude-api-relay-safely.html">How to audit a Claude API relay safely</a></li>
+    <li><a href="../guides/detect-prompt-injection-llm-api-proxies.html">Detecting prompt injection in LLM API proxies</a></li>
+    <li><a href="../guides/web3-wallet-prompt-injection-ai-agents.html">Web3 wallet prompt injection through AI agents</a></li>
+  </ul>
+</main>
+<footer>
+  <div class="wrap">AGPL-3.0-only. Threat model: <a href="https://arxiv.org/abs/2604.08407">arXiv:2604.08407</a>.</div>
+</footer>
+</body>
+</html>

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>API Relay Audit - AI API 中转站安全审计</title>
-<meta name="description" content="本地审计 AI API 中转站和 LLM proxy，检测 prompt injection、模型替换、工具调用改写、SSE 异常、错误泄漏和 Web3 钱包风险。API Key 留在本地。">
+<meta name="description" content="本地审计 AI API 中转站和 LLM proxy，检测 prompt injection、模型替换、工具调用改写、SSE 异常、错误泄漏和 Web3 钱包风险。API Key 只发送到你指定的中转站 URL。">
 <link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/zh/">
 <link rel="alternate" hreflang="en" href="https://toby-bridges.github.io/api-relay-audit/">
 <link rel="alternate" hreflang="zh-CN" href="https://toby-bridges.github.io/api-relay-audit/zh/">
@@ -30,7 +30,7 @@
 </header>
 <main class="wrap">
   <div class="eyebrow">Local AI API Relay Security Audit</div>
-  <h1>AI API 中转站安全审计，本地运行，Key 留在本地</h1>
+  <h1>AI API 中转站安全审计，本地运行，只连接你指定的中转站</h1>
   <p class="lead">API Relay Audit 是一个本地运行的 AI API 中转站 / LLM proxy 安全审计工具。它检测 prompt injection、模型替换、工具调用改写、SSE 流异常、错误响应泄漏，以及 Web3 钱包相关风险。</p>
   <div class="cta">
     <a class="button primary" href="../#install">生成审计命令</a>
@@ -63,6 +63,7 @@ python audit.py --key &lt;YOUR_KEY&gt; --url &lt;BASE_URL&gt; --profile web3 --o
   <ul>
     <li><a href="../guides/what-is-ai-api-relay-proxy.html">What is an AI API relay or LLM proxy?</a></li>
     <li><a href="../guides/audit-claude-api-relay-safely.html">How to audit a Claude API relay safely</a></li>
+    <li><a href="../guides/compare-api-relay-audit-hvoy-cctest.html">api-relay-audit vs hvoy.ai vs cctest.ai</a></li>
     <li><a href="../guides/detect-prompt-injection-llm-api-proxies.html">Detecting prompt injection in LLM API proxies</a></li>
     <li><a href="../guides/web3-wallet-prompt-injection-ai-agents.html">Web3 wallet prompt injection through AI agents</a></li>
   </ul>


### PR DESCRIPTION
## Summary
- Add community health files: SECURITY.md, CONTRIBUTING.md, and CODE_OF_CONDUCT.md.
- Add a dedicated Chinese Pages URL with canonical and hreflang metadata.
- Add sitemap.xml, robots.txt, and long-tail guide pages for AI API relay / LLM proxy search intent.
- Wire README and homepage links to the new guide and policy surfaces.
- Defer OpenClaw / Hermes / ClawHub skill distribution to a later PR so this one stays focused on community health and Pages content.

## Validation
- git diff --check
- python3 scripts/collect-metrics.py --check
- python3 scripts/build-standalone.py --check
- python3 -m pytest tests/test_dual_distribution_parity.py -q
- python3 -m pytest tests/ -q
- HTML parse check for all Pages HTML files
- sitemap.xml parse check
- local link check for relative href/src targets
- final diff check confirms no new OpenClaw/Hermes/ClawHub skill-distribution content

## Release note
This PR prepares the repo for v2.3 community health and GitHub Pages discoverability. Skill distribution and publishing validation are intentionally deferred to a separate future PR.
