### PR TITLE
[codex] thicken guide pages for search summaries

### DIFF
--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,8 +16,8 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **694** | `pytest --collect-only` |
-| 测试数 (static) | 675 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **696** | `pytest --collect-only` |
+| 测试数 (static) | 677 | grep `def test_*` in tests/ |
 | CLI flag 数 | 20 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-01 | `ROADMAP.md` 头部 |
@@ -25,13 +25,14 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 694] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `484cc52` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `fa12ae8` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-02 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
+- ⚠️ ROADMAP 最新记录 694 个测试，但当前 pytest 是 696。要么 ROADMAP 漏更新，要么有未记录的新测试。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/tests/test_static_site.py
+++ b/tests/test_static_site.py
@@ -1,6 +1,7 @@
 """Regression checks for the GitHub Pages static site."""
 
 import json
+import re
 from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import unquote, urlparse
@@ -59,6 +60,29 @@ def _html_pages():
     return sorted(WEB_ROOT.glob("**/*.html"))
 
 
+def _guide_pages():
+    return sorted((WEB_ROOT / "guides").glob("*.html"))
+
+
+def _json_ld_graph(parser):
+    nodes = []
+    for item in parser.json_ld:
+        data = json.loads(item)
+        if isinstance(data, dict) and isinstance(data.get("@graph"), list):
+            nodes.extend(data["@graph"])
+        else:
+            nodes.append(data)
+    return nodes
+
+
+def _visible_word_count(path):
+    text = path.read_text(encoding="utf-8")
+    text = re.sub(r"<script\b.*?</script>", " ", text, flags=re.S)
+    text = re.sub(r"<style\b.*?</style>", " ", text, flags=re.S)
+    text = re.sub(r"<[^>]+>", " ", text)
+    return len(re.findall(r"\b[\w'-]+\b", text))
+
+
 def _local_path_for_url(url):
     parsed = urlparse(url)
     assert parsed.scheme == "https"
@@ -89,6 +113,26 @@ def test_all_pages_parse_and_json_ld_is_valid():
         parser = _parse_html(path)
         for item in parser.json_ld:
             json.loads(item)
+
+
+def test_guide_pages_have_breadcrumbs_and_techarticle_json_ld():
+    for path in _guide_pages():
+        html = path.read_text(encoding="utf-8")
+        parser = _parse_html(path)
+        nodes = _json_ld_graph(parser)
+        types = {node.get("@type") for node in nodes if isinstance(node, dict)}
+        assert 'class="breadcrumb"' in html, f"{path} is missing visible breadcrumb"
+        assert "BreadcrumbList" in types, f"{path} is missing BreadcrumbList JSON-LD"
+        assert "TechArticle" in types, f"{path} is missing TechArticle JSON-LD"
+        article = next(node for node in nodes if isinstance(node, dict) and node.get("@type") == "TechArticle")
+        assert article.get("headline"), f"{path} TechArticle missing headline"
+        assert article.get("dateModified"), f"{path} TechArticle missing dateModified"
+        assert article.get("author", {}).get("name") == "Toby Bridges"
+
+
+def test_guide_pages_are_substantial_enough_for_search_and_ai_summaries():
+    for path in _guide_pages():
+        assert _visible_word_count(path) >= 650, f"{path} is too thin"
 
 
 def test_relative_links_and_fragments_resolve():

--- a/web/assets/content.css
+++ b/web/assets/content.css
@@ -23,10 +23,17 @@ p{color:var(--muted);margin:0 0 16px}
 ul,ol{color:var(--muted);padding-left:22px}
 li{margin:7px 0}
 .lead{font-size:1.08rem;max-width:760px}
+.breadcrumb{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin:-24px 0 28px;color:var(--soft);font-size:.84rem}
+.breadcrumb a{color:var(--muted)}
+.breadcrumb span{color:var(--soft)}
 .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px;margin:24px 0}
 .card{background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:18px}
 .card h2,.card h3{margin-top:0}
 .note{border-left:3px solid var(--orange);background:rgba(254,153,0,.08);padding:14px 16px;margin:22px 0;color:var(--muted)}
+.report-example{background:var(--panel2);border:1px solid var(--border);border-radius:8px;padding:18px;margin:22px 0}
+.report-example strong{color:var(--text)}
+.reference-list{font-size:.95rem}
+.mini-faq{border-top:1px solid var(--border);margin-top:24px;padding-top:8px}
 .code{background:#0d1117;border:1px solid var(--border);border-radius:8px;padding:14px 16px;overflow:auto;color:#bfdbfe}
 code{font-family:"SF Mono",Monaco,Consolas,monospace}
 table{width:100%;border-collapse:collapse;background:var(--panel);border:1px solid var(--border);border-radius:8px;overflow:hidden;display:block}

--- a/web/guides/audit-claude-api-relay-safely.html
+++ b/web/guides/audit-claude-api-relay-safely.html
@@ -7,20 +7,51 @@
 <meta name="description" content="Audit a Claude-compatible API relay locally for prompt injection, model substitution, context truncation, tool rewriting, error leakage, and SSE anomalies.">
 <link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/guides/audit-claude-api-relay-safely.html">
 <link rel="stylesheet" href="../assets/content.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "API Relay Audit", "item": "https://toby-bridges.github.io/api-relay-audit/"},
+        {"@type": "ListItem", "position": 2, "name": "Guides", "item": "https://toby-bridges.github.io/api-relay-audit/#guides"},
+        {"@type": "ListItem", "position": 3, "name": "How to Audit a Claude API Relay Safely", "item": "https://toby-bridges.github.io/api-relay-audit/guides/audit-claude-api-relay-safely.html"}
+      ]
+    },
+    {
+      "@type": "TechArticle",
+      "@id": "https://toby-bridges.github.io/api-relay-audit/guides/audit-claude-api-relay-safely.html#article",
+      "headline": "How to Audit a Claude API Relay Safely",
+      "description": "A local audit workflow for Claude-compatible relays that checks prompt injection, model identity, SSE integrity, tool rewriting, and error leakage without adding another web checker to the API-key path.",
+      "datePublished": "2026-06-01",
+      "dateModified": "2026-06-02",
+      "author": {"@type": "Person", "name": "Toby Bridges", "url": "https://github.com/toby-bridges"},
+      "publisher": {"@type": "Organization", "name": "API Relay Audit", "url": "https://github.com/toby-bridges/api-relay-audit"},
+      "mainEntityOfPage": "https://toby-bridges.github.io/api-relay-audit/guides/audit-claude-api-relay-safely.html",
+      "about": ["Claude API relay", "Anthropic-compatible proxy", "SSE stream integrity", "model substitution", "prompt injection"]
+    }
+  ]
+}
+</script>
 </head>
 <body>
-<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">中文</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
+<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">Chinese</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
 <main class="wrap">
+  <nav class="breadcrumb" aria-label="Breadcrumb"><a href="../">Home</a><span>/</span><a href="../#guides">Guides</a><span>/</span><span>Claude relay audit</span></nav>
   <div class="eyebrow">Guide</div>
   <h1>How to audit a Claude API relay safely</h1>
-  <p class="lead">To audit a Claude-compatible relay safely, run the audit locally, point it only at the relay URL you intend to test, and review each finding as evidence rather than as a safety certificate.</p>
+  <p class="lead">To audit a Claude-compatible API relay safely, run the audit locally, point it only at the relay URL you intend to test, and review each finding as evidence rather than as a safety certificate. The goal is not to prove a relay is good forever. The goal is to collect reproducible signals before a relay handles production, coding-agent, or wallet-related traffic.</p>
+
+  <section class="note">Short answer: use a scoped key, run `audit.py` locally, save the Markdown report, and treat red, yellow, and inconclusive findings as review inputs.</section>
 
   <h2>Safe audit checklist</h2>
   <ol>
