### PR TITLE
[codex] add citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,56 @@
+cff-version: 1.2.0
+message: "If you use API Relay Audit in research, security reports, or public relay evaluations, please cite the software using these metadata. The references below record academic work that informed the audit model; cite those papers directly when you rely on their methods or findings."
+type: software
+title: "API Relay Audit"
+version: "2.3"
+authors:
+  - family-names: "Bridges"
+    given-names: "Toby"
+abstract: "API Relay Audit is a local security audit tool for third-party AI API relays and LLM proxies. It detects prompt injection, model substitution, tool-call rewriting, error leakage, SSE stream anomalies, Web3 wallet risks, infrastructure fingerprints, latency variance, and upstream channel mismatches while sending the API key only to the relay URL chosen by the user."
+license: "AGPL-3.0-only"
+repository-code: "https://github.com/toby-bridges/api-relay-audit"
+url: "https://toby-bridges.github.io/api-relay-audit/"
+keywords:
+  - "AI API relay"
+  - "LLM proxy"
+  - "prompt injection"
+  - "model substitution"
+  - "tool-call rewriting"
+  - "SSE stream integrity"
+  - "Web3 wallet security"
+  - "security audit"
+references:
+  - type: article
+    title: "Your Agent Is Mine: Measuring Malicious Intermediary Attacks on the LLM Supply Chain"
+    authors:
+      - family-names: "Liu"
+        given-names: "Hanzhi"
+      - family-names: "Shou"
+        given-names: "Chaofan"
+      - family-names: "Wen"
+        given-names: "Hongbo"
+      - family-names: "Chen"
+        given-names: "Yanju"
+      - family-names: "Fang"
+        given-names: "Ryan Jingyang"
+      - family-names: "Feng"
+        given-names: "Yu"
+    year: 2026
+    url: "https://arxiv.org/abs/2604.08407"
+  - type: article
+    title: "Real Money, Fake Models: Deceptive Model Claims in Shadow APIs"
+    authors:
+      - family-names: "Zhang"
+        given-names: "Yage"
+      - family-names: "Jiang"
+        given-names: "Yukun"
+      - family-names: "Chen"
+        given-names: "Zeyuan"
+      - family-names: "Backes"
+        given-names: "Michael"
+      - family-names: "Shen"
+        given-names: "Xinyue"
+      - family-names: "Zhang"
+        given-names: "Yang"
+    year: 2026
+    url: "https://arxiv.org/abs/2603.01919"

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ AGPL-3.0-only. See [LICENSE](./LICENSE).
 
 This keeps modified network-service deployments accountable to the same public source-availability standard as the relay ecosystem evidence we audit.
 
+## Citation
+
+If you use API Relay Audit in research, security reports, or public relay evaluations, please cite the software with [CITATION.cff](./CITATION.cff). The citation file also records the two academic papers that inform the audit model: Liu et al., *Your Agent Is Mine* (arXiv:2604.08407) and Zhang et al., *Real Money, Fake Models* (arXiv:2603.01919).
+
 ## How to Contribute
 
 Good first contributions are small, reproducible, and evidence-focused: documentation examples, deterministic detector tests, or clearer wording around `clean`, `anomaly`, and `inconclusive` results.


### PR DESCRIPTION
## Summary\n- Add root CITATION.cff so GitHub can show a Cite this repository entry for API Relay Audit.\n- Keep API Relay Audit as the software citation target.\n- Record the two academic papers that inform the audit model in the CFF references list: Liu et al., Your Agent Is Mine, and Zhang et al., Real Money, Fake Models.\n- Add a short README Citation section.\n\n## Design note\nThis intentionally uses CFF references rather than preferred-citation. The preferred citation should remain the software itself; the papers are upstream methodology references and should be cited directly when their methods or findings are used.\n\n## Validation\n- ruby YAML parse check for CITATION.cff\n- cffconvert --validate -i CITATION.cff in a temporary venv\n- python3 scripts/collect-metrics.py --check\n- git diff --check