### PR TITLE
[codex] Handle client-gated relay probes honestly

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 04b7aa16a85d6094d6b0d5f1fd16e110bc1db1d84c33b59231776ffd2e7da60c
-# standalone_body_sha256: 30cecedb64e88021d8876affa1104de2dfbe431913e19c37ad524e2edb38a614
+# source_sha256: 38c09737f1d8eb431e34e592abedb8659a81feefb6268a0ed2ccb67de4522580
+# standalone_body_sha256: f223ef0874b1b4f300c33a1568ccac1a679a27286668aac32ee01ad943593b4d
 # END GENERATED STANDALONE HEADER
 
 """
@@ -4400,6 +4400,25 @@ def run_cmd(cmd, timeout=10):
         return f"error: {e}"
 
 
+def _looks_like_claude_code_client_gate(error) -> bool:
+    """Return True when an error string looks like a Claude Code-only gate.
+
+    Some relays expose ``/v1/models`` to generic API tokens but reject
+    ``/v1/messages`` unless the caller is the real Claude Code client.
+    We deliberately do NOT impersonate Claude Code headers (out of scope
+    per ROADMAP / CLAUDE.md); instead we downgrade the affected steps to
+    an honest inconclusive verdict.
+    """
+    if not error:
+        return False
+    text = str(error).lower()
+    return (
+        "claude code" in text
+        and "client" in text
+        and ("only allow" in text or "only allows" in text)
+    )
+
+
 # ============================================================
 # Test modules
 # ============================================================
@@ -4472,17 +4491,39 @@ def test_token_injection(client, report):
     report.p("|------|---------------------|----------|-------|")
 
     injection_size = 0
+    errors = []
+    success_count = 0
     for name, sys_prompt, user_msg, expected in tests:
         r = client.call([{"role": "user", "content": user_msg}],
                         system=sys_prompt, max_tokens=100)
         if "error" in r:
             report.p(f"| {name} | ERROR | ~{expected} | - |")
+            errors.append(r.get("error", ""))
         else:
+            success_count += 1
             actual = r["input_tokens"]
             diff = actual - expected
             injection_size = max(injection_size, diff)
             report.p(f"| {name} | **{actual}** | ~{expected} | **~{diff}** |")
         time.sleep(1)
+
+    if success_count == 0:
+        if errors and all(_looks_like_claude_code_client_gate(err) for err in errors):
+            report.flag(
+                "yellow",
+                "Token injection test INCONCLUSIVE: every completion probe "
+                "was rejected as Claude Code-client-only. The relay appears "
+                "restricted to Claude Code clients, so hidden prompt injection "
+                "could not be measured.",
+            )
+        else:
+            report.flag(
+                "yellow",
+                f"Token injection test INCONCLUSIVE: all {len(errors)} probes "
+                "errored, so hidden prompt injection could not be measured.",
+            )
+        print("  Done: token injection (inconclusive, all probes errored)")
+        return None
 
     if injection_size > 100:
         report.flag("red", f"Hidden system prompt injection detected (~{injection_size} tokens/request)")
@@ -4591,6 +4632,8 @@ def test_prompt_extraction(client, report):
 
 def test_instruction_conflict(client, report):
     report.h2("5. Instruction Override Tests")
+    error_messages = []
+    success_count = 0
 
     # Cat test
     report.h3("Test D: Cat Test")
@@ -4610,7 +4653,10 @@ def test_instruction_conflict(client, report):
         if "422" in str(r.get("error", "")):
             overridden = True
             report.flag("red", "Cat test blocked: relay rejects custom system prompts (HTTP 422)")
+        else:
+            error_messages.append(r.get("error", ""))
     else:
+        success_count += 1
         report.p(f"**input_tokens**: {r['input_tokens']} | **Response**: `{r['text']}`")
         text = r["text"].strip().lower()
         has_meow = "meow" in text
@@ -4643,7 +4689,10 @@ def test_instruction_conflict(client, report):
         if "422" in str(r.get("error", "")):
             overridden = True
             report.flag("red", "Identity test blocked: relay rejects custom system prompts (HTTP 422)")
+        else:
+            error_messages.append(r.get("error", ""))
     else:
+        success_count += 1
         report.p(f"**input_tokens**: {r['input_tokens']} | **Response**:")
         report.code(r["text"][:500])
         text_lower = r["text"].lower()
@@ -4667,6 +4716,24 @@ def test_instruction_conflict(client, report):
         else:
             report.flag("yellow", "Identity test inconclusive")
 
+    if success_count == 0 and not overridden:
+        if error_messages and all(_looks_like_claude_code_client_gate(err) for err in error_messages):
+            report.flag(
+                "yellow",
+                "Instruction override test INCONCLUSIVE: both completion "
+                "probes were rejected as Claude Code-client-only. The relay "
+                "appears restricted to Claude Code clients, so user system-"
+                "prompt adherence could not be verified.",
+            )
+        else:
+            report.flag(
+                "yellow",
+                "Instruction override test INCONCLUSIVE: both probes errored, "
+                "so user system-prompt adherence could not be verified.",
+            )
+        print("  Done: instruction conflict (inconclusive, all probes errored)")
+        return None
+
     print(f"  Done: instruction conflict (overridden: {'yes' if overridden else 'no'})")
     return overridden
 
@@ -4689,12 +4756,16 @@ def test_jailbreak(client, report):
     ]
 
     leaked_keywords = []
+    error_messages = []
+    success_count = 0
     for name, prompt in tests:
         report.h3(f"Test {name}")
         r = client.call([{"role": "user", "content": prompt}], max_tokens=1024)
         if "error" in r:
             report.p(f"Error: {r['error']}")
+            error_messages.append(r.get("error", ""))
         else:
+            success_count += 1
             report.p(f"**input_tokens**: {r['input_tokens']} | **output_tokens**: {r['output_tokens']}")
             report.p("**Response**:")
             report.code(r["text"][:2000])
@@ -4743,6 +4814,22 @@ def test_jailbreak(client, report):
 
     if leaked_keywords:
         report.p(f"\nInferred hidden prompt characteristics: {', '.join(set(leaked_keywords))}")
+    elif success_count == 0:
+        report.p("\nJailbreak probes did not return any usable completion.")
+        if error_messages and all(_looks_like_claude_code_client_gate(err) for err in error_messages):
+            report.flag(
+                "yellow",
+                "Jailbreak tests INCONCLUSIVE: every completion probe was "
+                "rejected as Claude Code-client-only. The relay appears "
+                "restricted to Claude Code clients, so jailbreak behavior "
+                "could not be verified.",
+            )
+        else:
+            report.flag(
+                "yellow",
+                f"Jailbreak tests INCONCLUSIVE: all {len(error_messages)} "
+                "probes errored, so jailbreak behavior could not be verified.",
+            )
     else:
         report.p("\nJailbreak tests did not extract useful information.")
         report.flag("green", "Jailbreak tests passed (no identity keywords leaked)")

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -25,7 +25,7 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `92fbe85` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `01d4682` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-07 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,8 +16,8 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **733** | `pytest --collect-only` |
-| 测试数 (static) | 714 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **739** | `pytest --collect-only` |
+| 测试数 (static) | 720 | grep `def test_*` in tests/ |
 | CLI flag 数 | 20 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-07 | `ROADMAP.md` 头部 |
@@ -25,14 +25,14 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `7925f1e` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `92fbe85` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-07 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
-- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 733。要么 ROADMAP 漏更新，要么有未记录的新测试。
+- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 739。要么 ROADMAP 漏更新，要么有未记录的新测试。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -166,6 +166,25 @@ def run_cmd(cmd, timeout=10):
         return f"error: {e}"
 
 
+def _looks_like_claude_code_client_gate(error) -> bool:
+    """Return True when an error string looks like a Claude Code-only gate.
+
+    Some relays expose ``/v1/models`` to generic API tokens but reject
+    ``/v1/messages`` unless the caller is the real Claude Code client.
+    We deliberately do NOT impersonate Claude Code headers (out of scope
+    per ROADMAP / CLAUDE.md); instead we downgrade the affected steps to
+    an honest inconclusive verdict.
+    """
+    if not error:
+        return False
+    text = str(error).lower()
+    return (
+        "claude code" in text
+        and "client" in text
+        and ("only allow" in text or "only allows" in text)
+    )
+
+
 # ============================================================
 # Test modules
 # ============================================================
@@ -238,17 +257,39 @@ def test_token_injection(client, report):
     report.p("|------|---------------------|----------|-------|")
 
     injection_size = 0
+    errors = []
+    success_count = 0
     for name, sys_prompt, user_msg, expected in tests:
         r = client.call([{"role": "user", "content": user_msg}],
                         system=sys_prompt, max_tokens=100)
         if "error" in r:
             report.p(f"| {name} | ERROR | ~{expected} | - |")
+            errors.append(r.get("error", ""))
         else:
+            success_count += 1
             actual = r["input_tokens"]
             diff = actual - expected
             injection_size = max(injection_size, diff)
             report.p(f"| {name} | **{actual}** | ~{expected} | **~{diff}** |")
         time.sleep(1)
+
+    if success_count == 0:
+        if errors and all(_looks_like_claude_code_client_gate(err) for err in errors):
+            report.flag(
+                "yellow",
+                "Token injection test INCONCLUSIVE: every completion probe "
+                "was rejected as Claude Code-client-only. The relay appears "
+                "restricted to Claude Code clients, so hidden prompt injection "
+                "could not be measured.",
+            )
+        else:
+            report.flag(
+                "yellow",
+                f"Token injection test INCONCLUSIVE: all {len(errors)} probes "
+                "errored, so hidden prompt injection could not be measured.",
+            )
+        print("  Done: token injection (inconclusive, all probes errored)")
+        return None
 
     if injection_size > 100:
         report.flag("red", f"Hidden system prompt injection detected (~{injection_size} tokens/request)")
@@ -357,6 +398,8 @@ def test_prompt_extraction(client, report):
 
 def test_instruction_conflict(client, report):
     report.h2("5. Instruction Override Tests")
+    error_messages = []
+    success_count = 0
 
     # Cat test
     report.h3("Test D: Cat Test")
@@ -376,7 +419,10 @@ def test_instruction_conflict(client, report):
         if "422" in str(r.get("error", "")):
             overridden = True
             report.flag("red", "Cat test blocked: relay rejects custom system prompts (HTTP 422)")
+        else:
+            error_messages.append(r.get("error", ""))
     else:
+        success_count += 1
         report.p(f"**input_tokens**: {r['input_tokens']} | **Response**: `{r['text']}`")
         text = r["text"].strip().lower()
         has_meow = "meow" in text
@@ -409,7 +455,10 @@ def test_instruction_conflict(client, report):
         if "422" in str(r.get("error", "")):
             overridden = True
             report.flag("red", "Identity test blocked: relay rejects custom system prompts (HTTP 422)")
+        else:
+            error_messages.append(r.get("error", ""))
     else:
+        success_count += 1
         report.p(f"**input_tokens**: {r['input_tokens']} | **Response**:")
         report.code(r["text"][:500])
         text_lower = r["text"].lower()
@@ -433,6 +482,24 @@ def test_instruction_conflict(client, report):
         else:
             report.flag("yellow", "Identity test inconclusive")
 
+    if success_count == 0 and not overridden:
+        if error_messages and all(_looks_like_claude_code_client_gate(err) for err in error_messages):
+            report.flag(
+                "yellow",
+                "Instruction override test INCONCLUSIVE: both completion "
+                "probes were rejected as Claude Code-client-only. The relay "
+                "appears restricted to Claude Code clients, so user system-"
+                "prompt adherence could not be verified.",
+            )
+        else:
+            report.flag(
+                "yellow",
+                "Instruction override test INCONCLUSIVE: both probes errored, "
+                "so user system-prompt adherence could not be verified.",
+            )
+        print("  Done: instruction conflict (inconclusive, all probes errored)")
+        return None
+
     print(f"  Done: instruction conflict (overridden: {'yes' if overridden else 'no'})")
     return overridden
 
@@ -455,12 +522,16 @@ def test_jailbreak(client, report):
     ]
 
     leaked_keywords = []
+    error_messages = []
+    success_count = 0
     for name, prompt in tests:
         report.h3(f"Test {name}")
         r = client.call([{"role": "user", "content": prompt}], max_tokens=1024)
         if "error" in r:
             report.p(f"Error: {r['error']}")
+            error_messages.append(r.get("error", ""))
         else:
+            success_count += 1
             report.p(f"**input_tokens**: {r['input_tokens']} | **output_tokens**: {r['output_tokens']}")
             report.p("**Response**:")
             report.code(r["text"][:2000])
@@ -509,6 +580,22 @@ def test_jailbreak(client, report):
 
     if leaked_keywords:
         report.p(f"\nInferred hidden prompt characteristics: {', '.join(set(leaked_keywords))}")
+    elif success_count == 0:
+        report.p("\nJailbreak probes did not return any usable completion.")
+        if error_messages and all(_looks_like_claude_code_client_gate(err) for err in error_messages):
+            report.flag(
+                "yellow",
+                "Jailbreak tests INCONCLUSIVE: every completion probe was "
+                "rejected as Claude Code-client-only. The relay appears "
+                "restricted to Claude Code clients, so jailbreak behavior "
+                "could not be verified.",
+            )
+        else:
+            report.flag(
+                "yellow",
+                f"Jailbreak tests INCONCLUSIVE: all {len(error_messages)} "
+                "probes errored, so jailbreak behavior could not be verified.",
+            )
     else:
         report.p("\nJailbreak tests did not extract useful information.")
         report.flag("green", "Jailbreak tests passed (no identity keywords leaked)")

--- a/tests/test_clean_summary_flags.py
+++ b/tests/test_clean_summary_flags.py
@@ -51,6 +51,16 @@ def _mock_client(text: str):
     return client
 
 
+def _error_client(error_text: str):
+    """Build a client whose .call() always returns an error dict."""
+    client = MagicMock()
+    client.call.return_value = {
+        "error": error_text,
+        "time": 0.05,
+    }
+    return client
+
+
 def _summary_levels(reporter):
     """Extract the (level, message) tuples from the reporter summary."""
     return list(reporter.summary)
@@ -183,6 +193,81 @@ class TestJailbreakGreenOnClean:
         assert any("Jailbreak tests passed" in g for g in greens), (
             f"Step 6 clean run in standalone did not emit a green flag. Summary: {levels}"
         )
+
+    def test_modular_all_errors_is_inconclusive_not_green(self, modular, monkeypatch):
+        from api_relay_audit.reporter import Reporter
+        self._time_sleep_patched(monkeypatch, modular)
+        reporter = Reporter()
+        client = _error_client(
+            'HTTP 503: {"error":{"message":"No available accounts: this group only allows Claude Code clients"}}'
+        )
+        modular.test_jailbreak(client, reporter)
+        levels = _summary_levels(reporter)
+        assert any(level == "yellow" and "INCONCLUSIVE" in msg for level, msg in levels), (
+            f"All-error Step 6 run must be inconclusive. Summary: {levels}"
+        )
+        greens = [m for level, m in levels if level == "green" and "Jailbreak tests" in m]
+        assert not greens
+
+    def test_standalone_all_errors_is_inconclusive_not_green(self, standalone, monkeypatch):
+        self._time_sleep_patched(monkeypatch, standalone)
+        reporter = standalone.Reporter()
+        client = _error_client(
+            'HTTP 503: {"error":{"message":"No available accounts: this group only allows Claude Code clients"}}'
+        )
+        standalone.test_jailbreak(client, reporter)
+        levels = list(reporter.summary)
+        assert any(level == "yellow" and "INCONCLUSIVE" in msg for level, msg in levels), (
+            f"All-error Step 6 run in standalone must be inconclusive. Summary: {levels}"
+        )
+        greens = [m for level, m in levels if level == "green" and "Jailbreak tests" in m]
+        assert not greens
+
+
+class TestCompletionGatedRelayInconclusive:
+    GATE_ERROR = (
+        'HTTP 503: {"error":{"message":"No available accounts: '
+        'this group only allows Claude Code clients"}}'
+    )
+
+    def _time_sleep_patched(self, monkeypatch, mod):
+        monkeypatch.setattr(mod, "time", MagicMock(sleep=MagicMock()))
+
+    def test_modular_token_injection_all_errors_returns_none_and_yellow(self, modular, monkeypatch):
+        from api_relay_audit.reporter import Reporter
+        self._time_sleep_patched(monkeypatch, modular)
+        reporter = Reporter()
+        result = modular.test_token_injection(_error_client(self.GATE_ERROR), reporter)
+        assert result is None
+        levels = _summary_levels(reporter)
+        assert any(level == "yellow" and "Token injection test INCONCLUSIVE" in msg for level, msg in levels)
+        assert not any(level == "green" and "No token injection detected" in msg for level, msg in levels)
+
+    def test_standalone_token_injection_all_errors_returns_none_and_yellow(self, standalone, monkeypatch):
+        self._time_sleep_patched(monkeypatch, standalone)
+        reporter = standalone.Reporter()
+        result = standalone.test_token_injection(_error_client(self.GATE_ERROR), reporter)
+        assert result is None
+        levels = list(reporter.summary)
+        assert any(level == "yellow" and "Token injection test INCONCLUSIVE" in msg for level, msg in levels)
+        assert not any(level == "green" and "No token injection detected" in msg for level, msg in levels)
+
+    def test_modular_instruction_override_all_errors_returns_none_and_yellow(self, modular, monkeypatch):
+        from api_relay_audit.reporter import Reporter
+        self._time_sleep_patched(monkeypatch, modular)
+        reporter = Reporter()
+        result = modular.test_instruction_conflict(_error_client(self.GATE_ERROR), reporter)
+        assert result is None
+        levels = _summary_levels(reporter)
+        assert any(level == "yellow" and "Instruction override test INCONCLUSIVE" in msg for level, msg in levels)
+
+    def test_standalone_instruction_override_all_errors_returns_none_and_yellow(self, standalone, monkeypatch):
+        self._time_sleep_patched(monkeypatch, standalone)
+        reporter = standalone.Reporter()
+        result = standalone.test_instruction_conflict(_error_client(self.GATE_ERROR), reporter)
+        assert result is None
+        levels = list(reporter.summary)
+        assert any(level == "yellow" and "Instruction override test INCONCLUSIVE" in msg for level, msg in levels)
 
 
 # ---------------------------------------------------------------------------

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">733</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">739</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## What changed

This PR makes completion-dependent audit steps fail honestly on client-gated relays instead of silently looking clean.

Specifically:
- detect the Claude Code-only gate signature from completion errors
- mark Step 3 token injection as INCONCLUSIVE when every probe errors
- mark Step 5 instruction override as INCONCLUSIVE when both probes error
- mark Step 6 jailbreak as INCONCLUSIVE when every probe errors
- add regression tests for modular + standalone distributions

## Why

Some relays expose `/v1/models` to generic tokens but reject `/v1/messages` unless the caller is the real Claude Code client. Before this change, that failure mode could still produce misleading green flags:
- Step 3 could report `No token injection detected`
- Step 6 could report `Jailbreak tests passed`
- Step 5 could return `False` with no explicit inconclusive summary

That is a semantic bug in an evidence-first audit tool.

## Scope boundary

This PR does **not** impersonate Claude Code headers. That remains out of scope per the repo's documented policy. The fix here is honest downgrade, not protocol spoofing.

## User impact

For Claude Code-gated relays, the report now says the affected checks were inconclusive because generic completion probes could not run. That gives users a truthful result instead of a false clean signal.

## Validation

- `py -m pytest tests/test_clean_summary_flags.py -q`
- `py -m pytest tests/test_dual_distribution_parity.py -q`
- `py -m pytest tests/test_fail_open_step_wrapper.py -q`