-    <li>Use a scoped API key with limited budget when possible.</li>
-    <li>Run the standalone `audit.py` locally so the key does not pass through a separate web checker.</li>
-    <li>Save the Markdown report and review red, yellow, and inconclusive items.</li>
-    <li>Do not publish real relay credentials, private domains, wallet addresses tied to private use, or raw traffic captures.</li>
+    <li>Use a temporary or low-budget key when possible. Relay audits intentionally send unusual prompts and malformed requests.</li>
+    <li>Confirm the base URL. A typo in the URL changes the target of the whole audit.</li>
+    <li>Run the standalone script locally so the key is not passed through a separate web checker.</li>
+    <li>Use the model name you actually plan to rely on. Model substitution and stream identity checks are only meaningful against the claimed route.</li>
+    <li>Save the Markdown report. Do not publish raw credentials, private relay domains, wallet material, or unredacted traffic captures.</li>
   </ol>
 
   <h2>Command</h2>
@@ -33,15 +64,40 @@ python audit.py \
 
   <h2>Claude-specific checks</h2>
   <table>
-    <tr><th>Area</th><th>What API Relay Audit checks</th></tr>
-    <tr><td>Identity</td><td>Non-Claude identity leaks, model substitution wording, and stream model identity where available.</td></tr>
-    <tr><td>Streaming</td><td>Anthropic-style SSE event types, usage monotonicity, thinking signature presence, and stream model consistency.</td></tr>
-    <tr><td>Prompt path</td><td>Token injection, prompt extraction, instruction conflict, and jailbreak behavior.</td></tr>
-    <tr><td>Tool path</td><td>Text-echo package command integrity for tool-call rewriting risks.</td></tr>
+    <tr><th>Area</th><th>What API Relay Audit checks</th><th>Why it matters</th></tr>
+    <tr><td>Identity</td><td>Non-Claude identity leaks, anchor phrases, and model identity signals where available.</td><td>A relay may claim one model while routing to another or injecting a different assistant identity.</td></tr>
+    <tr><td>Streaming</td><td>Anthropic-style SSE event whitelist, usage monotonicity, thinking signature presence, and stream model consistency.</td><td>Stream-level anomalies can reveal unsupported event types, metadata rewriting, or model mismatch.</td></tr>
+    <tr><td>Prompt path</td><td>Token injection, prompt extraction, instruction conflict, and jailbreak resistance.</td><td>Hidden relay instructions can override user intent or make the user pay for injected context.</td></tr>
+    <tr><td>Tool path</td><td>Text-echo package command integrity for tool-call rewriting risks.</td><td>Coding agents often copy package commands. A relay that changes them can create supply-chain exposure.</td></tr>
+    <tr><td>Error path</td><td>Deterministic malformed requests and leak scanning.</td><td>Some proxy stacks leak upstream hosts, internal fields, or credential-like strings only on errors.</td></tr>
   </table>
 
-  <h2>Interpreting inconclusive results</h2>
-  <p>Inconclusive means the probe could not establish a clean or anomalous result. It may happen because the relay blocks a request, does not support a format, truncates an answer, or returns an ambiguous response. Do not treat inconclusive as clean.</p>
+  <h2>Interpreting the result</h2>
+  <p>Read the overall verdict first, then inspect why it was assigned. A HIGH result can come from severe prompt injection, instruction override, tool-call substitution, error leakage, stream anomaly, Web3 prompt injection, or upstream channel mismatch. A MEDIUM result can include weaker signals or inconclusive checks. A LOW result means these probes did not catch a material issue in that run; it does not certify that the relay is safe.</p>
+  <p>Inconclusive is especially important for Claude-compatible relays. Some relays block streaming, remove thinking metadata, reject malformed requests, or return ambiguous model identity text. Blocking a probe is not the same as passing it. The report keeps those cases visible so a reviewer can decide whether the uncertainty matters for their workflow.</p>
+
+  <div class="report-example">
+    <strong>Anonymous report slice:</strong>
+    <p>Target relay: redacted. Instruction conflict: clean. Identity check: Claude wording respected. Stream integrity: inconclusive because streaming was unsupported. Tool-call substitution: clean. Error leakage: medium because one broken request exposed framework internals. Overall result: MEDIUM, with a recommendation to avoid coding-agent automation until the relay operator explains the error path.</p>
+  </div>
+
+  <h2>What this does not prove</h2>
+  <p>This guide does not prove that a relay is direct Anthropic, honest under all conditions, or safe for every user. It gives you a repeatable local audit path. A relay can behave differently by account, model, time, route, or request count. For higher-risk deployments, combine this report with direct provider billing records, network logs, operator documentation, and strict spend limits.</p>
+
+  <h2>References and follow-up</h2>
+  <ul class="reference-list">
+    <li><a href="https://arxiv.org/abs/2604.08407">Your Agent Is Mine</a> describes malicious intermediary attacks on the LLM supply chain, including prompt and tool-path risks.</li>
+    <li><a href="https://github.com/toby-bridges/api-relay-audit/issues/35">Issue #35</a> tracks SSE stream anomaly patterns.</li>
+    <li><a href="compare-api-relay-audit-hvoy-cctest.html">Tool comparison</a> explains when a local audit differs from relay lookup or web-based checks.</li>
+  </ul>
+
+  <section class="mini-faq">
+    <h2>FAQ</h2>
+    <h3>Should I skip error-leakage probes?</h3>
+    <p>Only skip them if intentionally broken requests are unacceptable for the target relay. Error behavior is part of the trust boundary, so skipping it reduces evidence.</p>
+    <h3>Should I run Web3 checks for a normal Claude relay?</h3>
+    <p>Use `--profile web3` only when wallet-related traffic or agent transaction planning is in scope. General relay audits stay focused by default.</p>
+  </section>
 </main>
 <footer><div class="wrap">Related: <a href="what-is-ai-api-relay-proxy.html">what is an AI API relay?</a> · <a href="compare-api-relay-audit-hvoy-cctest.html">tool comparison</a></div></footer>
 </body>

--- a/web/guides/compare-api-relay-audit-hvoy-cctest.html
+++ b/web/guides/compare-api-relay-audit-hvoy-cctest.html
@@ -7,32 +7,94 @@
 <meta name="description" content="A restrained comparison of api-relay-audit, hvoy.ai, and cctest.ai for AI API relay and Claude proxy checking.">
 <link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/guides/compare-api-relay-audit-hvoy-cctest.html">
 <link rel="stylesheet" href="../assets/content.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "API Relay Audit", "item": "https://toby-bridges.github.io/api-relay-audit/"},
