### PR TITLE
chore: sync metrics after sanitized report merge

### DIFF
--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -25,7 +25,7 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `af580a6` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `d6a2967` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-03 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检


### PR DESCRIPTION
## Summary\n- Sync docs/_metrics.md after #53 was squash-merged to master.\n- Updates only the recorded reachable commit SHA from the PR-internal merge commit to the master squash commit.\n\n## Validation\n- python3 scripts/collect-metrics.py --check\n- python3 scripts/build-standalone.py --check\n- git diff --check\n- python3 -m pytest tests/ -q -> 708 passed\n\nFixes the post-merge Metrics Drift / Standalone Drift failures from #53.