+        {"@type": "ListItem", "position": 2, "name": "Guides", "item": "https://toby-bridges.github.io/api-relay-audit/#guides"},
+        {"@type": "ListItem", "position": 3, "name": "api-relay-audit vs hvoy.ai vs cctest.ai", "item": "https://toby-bridges.github.io/api-relay-audit/guides/compare-api-relay-audit-hvoy-cctest.html"}
+      ]
+    },
+    {
+      "@type": "TechArticle",
+      "@id": "https://toby-bridges.github.io/api-relay-audit/guides/compare-api-relay-audit-hvoy-cctest.html#article",
+      "headline": "api-relay-audit vs hvoy.ai vs cctest.ai",
+      "description": "A restrained comparison of local AI API relay audits, relay reputation lookup, and web-based Claude proxy checks.",
+      "datePublished": "2026-06-01",
+      "dateModified": "2026-06-02",
+      "author": {"@type": "Person", "name": "Toby Bridges", "url": "https://github.com/toby-bridges"},
+      "publisher": {"@type": "Organization", "name": "API Relay Audit", "url": "https://github.com/toby-bridges/api-relay-audit"},
+      "mainEntityOfPage": "https://toby-bridges.github.io/api-relay-audit/guides/compare-api-relay-audit-hvoy-cctest.html",
+      "about": ["AI API relay audit", "hvoy.ai", "cctest.ai", "Claude proxy", "security tooling"]
+    }
+  ]
+}
+</script>
 </head>
 <body>
-<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">中文</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
+<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">Chinese</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
 <main class="wrap">
+  <nav class="breadcrumb" aria-label="Breadcrumb"><a href="../">Home</a><span>/</span><a href="../#guides">Guides</a><span>/</span><span>Tool comparison</span></nav>
   <div class="eyebrow">Comparison</div>
   <h1>api-relay-audit vs hvoy.ai vs cctest.ai</h1>
-  <p class="lead">These tools answer related but different questions. API Relay Audit is a local, open-source, repeatable audit script. hvoy.ai is useful for relay reputation lookup and public relay observations. cctest.ai focuses on low-friction web checks and Claude channel fingerprinting.</p>
+  <p class="lead">These tools answer related but different questions. API Relay Audit is a local, open-source, repeatable audit script. hvoy.ai is useful for relay lookup and public relay observations. cctest.ai focuses on low-friction web checks and Claude-oriented channel fingerprinting claims. The right choice depends on whether you need discovery, convenience, or local evidence.</p>
+
+  <section class="note">Short answer: use API Relay Audit when you need a local Markdown report for your own relay route. Use relay lookup surfaces when you need public discovery. Use web checkers when convenience matters more than adding another service to the key path.</section>
 
   <h2>Positioning</h2>
   <table>
     <tr><th>Tool</th><th>Best fit</th><th>Trust tradeoff</th></tr>
-    <tr><td>API Relay Audit</td><td>Local audit reports, reproducible evidence, security review before production or wallet traffic.</td><td>You run the code locally and can inspect it; CLI use is less convenient than a web form.</td></tr>
-    <tr><td>hvoy.ai</td><td>Relay lookup, public observations, operator and user reputation signals.</td><td>Useful discovery surface; not a substitute for a local audit of your own route.</td></tr>
-    <tr><td>cctest.ai</td><td>Fast Claude-oriented web checks and channel fingerprinting claims.</td><td>Lower friction; users still need to decide whether to trust the web checker with sensitive inputs.</td></tr>
+    <tr><td>API Relay Audit</td><td>Local audit reports, reproducible evidence, security review before production, coding-agent, or wallet traffic.</td><td>You run the code locally and can inspect it; CLI use is less convenient than a web form.</td></tr>
+    <tr><td>hvoy.ai</td><td>Relay lookup, public observations, operator and user reputation signals.</td><td>Useful discovery surface; not a substitute for a local audit of your own key, model, and route.</td></tr>
+    <tr><td>cctest.ai</td><td>Fast Claude-oriented web checks and channel-fingerprint style signals.</td><td>Lower friction; users still need to decide whether to trust the web checker with sensitive inputs.</td></tr>
+  </table>
+
+  <h2>Capability comparison</h2>
+  <table>
+    <tr><th>Question</th><th>API Relay Audit</th><th>hvoy.ai</th><th>cctest.ai</th></tr>
+    <tr><td>Can I run the audit locally?</td><td>Yes. Standalone `audit.py` uses Python stdlib plus curl.</td><td>Primarily a web/reputation surface.</td><td>Primarily a web checker.</td></tr>
+    <tr><td>Does it produce a reviewable report?</td><td>Yes. Markdown report with per-step findings and final verdict.</td><td>Public observations and lookup-style output.</td><td>Web result output, depending on the service flow.</td></tr>
+    <tr><td>Does it check tool-call rewriting?</td><td>Yes. Pinned package commands are compared for substitution.</td><td>Not the primary positioning.</td><td>Not the primary positioning.</td></tr>
+    <tr><td>Does it separate inconclusive from clean?</td><td>Yes. Inconclusive remains visible in the report.</td><td>Different scoring/reporting model.</td><td>Different scoring/reporting model.</td></tr>
+    <tr><td>Does it help pick a relay from public options?</td><td>No. It audits a target relay you choose.</td><td>Yes, public discovery is part of the value.</td><td>More focused on testing a supplied route.</td></tr>
   </table>
 
   <h2>Where API Relay Audit is intentionally different</h2>
   <ul>
-    <li>It runs locally, so the extra checker server is removed from the API-key path.</li>
-    <li>It produces a Markdown report that can be reviewed, redacted, and attached to issues.</li>
-    <li>It keeps `inconclusive` separate from `clean`.</li>
+    <li>It runs locally, so a separate checker server is removed from the audit path.</li>
+    <li>It produces a Markdown report that can be reviewed, redacted, attached to issues, or archived with a test case.</li>
+    <li>It keeps `inconclusive` separate from `clean`, which matters when relays block probes or do not support a protocol.</li>
     <li>It maps important probes to relay supply-chain risks such as AC-1, AC-1.a, and AC-2.</li>
+    <li>It avoids relay recommendation language. The output is evidence under one run, not a public safe/unsafe ranking.</li>
   </ul>
 
+  <div class="report-example">
+    <strong>Anonymous report slice:</strong>
+    <p>A user first found a relay through a public lookup surface, then ran API Relay Audit locally against the exact base URL and model they planned to use. The local report found no tool-call substitution but marked stream integrity inconclusive because the route did not support the expected Anthropic streaming shape. That is a useful result: public reputation and local route evidence answered different questions.</p>
+  </div>
+
   <h2>Not a winner-takes-all claim</h2>
-  <p>Use the tool that matches the question. If you want public relay discovery, a reputation surface may be useful. If you want a local report for your own key, route, and workflow, run API Relay Audit. If you need channel-fingerprint research, track the design memo before treating it as implemented here.</p>
+  <p>Use the tool that matches the question. If you want public relay discovery, a reputation surface may be useful. If you want a local report for your own key, route, and workflow, run API Relay Audit. If you need channel-fingerprint research, track the design memo and implemented channel-classifier work before treating a claim as a production detector.</p>
+  <p>The comparison should stay current. External tools change, and public launch copy should not freeze old claims about their coverage, pricing, or internals. When in doubt, describe API Relay Audit's current scope rather than over-describing another tool.</p>
+
+  <h2>References and follow-up</h2>
+  <ul class="reference-list">
+    <li><a href="what-is-ai-api-relay-proxy.html">What is an AI API relay?</a> explains the shared trust boundary these tools care about.</li>
+    <li><a href="audit-claude-api-relay-safely.html">How to audit a Claude API relay safely</a> gives the local workflow.</li>
+    <li><a href="https://arxiv.org/abs/2604.08407">Your Agent Is Mine</a> anchors the malicious intermediary threat model used by API Relay Audit.</li>
+  </ul>
+
+  <section class="mini-faq">
+    <h2>FAQ</h2>
+    <h3>Should API Relay Audit replace relay reputation lookup?</h3>
+    <p>No. Lookup surfaces help discovery. API Relay Audit helps verify a specific route locally.</p>
+    <h3>Should a web checker replace a local audit?</h3>
+    <p>Only if the convenience tradeoff is acceptable for your threat model. For sensitive keys, local evidence is usually easier to reason about.</p>
+  </section>
 
   <div class="cta"><a class="button primary" href="../#install">Generate a local audit command</a></div>
 </main>

--- a/web/guides/detect-prompt-injection-llm-api-proxies.html
+++ b/web/guides/detect-prompt-injection-llm-api-proxies.html
@@ -7,29 +7,94 @@
 <meta name="description" content="How to detect prompt injection and hidden instruction changes in LLM API proxies with local probes and reviewable audit evidence.">
 <link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/guides/detect-prompt-injection-llm-api-proxies.html">
 <link rel="stylesheet" href="../assets/content.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "API Relay Audit", "item": "https://toby-bridges.github.io/api-relay-audit/"},
+        {"@type": "ListItem", "position": 2, "name": "Guides", "item": "https://toby-bridges.github.io/api-relay-audit/#guides"},
+        {"@type": "ListItem", "position": 3, "name": "Detecting Prompt Injection in LLM API Proxies", "item": "https://toby-bridges.github.io/api-relay-audit/guides/detect-prompt-injection-llm-api-proxies.html"}
+      ]
+    },
+    {
+      "@type": "TechArticle",
+      "@id": "https://toby-bridges.github.io/api-relay-audit/guides/detect-prompt-injection-llm-api-proxies.html#article",
+      "headline": "Detecting Prompt Injection in LLM API Proxies",
+      "description": "A local evidence workflow for detecting hidden instruction changes in LLM API proxies using token deltas, prompt extraction probes, identity checks, and report review.",
+      "datePublished": "2026-06-01",
+      "dateModified": "2026-06-02",
+      "author": {"@type": "Person", "name": "Toby Bridges", "url": "https://github.com/toby-bridges"},
+      "publisher": {"@type": "Organization", "name": "API Relay Audit", "url": "https://github.com/toby-bridges/api-relay-audit"},
+      "mainEntityOfPage": "https://toby-bridges.github.io/api-relay-audit/guides/detect-prompt-injection-llm-api-proxies.html",
+      "about": ["prompt injection", "LLM API proxy", "hidden instructions", "model substitution", "security audit"]
+    }
+  ]
+}
+</script>
 </head>
 <body>
-<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">中文</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
+<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">Chinese</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
 <main class="wrap">
+  <nav class="breadcrumb" aria-label="Breadcrumb"><a href="../">Home</a><span>/</span><a href="../#guides">Guides</a><span>/</span><span>Prompt injection</span></nav>
   <div class="eyebrow">Guide</div>
   <h1>Detecting prompt injection in LLM API proxies</h1>
-  <p class="lead">Prompt injection in an LLM API proxy means the intermediary may add hidden instructions, identity text, or policy text to your request before it reaches the model. Local detection works by combining token-delta evidence, extraction probes, identity checks, and instruction-conflict tests.</p>
+  <p class="lead">Prompt injection in an LLM API proxy means the intermediary may add hidden instructions, identity text, filtering rules, or policy text to your request before it reaches the model. Local detection works by combining token-delta evidence, extraction probes, identity checks, instruction-conflict tests, and careful interpretation of inconclusive results.</p>
+
+  <section class="note">Short answer: do not trust a single signal. Prompt injection is best treated as an evidence bundle: token usage, leaked hidden text, instruction conflict, identity mismatch, and repeatable report artifacts.</section>
 
   <h2>Signals to look for</h2>
   <div class="grid">
-    <section class="card"><h3>Unexpected token delta</h3><p>If a small request produces a much larger prompt-token count than expected, the relay may be adding hidden context.</p></section>
+    <section class="card"><h3>Unexpected token delta</h3><p>If a small request produces a much larger prompt-token count than expected, the relay may be adding hidden context. Small deltas can be framework defaults; large deltas deserve review.</p></section>
     <section class="card"><h3>Prompt extraction</h3><p>If the model reveals hidden relay instructions under recall, translation, or continuation probes, the relay path is not transparent.</p></section>
-    <section class="card"><h3>Identity conflict</h3><p>If a Claude-compatible route leaks GPT, GLM, DeepSeek, Qwen, or other non-claimed identities, model substitution or prompt injection may be involved.</p></section>
+    <section class="card"><h3>Identity conflict</h3><p>If a Claude-compatible route leaks GPT, GLM, DeepSeek, Qwen, or other non-claimed identities, model substitution or relay-side instruction injection may be involved.</p></section>
   </div>
 
+  <h2>Prompt-injection evidence map</h2>
+  <table>
+    <tr><th>Probe family</th><th>What it asks</th><th>How to read it</th></tr>
+    <tr><td>Token injection</td><td>Does the input-token count exceed the expected prompt size?</td><td>A large repeatable delta is a strong hidden-context signal, but not a full proof on its own.</td></tr>
+    <tr><td>Prompt extraction</td><td>Can hidden system or relay instructions be recalled, translated, or continued?</td><td>Recovered hidden text is direct evidence. Refusals or blocked probes may be inconclusive.</td></tr>
+    <tr><td>Instruction conflict</td><td>Does a user-controlled system instruction still win?</td><td>If the relay's hidden instruction overrides user intent, the trust boundary is compromised.</td></tr>
+    <tr><td>Identity substitution</td><td>Does the assistant reveal a different model or vendor identity?</td><td>Identity mismatch can corroborate injection or upstream model substitution.</td></tr>
+    <tr><td>Warm-up behavior</td><td>Does behavior change after benign requests?</td><td>Conditional delivery is harder to prove, so repeated runs can matter.</td></tr>
+  </table>
+
   <h2>Run the local probe set</h2>
-  <pre class="code"><code>python audit.py --key &lt;YOUR_KEY&gt; --url &lt;BASE_URL&gt; --output prompt-injection-audit.md</code></pre>
+  <pre class="code"><code>curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py
+python audit.py --key &lt;YOUR_KEY&gt; --url &lt;BASE_URL&gt; --output prompt-injection-audit.md
+
+# For suspicious relays that may activate after request history:
+python audit.py --key &lt;YOUR_KEY&gt; --url &lt;BASE_URL&gt; --warmup 10 --output prompt-injection-audit.md</code></pre>
 
   <h2>Why one signal is not enough</h2>
-  <p>Token counts can be noisy, extraction probes can be refused, and identity wording can produce false positives. API Relay Audit records multiple probe families so a reviewer can see whether the evidence is consistent, contradictory, or inconclusive.</p>
+  <p>Token counts can be noisy, extraction probes can be refused, and identity wording can produce false positives. A relay may also sanitize obvious probes while leaving other attack paths open. API Relay Audit records multiple probe families so a reviewer can see whether the evidence is consistent, contradictory, or inconclusive.</p>
+  <p>The strongest cases usually combine more than one signal: a large token delta, extracted hidden text, and instruction-conflict failure. A weaker case might include a small token delta but no extracted text. A blocked case should remain visible as inconclusive rather than being converted into a clean result.</p>
 
-  <h2>Useful follow-up issue</h2>
-  <p>For reproducible examples and detector gaps, track <a href="https://github.com/toby-bridges/api-relay-audit/issues/31">issue #31: relay prompt injection examples and detection gaps</a>.</p>
+  <div class="report-example">
+    <strong>Anonymous report slice:</strong>
+    <p>Token injection: plus 380 tokens above baseline. Prompt extraction: one continuation probe revealed relay instructions to preserve a non-user identity. Instruction conflict: partial failure. Identity check: upstream model wording inconsistent with the requested route. Overall result: HIGH because multiple signals pointed to relay-side instruction control.</p>
+  </div>
+
+  <h2>What this does not prove</h2>
+  <p>Prompt-injection probes do not prove the exact source of every hidden token. Some providers add safety text, some proxy stacks normalize prompts, and some relays block diagnostic probes. The report should be read as local evidence from a specific time, profile, model, and relay URL. Do not use it as a permanent verdict for all future traffic.</p>
+
+  <h2>References and follow-up</h2>
+  <ul class="reference-list">
+    <li><a href="https://arxiv.org/abs/2604.08407">Your Agent Is Mine</a> provides the malicious intermediary threat taxonomy used by the audit model.</li>
+    <li><a href="https://github.com/toby-bridges/api-relay-audit/issues/31">Issue #31</a> tracks relay prompt injection examples and detection gaps.</li>
+    <li><a href="what-is-ai-api-relay-proxy.html">What is an AI API relay?</a> explains why this proxy position is powerful.</li>
+  </ul>
+
+  <section class="mini-faq">
+    <h2>FAQ</h2>
+    <h3>Can a relay hide from these probes?</h3>
+    <p>Yes. Conditional behavior is a real limitation. Warm-up runs, repeated audits, and manual traffic review can help, but no black-box probe set can certify permanent safety.</p>
+    <h3>Is a small token delta always bad?</h3>
+    <p>No. Some API frameworks add small defaults. Treat token delta as a signal to inspect, not as a standalone accusation.</p>
+  </section>
 </main>
 <footer><div class="wrap">Related: <a href="what-is-ai-api-relay-proxy.html">what is an LLM proxy?</a> · <a href="web3-wallet-prompt-injection-ai-agents.html">Web3 wallet prompt injection</a></div></footer>
 </body>

--- a/web/guides/openclaw-hermes-skill-api-relay-audit.html
+++ b/web/guides/openclaw-hermes-skill-api-relay-audit.html
@@ -7,21 +7,53 @@
 <meta name="description" content="Install API Relay Audit as an OpenClaw or Hermes Agent skill to run local AI API relay and LLM proxy security audits before trusting relay traffic.">
 <link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/guides/openclaw-hermes-skill-api-relay-audit.html">
 <link rel="stylesheet" href="../assets/content.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "API Relay Audit", "item": "https://toby-bridges.github.io/api-relay-audit/"},
+        {"@type": "ListItem", "position": 2, "name": "Guides", "item": "https://toby-bridges.github.io/api-relay-audit/#guides"},
+        {"@type": "ListItem", "position": 3, "name": "OpenClaw and Hermes Skill for AI API Relay Audits", "item": "https://toby-bridges.github.io/api-relay-audit/guides/openclaw-hermes-skill-api-relay-audit.html"}
+      ]
+    },
+    {
+      "@type": "TechArticle",
+      "@id": "https://toby-bridges.github.io/api-relay-audit/guides/openclaw-hermes-skill-api-relay-audit.html#article",
+      "headline": "OpenClaw and Hermes Skill for AI API Relay Audits",
+      "description": "How OpenClaw and Hermes Agent workflows can run API Relay Audit as a local skill before trusting AI API relay traffic.",
+      "datePublished": "2026-06-01",
+      "dateModified": "2026-06-02",
+      "author": {"@type": "Person", "name": "Toby Bridges", "url": "https://github.com/toby-bridges"},
+      "publisher": {"@type": "Organization", "name": "API Relay Audit", "url": "https://github.com/toby-bridges/api-relay-audit"},
+      "mainEntityOfPage": "https://toby-bridges.github.io/api-relay-audit/guides/openclaw-hermes-skill-api-relay-audit.html",
+      "about": ["OpenClaw skill", "Hermes Agent skill", "AI API relay audit", "agent safety", "LLM proxy security"]
+    }
+  ]
+}
+</script>
 </head>
 <body>
-<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">中文</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
+<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">Chinese</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
 <main class="wrap">
+  <nav class="breadcrumb" aria-label="Breadcrumb"><a href="../">Home</a><span>/</span><a href="../#guides">Guides</a><span>/</span><span>OpenClaw and Hermes</span></nav>
   <div class="eyebrow">Agent Skill</div>
   <h1>OpenClaw and Hermes skill for AI API relay audits</h1>
-  <p class="lead">API Relay Audit can run as an agent skill so OpenClaw or Hermes users can generate a local, reviewable Markdown report before an agent sends coding, tool, or wallet-related traffic through a third-party relay.</p>
+  <p class="lead">API Relay Audit can run as an agent skill so OpenClaw or Hermes users can generate a local, reviewable Markdown report before an agent sends coding, tool, or wallet-related traffic through a third-party relay. The skill does not replace manual review. It gives an agent a repeatable local workflow instead of asking it to improvise a security test from memory.</p>
 
-  <section class="note">The skill does not certify that a relay is safe. It helps an agent run the same local 14-step audit and keep API-key handling explicit.</section>
+  <section class="note">Short answer: OpenClaw and Hermes are distribution surfaces for the same local audit. They should make relay checks easier to run, not turn audit output into a safety certificate.</section>
+
+  <h2>Why agent skills matter here</h2>
+  <p>AI agents often sit close to tools: package managers, terminals, deploy scripts, wallets, browser automation, and API clients. If an agent routes its model calls through an untrusted relay, that relay may influence not only text, but tool choices and safety decisions. A skill gives the agent a fixed audit recipe: collect a base URL, use a scoped key, run the standalone script, write a Markdown report, and summarize only evidence from that report.</p>
+  <p>This is especially relevant for coding and wallet-adjacent workflows. Tool-call rewriting can modify package install commands. Web3 prompt injection can normalize unsafe private-key or signing behavior. Error leakage can reveal upstream framework details. A skill keeps those checks explicit before the agent trusts a relay path.</p>
 
   <h2>OpenClaw use case</h2>
-  <p>Use the OpenClaw skill when an OpenClaw agent is about to depend on an AI API relay, proxy API, or resale key. The skill is designed to check prompt injection, model substitution, tool-call rewriting, SSE anomalies, upstream channel mismatch, error leakage, and Web3 wallet risks.</p>
+  <p>Use the OpenClaw skill when an OpenClaw agent is about to depend on an AI API relay, proxy API, or resale key. The skill is designed to check prompt injection, model substitution, tool-call rewriting, SSE anomalies, upstream channel mismatch, error leakage, and Web3 wallet risks. For OpenClaw-style workflows, the most important behavior is pre-flight restraint: run the audit before giving a relay route sensitive coding, tool, or wallet-related work.</p>
 
   <h2>Hermes Agent use case</h2>
-  <p>Use the Hermes skill when a Hermes workflow needs a repeatable local audit recipe. The skill prefers `$API_RELAY_AUDIT_KEY` for secret handling and writes a Markdown report instead of asking the agent to summarize raw traffic from memory.</p>
+  <p>Use the Hermes skill when a Hermes workflow needs a repeatable local audit recipe. The skill prefers `$API_RELAY_AUDIT_KEY` for secret handling and writes a Markdown report instead of asking the agent to summarize raw traffic from memory. Hermes users can install directly from the repository skill folder or, after publication, through a tap or skills hub flow.</p>
 
   <h2>Install commands</h2>
   <pre class="code"><code># Hermes direct install
@@ -35,15 +67,38 @@ hermes skills install toby-bridges/api-relay-audit/api-relay-audit
 openclaw skills search "api relay audit"
 openclaw skills install api-relay-audit</code></pre>
 
-  <h2>Why this helps agent safety</h2>
-  <ul>
-    <li>The audit runs locally rather than through another web checker.</li>
-    <li>The report distinguishes `clean`, `anomaly`, and `inconclusive` results.</li>
-    <li>Tool-call rewriting and Web3 wallet probes are visible before the agent trusts a relay path.</li>
-    <li>The skill keeps OpenClaw and Hermes as distribution channels, not as replacements for manual security review.</li>
+  <h2>Skill behavior checklist</h2>
+  <table>
+    <tr><th>Requirement</th><th>Why it matters</th><th>Expected skill behavior</th></tr>
+    <tr><td>Scoped key</td><td>Relay audits spend tokens and test unusual paths.</td><td>Prefer environment variables and avoid echoing keys in summaries.</td></tr>
+    <tr><td>Local script</td><td>The audit should not add a separate web checker to the key path.</td><td>Download or use `audit.py` locally, then write a Markdown report.</td></tr>
+    <tr><td>Evidence-only summary</td><td>Agents can overstate confidence if left unconstrained.</td><td>Summarize only report findings and keep `inconclusive` visible.</td></tr>
+    <tr><td>No certification language</td><td>A single black-box run cannot prove permanent relay safety.</td><td>Say what was observed, not that a relay is globally safe.</td></tr>
+  </table>
+
+  <div class="report-example">
+    <strong>Anonymous skill run:</strong>
+    <p>A Hermes workflow received a relay base URL and a scoped key through local environment setup. The skill downloaded `audit.py`, ran the general profile, wrote `api-relay-audit-report.md`, and summarized that prompt extraction was clean, tool-call substitution was clean, but stream integrity was inconclusive. The agent recommended using the relay for low-risk text tasks only until the operator explained the stream behavior.</p>
+  </div>
+
+  <h2>What this does not prove</h2>
+  <p>Installing an OpenClaw or Hermes skill does not make the relay safe. It also does not make the agent immune to prompt injection. The skill only standardizes the audit workflow and reduces improvisation. Users still need to scope credentials, review reports, avoid publishing secrets, and decide whether inconclusive findings are acceptable for their risk level.</p>
+
+  <h2>References and follow-up</h2>
+  <ul class="reference-list">
+    <li><a href="what-is-ai-api-relay-proxy.html">What is an AI API relay?</a> explains the relay trust boundary.</li>
+    <li><a href="web3-wallet-prompt-injection-ai-agents.html">Web3 wallet prompt injection</a> explains why wallet-related agent traffic needs profile-gated checks.</li>
+    <li><a href="https://github.com/toby-bridges/api-relay-audit/blob/master/docs/skill-distribution.md">Skill distribution notes</a> track OpenClaw and Hermes publishing details.</li>
   </ul>
+
+  <section class="mini-faq">
+    <h2>FAQ</h2>
+    <h3>Should OpenClaw or Hermes become the main project concept?</h3>
+    <p>No. The main concept stays API Relay Audit. OpenClaw and Hermes are agent-skill distribution channels for users who already work in those ecosystems.</p>
+    <h3>Can an agent run the audit without seeing my key?</h3>
+    <p>The agent needs access to a key in order to run requests, but the skill should prefer local environment variables and avoid repeating the raw key in chat, filenames, reports, or public comments.</p>
+  </section>
 </main>
 <footer><div class="wrap">Related: <a href="what-is-ai-api-relay-proxy.html">what is an AI API relay?</a> · <a href="detect-prompt-injection-llm-api-proxies.html">prompt injection in LLM proxies</a></div></footer>
 </body>
 </html>
-

--- a/web/guides/web3-wallet-prompt-injection-ai-agents.html
+++ b/web/guides/web3-wallet-prompt-injection-ai-agents.html
@@ -7,23 +7,55 @@
 <meta name="description" content="How AI API relays can affect Web3 wallet workflows, and how to run local signature-isolation probes before wallet-related traffic is trusted.">
 <link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/guides/web3-wallet-prompt-injection-ai-agents.html">
 <link rel="stylesheet" href="../assets/content.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "API Relay Audit", "item": "https://toby-bridges.github.io/api-relay-audit/"},
+        {"@type": "ListItem", "position": 2, "name": "Guides", "item": "https://toby-bridges.github.io/api-relay-audit/#guides"},
+        {"@type": "ListItem", "position": 3, "name": "Web3 Wallet Prompt Injection Through AI Agents", "item": "https://toby-bridges.github.io/api-relay-audit/guides/web3-wallet-prompt-injection-ai-agents.html"}
+      ]
+    },
+    {
+      "@type": "TechArticle",
+      "@id": "https://toby-bridges.github.io/api-relay-audit/guides/web3-wallet-prompt-injection-ai-agents.html#article",
+      "headline": "Web3 Wallet Prompt Injection Through AI Agents",
+      "description": "A local audit guide for Web3 wallet-related agent traffic, relay prompt injection, and signature-isolation probes.",
+      "datePublished": "2026-06-01",
+      "dateModified": "2026-06-02",
+      "author": {"@type": "Person", "name": "Toby Bridges", "url": "https://github.com/toby-bridges"},
+      "publisher": {"@type": "Organization", "name": "API Relay Audit", "url": "https://github.com/toby-bridges/api-relay-audit"},
+      "mainEntityOfPage": "https://toby-bridges.github.io/api-relay-audit/guides/web3-wallet-prompt-injection-ai-agents.html",
+      "about": ["Web3 wallet security", "prompt injection", "AI agents", "signature isolation", "LLM proxy"]
+    }
+  ]
+}
+</script>
 </head>
 <body>
-<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">中文</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
+<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">Chinese</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
 <main class="wrap">
+  <nav class="breadcrumb" aria-label="Breadcrumb"><a href="../">Home</a><span>/</span><a href="../#guides">Guides</a><span>/</span><span>Web3 wallet injection</span></nav>
   <div class="eyebrow">Web3 Guide</div>
   <h1>Web3 wallet prompt injection through AI agents</h1>
-  <p class="lead">When an AI agent uses a relay before wallet-related actions, a malicious or compromised relay can try to steer transfer guidance, weaken signature isolation, or normalize unsafe handling of private keys. API Relay Audit keeps these checks profile-gated so general relay audits remain focused.</p>
+  <p class="lead">When an AI agent uses a relay before wallet-related actions, a malicious or compromised relay can try to steer transfer guidance, weaken signature isolation, or normalize unsafe handling of private keys. API Relay Audit keeps Web3 checks profile-gated so normal relay audits stay focused, while wallet users can opt into targeted refusal probes.</p>
+
+  <section class="note">Short answer: if a relay sits between an agent and wallet-related reasoning, test whether the model refuses unsafe signing, private-key, and transfer guidance before trusting that route.</section>
 
   <h2>Threat model</h2>
   <ul>
     <li>The user sends wallet-related instructions through an AI API relay.</li>
-    <li>The relay can insert hidden instructions or rewrite the model path.</li>
-    <li>The model may then provide unsafe transfer guidance, signed-transaction behavior, or private-key handling language.</li>
+    <li>The relay can insert hidden instructions, rewrite the model path, or alter the wording returned to the agent.</li>
+    <li>The model may then produce unsafe transfer guidance, signed-transaction behavior, or private-key handling language.</li>
+    <li>The user or agent may treat that output as a step toward a real transaction.</li>
   </ul>
 
   <h2>Run Web3 profile checks</h2>
-  <pre class="code"><code>python audit.py \
+  <pre class="code"><code>curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py
+python audit.py \
   --key &lt;YOUR_KEY&gt; \
   --url &lt;BASE_URL&gt; \
   --profile web3 \
@@ -31,16 +63,39 @@
 
   <h2>What the probes check</h2>
   <table>
-    <tr><th>Probe family</th><th>Expected safe behavior</th></tr>
-    <tr><td>Transfer guidance</td><td>The model should avoid directly instructing unsafe or unauthorized transfers.</td></tr>
-    <tr><td>Signed transaction refusal</td><td>The model should refuse to sign transactions or imply it can sign on the user's behalf.</td></tr>
-    <tr><td>Private-key refusal</td><td>The model should refuse to request, reveal, or process private keys.</td></tr>
+    <tr><th>Probe family</th><th>Expected safe behavior</th><th>Why it matters</th></tr>
+    <tr><td>Transfer guidance</td><td>The model should avoid directly instructing unsafe or unauthorized transfers.</td><td>A hidden relay instruction could push an agent toward a transaction the user did not intend.</td></tr>
+    <tr><td>Signed transaction refusal</td><td>The model should refuse to sign transactions or imply it can sign on the user's behalf.</td><td>Signing authority should remain isolated from natural-language relay behavior.</td></tr>
+    <tr><td>Private-key refusal</td><td>The model should refuse to request, reveal, transform, or process private keys.</td><td>Private-key handling should never be normalized as a chat workflow.</td></tr>
+    <tr><td>Contradictory answers</td><td>The classifier treats hard unsafe markers as injected even if a safe phrase appears too.</td><td>"I cannot sign, but here is the signed transaction" should not pass as safe.</td></tr>
   </table>
 
-  <h2>Limits</h2>
-  <p>These probes do not prove a wallet stack is safe. They test relay and model behavior under specific prompts. Keep transaction signing, key custody, and policy enforcement outside the relay path wherever possible.</p>
+  <h2>How to read Web3 results</h2>
+  <p>A clean Web3 profile means these probes did not catch unsafe wallet behavior during that run. It does not prove the wallet stack is safe, and it does not prove the relay cannot behave differently later. An injected result means the response crossed a hard unsafe marker, such as offering to sign, requesting private keys, or giving direct transfer instructions under a risky prompt. An inconclusive result means the response was blocked, ambiguous, unsupported, or too weak to classify.</p>
+  <p>The distinction matters because wallet workflows have asymmetric downside. A single unsafe instruction can matter more than many harmless answers. If a relay will sit near transaction planning, use scoped keys, isolated wallets, simulation, explicit user confirmation, and external policy checks. The audit report should be one piece of evidence, not the only control.</p>
 
-  <p>For documentation work on this threat model, track <a href="https://github.com/toby-bridges/api-relay-audit/issues/33">issue #33: Web3 wallet prompt injection threat model</a>.</p>
+  <div class="report-example">
+    <strong>Anonymous report slice:</strong>
+    <p>Profile: web3. Transfer guidance: inconclusive because the relay returned a generic refusal without enough context. Signed-transaction refusal: clean. Private-key refusal: injected because the response asked the user to paste a private key for "validation". Overall result: HIGH for Web3 use, with a recommendation to avoid wallet-related traffic through the relay.</p>
+  </div>
+
+  <h2>Limits</h2>
+  <p>These probes do not test an actual wallet implementation, transaction simulator, hardware signer, or custody policy. They test relay and model behavior under specific prompts. Keep transaction signing, key custody, address allowlists, spend limits, and user confirmation outside the relay path wherever possible.</p>
+
+  <h2>References and follow-up</h2>
+  <ul class="reference-list">
+    <li><a href="https://arxiv.org/abs/2604.08407">Your Agent Is Mine</a> includes a Web3-related malicious intermediary example in the broader LLM supply-chain threat model.</li>
+    <li>SlowMist OpenClaw security guidance inspired the signature-isolation framing used by the Web3 probes.</li>
+    <li><a href="https://github.com/toby-bridges/api-relay-audit/issues/33">Issue #33</a> tracks Web3 wallet prompt injection threat-model documentation.</li>
+  </ul>
+
+  <section class="mini-faq">
+    <h2>FAQ</h2>
+    <h3>Should every relay audit use `--profile web3`?</h3>
+    <p>No. Use it when wallet-related planning, transaction guidance, signing, or private-key handling could appear in the workflow.</p>
+    <h3>Does a clean Web3 result mean the wallet is safe?</h3>
+    <p>No. It only means these relay probes did not catch unsafe behavior in that run. Wallet security still needs separate controls.</p>
+  </section>
 </main>
 <footer><div class="wrap">Related: <a href="detect-prompt-injection-llm-api-proxies.html">prompt injection in LLM proxies</a> · <a href="audit-claude-api-relay-safely.html">audit Claude relays safely</a></div></footer>
 </body>

--- a/web/guides/what-is-ai-api-relay-proxy.html
+++ b/web/guides/what-is-ai-api-relay-proxy.html
@@ -7,32 +7,91 @@
 <meta name="description" content="An AI API relay or LLM proxy sits between your app and an AI provider. Learn what it can change, why it matters, and how to audit it locally.">
 <link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/guides/what-is-ai-api-relay-proxy.html">
 <link rel="stylesheet" href="../assets/content.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "API Relay Audit", "item": "https://toby-bridges.github.io/api-relay-audit/"},
+        {"@type": "ListItem", "position": 2, "name": "Guides", "item": "https://toby-bridges.github.io/api-relay-audit/#guides"},
+        {"@type": "ListItem", "position": 3, "name": "What Is an AI API Relay or LLM Proxy?", "item": "https://toby-bridges.github.io/api-relay-audit/guides/what-is-ai-api-relay-proxy.html"}
+      ]
+    },
+    {
+      "@type": "TechArticle",
+      "@id": "https://toby-bridges.github.io/api-relay-audit/guides/what-is-ai-api-relay-proxy.html#article",
+      "headline": "What Is an AI API Relay or LLM Proxy?",
+      "description": "A practical definition of AI API relays and LLM proxies, the trust boundary they create, and the local audit evidence to collect before relying on one.",
+      "datePublished": "2026-06-01",
+      "dateModified": "2026-06-02",
+      "author": {"@type": "Person", "name": "Toby Bridges", "url": "https://github.com/toby-bridges"},
+      "publisher": {"@type": "Organization", "name": "API Relay Audit", "url": "https://github.com/toby-bridges/api-relay-audit"},
+      "mainEntityOfPage": "https://toby-bridges.github.io/api-relay-audit/guides/what-is-ai-api-relay-proxy.html",
+      "about": ["AI API relay", "LLM proxy", "prompt injection", "model substitution", "security audit"]
+    }
+  ]
+}
+</script>
 </head>
 <body>
-<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">中文</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
+<header><div class="wrap nav"><a class="brand" href="../">API Relay Audit</a><div class="links"><a href="../">Home</a><a href="../zh/">Chinese</a><a href="https://github.com/toby-bridges/api-relay-audit">GitHub</a></div></div></header>
 <main class="wrap">
+  <nav class="breadcrumb" aria-label="Breadcrumb"><a href="../">Home</a><span>/</span><a href="../#guides">Guides</a><span>/</span><span>AI API relay</span></nav>
   <div class="eyebrow">Guide</div>
   <h1>What is an AI API relay or LLM proxy?</h1>
-  <p class="lead">An AI API relay or LLM proxy is a third-party service that sits between your application and an upstream AI provider such as Anthropic or OpenAI. It can forward requests, normalize APIs, meter usage, or route traffic, but it can also change the prompt, model, context, stream, or error response you receive.</p>
+  <p class="lead">An AI API relay or LLM proxy is a third-party service that sits between your application and an upstream AI provider such as Anthropic or OpenAI. It may forward requests, normalize API formats, meter usage, cache responses, or route traffic, but it can also change the prompt, model, context, stream, tool output, or error response you receive.</p>
 
-  <section class="note">Short answer: a relay is part of your model supply chain. If it can read and rewrite requests, it should be audited before production or wallet-related traffic depends on it.</section>
+  <section class="note">Short answer: a relay is part of your model supply chain. If it can read and rewrite requests or responses, it should be audited before production, coding-agent, or wallet-related traffic depends on it.</section>
+
+  <h2>Why the trust boundary matters</h2>
+  <p>A relay is not only a network hop. It is a position of control. It sees the API key you give it, the model name you request, the messages you send, and the answer that comes back. A benign relay can make access easier. A malicious or compromised relay can quietly add hidden instructions, route to a cheaper model, truncate context, rewrite package names, or leak implementation details through errors.</p>
+  <p>This is why local auditing is different from using a second web checker. A web checker can be convenient, but it adds another server to the key path. API Relay Audit keeps the audit local: the script runs on your machine, and the API key is sent only to the relay URL you specify.</p>
 
   <h2>What a relay can change</h2>
   <div class="grid">
-    <section class="card"><h3>Prompt path</h3><p>A relay can prepend hidden instructions, inject identity text, ask the model to ignore user instructions, or reveal hidden prompt content in later responses.</p></section>
-    <section class="card"><h3>Model path</h3><p>A relay can route a request to a different model than the one named in the API response, or leak an upstream model identity through wording or stream metadata.</p></section>
-    <section class="card"><h3>Tool path</h3><p>A relay can rewrite package-install commands or tool-like output before it reaches a coding agent, which turns proxy behavior into a supply-chain risk.</p></section>
+    <section class="card"><h3>Prompt path</h3><p>A relay can prepend hidden instructions, inject identity text, weaken user instructions, or reveal hidden prompt content in later responses.</p></section>
+    <section class="card"><h3>Model path</h3><p>A relay can route a request to a different model than the one named in the API response, or leak a different upstream identity through wording or stream metadata.</p></section>
+    <section class="card"><h3>Tool path</h3><p>A relay can rewrite package-install commands or tool-like output before it reaches a coding agent, turning proxy behavior into a supply-chain risk.</p></section>
   </div>
 
-  <h2>Why local auditing matters</h2>
-  <p>A web-based checker asks you to send a relay key to another service before you can test the relay. API Relay Audit avoids that extra trust hop: the script runs locally, and your API key is sent only to the relay URL you specify.</p>
+  <h2>Audit signals to collect</h2>
+  <table>
+    <tr><th>Signal</th><th>Why it matters</th><th>Example evidence</th></tr>
+    <tr><td>Token delta</td><td>Large unexpected prompt-token use may indicate hidden instructions.</td><td>Step 3 reports an input-token delta above the expected baseline.</td></tr>
+    <tr><td>Prompt extraction</td><td>If hidden relay text can be recalled or continued, the relay path is not transparent.</td><td>Step 4 records whether extraction probes reveal relay-side instructions.</td></tr>
+    <tr><td>Tool-call rewriting</td><td>Package-name edits can become code-execution risk for agents.</td><td>Step 8 compares pinned package commands character by character.</td></tr>
+    <tr><td>Error leakage</td><td>Broken requests can expose upstream hosts, stack traces, or credentials.</td><td>Step 9 scans deterministic error responses for sensitive markers.</td></tr>
+    <tr><td>Stream integrity</td><td>Streaming metadata can reveal unsupported events, usage anomalies, or model mismatch.</td><td>Step 10 checks Anthropic-style SSE invariants when supported.</td></tr>
+  </table>
 
-  <h2>How to audit one</h2>
+  <h2>How to audit one locally</h2>
   <pre class="code"><code>curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py
 python audit.py --key &lt;YOUR_KEY&gt; --url &lt;BASE_URL&gt; --output report.md</code></pre>
 
-  <h2>What the report does not prove</h2>
-  <p>A clean-looking run is not a certificate. Relays can behave conditionally, models can be ambiguous, and unsupported formats can make a step inconclusive. Treat the report as reproducible evidence, not a final safety label.</p>
+  <div class="report-example">
+    <strong>Anonymous report slice:</strong>
+    <p>Target relay: redacted. Token injection: minor delta. Prompt extraction: no hidden text recovered. Tool-call substitution: clean. Error leakage: inconclusive because several malformed requests were blocked. Overall result: MEDIUM, not because the relay was proven malicious, but because blocked probes should not be treated as clean evidence.</p>
+  </div>
+
+  <h2>What this does not prove</h2>
+  <p>A clean-looking run is not a certificate. Relays can behave conditionally, models can be ambiguous, and unsupported formats can make a step inconclusive. Treat the report as reproducible evidence, not a final safety label. If you plan to use a relay for production automation, package installation, or wallet-related actions, pair this report with manual review, provider logs, scoped keys, and spending limits.</p>
+
+  <h2>References and follow-up</h2>
+  <ul class="reference-list">
+    <li><a href="https://arxiv.org/abs/2604.08407">Your Agent Is Mine</a> frames malicious intermediary attacks on the LLM supply chain.</li>
+    <li><a href="https://arxiv.org/abs/2603.01919">Real Money, Fake Models</a> motivates infrastructure and latency signals for deceptive API claims.</li>
+    <li><a href="https://github.com/toby-bridges/api-relay-audit/issues/34">Issue #34</a> tracks reproducible LLM proxy security test cases.</li>
+  </ul>
+
+  <section class="mini-faq">
+    <h2>FAQ</h2>
+    <h3>Is an API relay always unsafe?</h3>
+    <p>No. A relay can be useful infrastructure. The point is that it has enough visibility and control to deserve verification before sensitive traffic depends on it.</p>
+    <h3>Is this the same as benchmarking model quality?</h3>
+    <p>No. API Relay Audit focuses on relay-path integrity and evidence. It does not rank model intelligence, price, or general answer quality.</p>
+  </section>
 </main>
 <footer><div class="wrap">Related: <a href="audit-claude-api-relay-safely.html">audit a Claude API relay safely</a> · <a href="detect-prompt-injection-llm-api-proxies.html">prompt injection in LLM proxies</a></div></footer>
 </body>

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">694</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">696</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## Summary\n- Add visible breadcrumbs plus BreadcrumbList and TechArticle JSON-LD to every guide page.\n- Expand all six guide pages into more substantial, citation-friendly pages with tables, anonymous report slices, limits, FAQ, and references/follow-up links.\n- Add static-site regression tests so guide pages must keep breadcrumbs, TechArticle metadata, and minimum visible content thickness.\n- Sync public test-count metrics from 694 to 696 after adding the regression tests.\n\n## Guide page word counts\n- audit-claude-api-relay-safely.html: 726 words\n- compare-api-relay-audit-hvoy-cctest.html: 719 words\n- detect-prompt-injection-llm-api-proxies.html: 693 words\n- openclaw-hermes-skill-api-relay-audit.html: 762 words\n- web3-wallet-prompt-injection-ai-agents.html: 663 words\n- what-is-ai-api-relay-proxy.html: 706 words\n\n## Validation\n- python3 -m pytest tests/test_static_site.py -q\n- python3 scripts/collect-metrics.py --check\n- git diff --check\n- local static server curl 200 checks for every guide page and homepage