### PR TITLE
[codex] Rewrite Step 1 probes for cross-platform hosts

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 38c09737f1d8eb431e34e592abedb8659a81feefb6268a0ed2ccb67de4522580
-# standalone_body_sha256: f223ef0874b1b4f300c33a1568ccac1a679a27286668aac32ee01ad943593b4d
+# source_sha256: 22961a738b9ebc012d9a27931bf2cb002096e404626ee8cacdd6feb5bc412626
+# standalone_body_sha256: b958a39b4bd2b45bfdc13782488e384739424c5839625eb694956008de103015
 # END GENERATED STANDALONE HEADER
 
 """
@@ -4288,12 +4288,16 @@ Usage:
 
 import argparse
 import re
-import shlex
+import shutil
+import socket
+import ssl
 import subprocess
 import sys
 import time
 from pathlib import Path
+from urllib import error as urllib_error
 from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 
 
@@ -4419,6 +4423,159 @@ def _looks_like_claude_code_client_gate(error) -> bool:
     )
 
 
+def _compact_multiline(text, max_lines=6):
+    """Collapse a verbose multi-line tool output into a compact inline string."""
+    if not text:
+        return None
+    lines = [line.strip() for line in str(text).splitlines() if line.strip()]
+    if not lines:
+        return None
+    return " | ".join(lines[:max_lines])
+
+
+def _run_optional_command(argv, timeout=10, max_lines=None):
+    """Run an optional local binary and return combined stdout/stderr text.
+
+    Missing executables are treated as an unavailable signal rather than
+    as a hard error in the report.
+    """
+    if not argv or shutil.which(argv[0]) is None:
+        return None
+    try:
+        r = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except Exception:
+        return None
+    parts = []
+    if r.stdout:
+        parts.append(r.stdout.strip())
+    if r.stderr:
+        parts.append(r.stderr.strip())
+    text = "\n".join(part for part in parts if part).strip()
+    if not text:
+        return None
+    if max_lines is not None:
+        text = "\n".join(text.splitlines()[:max_lines])
+    return text
+
+
+def _resolve_dns_records(domain):
+    """Resolve A records via stdlib and optional CNAME/NS via nslookup."""
+    records = {}
+
+    try:
+        infos = socket.getaddrinfo(domain, None, family=socket.AF_INET, type=socket.SOCK_STREAM)
+        ipv4s = sorted({info[4][0] for info in infos})
+        records["A"] = ", ".join(ipv4s) if ipv4s else "(empty)"
+    except Exception as e:
+        records["A"] = f"error: {e}"
+
+    for rtype in ("CNAME", "NS"):
+        raw = _run_optional_command(["nslookup", f"-type={rtype}", domain], timeout=10, max_lines=20)
+        records[rtype] = _compact_multiline(raw) or "nslookup not available on this host"
+
+    return records
+
+
+def _format_x509_name(name):
+    parts = []
+    for group in name or []:
+        for key, value in group:
+            parts.append(f"{key}={value}")
+    return ", ".join(parts)
+
+
+def _fetch_tls_certificate_summary(domain):
+    """Fetch peer cert metadata without requiring openssl on the host."""
+    context = ssl._create_unverified_context()
+    try:
+        with socket.create_connection((domain, 443), timeout=10) as sock:
+            with context.wrap_socket(sock, server_hostname=domain) as tls_sock:
+                cert = tls_sock.getpeercert()
+    except Exception:
+        return None
+
+    if not cert:
+        return None
+
+    lines = []
+    subject = _format_x509_name(cert.get("subject"))
+    issuer = _format_x509_name(cert.get("issuer"))
+    if subject:
+        lines.append(f"subject={subject}")
+    if issuer:
+        lines.append(f"issuer={issuer}")
+    if cert.get("notBefore"):
+        lines.append(f"notBefore={cert['notBefore']}")
+    if cert.get("notAfter"):
+        lines.append(f"notAfter={cert['notAfter']}")
+    sans = [value for kind, value in cert.get("subjectAltName", []) if kind == "DNS"]
+    if sans:
+        lines.append("subjectAltName=" + ", ".join(sans[:20]))
+    return "\n".join(lines) if lines else None
+
+
+def _response_to_snapshot(resp, read_body=False, max_body_chars=500):
+    body_preview = ""
+    if read_body:
+        try:
+            body_preview = resp.read(max_body_chars).decode("utf-8", errors="replace")
+        except Exception:
+            body_preview = ""
+    return {
+        "status": getattr(resp, "status", None) or getattr(resp, "code", None),
+        "url": resp.geturl() if hasattr(resp, "geturl") else None,
+        "headers": dict(resp.headers.items()) if getattr(resp, "headers", None) else {},
+        "body_preview": body_preview,
+    }
+
+
+def _fetch_http_snapshot(url, method="GET", max_body_chars=500):
+    """Fetch headers/body preview via stdlib urllib instead of curl/head."""
+    request = Request(
+        url,
+        headers={"User-Agent": "api-relay-audit/step1"},
+        method=method,
+    )
+    context = ssl._create_unverified_context() if url.lower().startswith("https://") else None
+    try:
+        with urlopen(request, timeout=10, context=context) as resp:
+            return _response_to_snapshot(
+                resp,
+                read_body=(method != "HEAD"),
+                max_body_chars=max_body_chars,
+            )
+    except urllib_error.HTTPError as e:
+        return _response_to_snapshot(
+            e,
+            read_body=(method != "HEAD"),
+            max_body_chars=max_body_chars,
+        )
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _format_http_headers(snapshot, limit=20):
+    if not snapshot or snapshot.get("error"):
+        return None
+    lines = []
+    status = snapshot.get("status")
+    final_url = snapshot.get("url")
+    if status or final_url:
+        label = f"HTTP {status}" if status else "HTTP"
+        if final_url:
+            label += f" {final_url}"
+        lines.append(label)
+    for idx, (key, value) in enumerate(snapshot.get("headers", {}).items()):
+        if idx >= limit:
+            break
+        lines.append(f"{key}: {value}")
+    return "\n".join(lines) if lines else None
+
+
+def _lookup_whois(domain):
+    return _run_optional_command(["whois", domain], timeout=10, max_lines=30)
+
+
 # ============================================================
 # Test modules
 # ============================================================
@@ -4426,39 +4583,37 @@ def _looks_like_claude_code_client_gate(error) -> bool:
 def test_infrastructure(base_url, report):
     report.h2("1. Infrastructure Recon")
     domain = urlparse(base_url).hostname
-    q_domain = shlex.quote(domain)
-    q_url = shlex.quote(base_url)
 
     # DNS
     report.h3("1.1 DNS Records")
+    dns_records = _resolve_dns_records(domain)
     for rtype in ["A", "CNAME", "NS"]:
-        result = run_cmd(f"dig +short {q_domain} {rtype} 2>/dev/null || nslookup -type={rtype} {q_domain} 2>/dev/null")
-        report.p(f"**{rtype}**: `{result or '(empty)'}`")
+        report.p(f"**{rtype}**: `{dns_records.get(rtype, '(empty)')}`")
 
     # WHOIS
     report.h3("1.2 WHOIS")
     parts = domain.split(".")
     main_domain = ".".join(parts[-2:]) if len(parts) >= 2 else domain
-    q_main_domain = shlex.quote(main_domain)
-    whois = run_cmd(f"whois {q_main_domain} 2>/dev/null | head -30")
-    report.code(whois) if whois else report.p("whois not available")
+    whois = _lookup_whois(main_domain)
+    report.code(whois) if whois else report.p("whois not available on this host")
 
     # SSL
     report.h3("1.3 SSL Certificate")
-    ssl_info = run_cmd(
-        f"echo | openssl s_client -connect {q_domain}:443 -servername {q_domain} 2>/dev/null "
-        f"| openssl x509 -noout -subject -issuer -dates -ext subjectAltName 2>/dev/null"
-    )
+    ssl_info = _fetch_tls_certificate_summary(domain)
     report.code(ssl_info) if ssl_info else report.p("Unable to retrieve SSL certificate")
 
     # HTTP headers
     report.h3("1.4 HTTP Response Headers")
-    headers = run_cmd(f"curl -sI {q_url} 2>/dev/null | head -20")
+    headers_snapshot = _fetch_http_snapshot(base_url, method="HEAD")
+    if headers_snapshot.get("error"):
+        headers_snapshot = _fetch_http_snapshot(base_url, method="GET")
+    headers = _format_http_headers(headers_snapshot)
     report.code(headers) if headers else report.p("Unable to retrieve response headers")
 
     # System identification
     report.h3("1.5 System Identification")
-    homepage = run_cmd(f"curl -s {q_url} 2>/dev/null | head -5")
+    homepage_snapshot = _fetch_http_snapshot(base_url, method="GET")
+    homepage = homepage_snapshot.get("body_preview") if homepage_snapshot else None
     if homepage:
         report.code(homepage[:500])
 

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,8 +16,8 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **739** | `pytest --collect-only` |
-| 测试数 (static) | 720 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **741** | `pytest --collect-only` |
+| 测试数 (static) | 722 | grep `def test_*` in tests/ |
 | CLI flag 数 | 20 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-07 | `ROADMAP.md` 头部 |
@@ -25,14 +25,14 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `01d4682` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `7d90163` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-07 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
-- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 739。要么 ROADMAP 漏更新，要么有未记录的新测试。
+- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 741。要么 ROADMAP 漏更新，要么有未记录的新测试。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -19,12 +19,16 @@ Usage:
 
 import argparse
 import re
-import shlex
+import shutil
+import socket
+import ssl
 import subprocess
 import sys
 import time
 from pathlib import Path
+from urllib import error as urllib_error
 from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 # Allow importing from parent directory
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -185,6 +189,159 @@ def _looks_like_claude_code_client_gate(error) -> bool:
     )
 
 
+def _compact_multiline(text, max_lines=6):
+    """Collapse a verbose multi-line tool output into a compact inline string."""
+    if not text:
+        return None
+    lines = [line.strip() for line in str(text).splitlines() if line.strip()]
+    if not lines:
+        return None
+    return " | ".join(lines[:max_lines])
+
+
+def _run_optional_command(argv, timeout=10, max_lines=None):
+    """Run an optional local binary and return combined stdout/stderr text.
+
+    Missing executables are treated as an unavailable signal rather than
+    as a hard error in the report.
+    """
+    if not argv or shutil.which(argv[0]) is None:
+        return None
+    try:
+        r = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except Exception:
+        return None
+    parts = []
+    if r.stdout:
+        parts.append(r.stdout.strip())
+    if r.stderr:
+        parts.append(r.stderr.strip())
+    text = "\n".join(part for part in parts if part).strip()
+    if not text:
+        return None
+    if max_lines is not None:
+        text = "\n".join(text.splitlines()[:max_lines])
+    return text
+
+
+def _resolve_dns_records(domain):
+    """Resolve A records via stdlib and optional CNAME/NS via nslookup."""
+    records = {}
+
+    try:
+        infos = socket.getaddrinfo(domain, None, family=socket.AF_INET, type=socket.SOCK_STREAM)
+        ipv4s = sorted({info[4][0] for info in infos})
+        records["A"] = ", ".join(ipv4s) if ipv4s else "(empty)"
+    except Exception as e:
+        records["A"] = f"error: {e}"
+
+    for rtype in ("CNAME", "NS"):
+        raw = _run_optional_command(["nslookup", f"-type={rtype}", domain], timeout=10, max_lines=20)
+        records[rtype] = _compact_multiline(raw) or "nslookup not available on this host"
+
+    return records
+
+
+def _format_x509_name(name):
+    parts = []
+    for group in name or []:
+        for key, value in group:
+            parts.append(f"{key}={value}")
+    return ", ".join(parts)
+
+
+def _fetch_tls_certificate_summary(domain):
+    """Fetch peer cert metadata without requiring openssl on the host."""
+    context = ssl._create_unverified_context()
+    try:
+        with socket.create_connection((domain, 443), timeout=10) as sock:
+            with context.wrap_socket(sock, server_hostname=domain) as tls_sock:
+                cert = tls_sock.getpeercert()
+    except Exception:
+        return None
+
+    if not cert:
+        return None
+
+    lines = []
+    subject = _format_x509_name(cert.get("subject"))
+    issuer = _format_x509_name(cert.get("issuer"))
+    if subject:
+        lines.append(f"subject={subject}")
+    if issuer:
+        lines.append(f"issuer={issuer}")
+    if cert.get("notBefore"):
+        lines.append(f"notBefore={cert['notBefore']}")
+    if cert.get("notAfter"):
+        lines.append(f"notAfter={cert['notAfter']}")
+    sans = [value for kind, value in cert.get("subjectAltName", []) if kind == "DNS"]
+    if sans:
+        lines.append("subjectAltName=" + ", ".join(sans[:20]))
+    return "\n".join(lines) if lines else None
+
+
+def _response_to_snapshot(resp, read_body=False, max_body_chars=500):
+    body_preview = ""
+    if read_body:
+        try:
+            body_preview = resp.read(max_body_chars).decode("utf-8", errors="replace")
+        except Exception:
+            body_preview = ""
+    return {
+        "status": getattr(resp, "status", None) or getattr(resp, "code", None),
+        "url": resp.geturl() if hasattr(resp, "geturl") else None,
+        "headers": dict(resp.headers.items()) if getattr(resp, "headers", None) else {},
+        "body_preview": body_preview,
+    }
+
+
+def _fetch_http_snapshot(url, method="GET", max_body_chars=500):
+    """Fetch headers/body preview via stdlib urllib instead of curl/head."""
+    request = Request(
+        url,
+        headers={"User-Agent": "api-relay-audit/step1"},
+        method=method,
+    )
+    context = ssl._create_unverified_context() if url.lower().startswith("https://") else None
+    try:
+        with urlopen(request, timeout=10, context=context) as resp:
+            return _response_to_snapshot(
+                resp,
+                read_body=(method != "HEAD"),
+                max_body_chars=max_body_chars,
+            )
+    except urllib_error.HTTPError as e:
+        return _response_to_snapshot(
+            e,
+            read_body=(method != "HEAD"),
+            max_body_chars=max_body_chars,
+        )
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _format_http_headers(snapshot, limit=20):
+    if not snapshot or snapshot.get("error"):
+        return None
+    lines = []
+    status = snapshot.get("status")
+    final_url = snapshot.get("url")
+    if status or final_url:
+        label = f"HTTP {status}" if status else "HTTP"
+        if final_url:
+            label += f" {final_url}"
+        lines.append(label)
+    for idx, (key, value) in enumerate(snapshot.get("headers", {}).items()):
+        if idx >= limit:
+            break
+        lines.append(f"{key}: {value}")
+    return "\n".join(lines) if lines else None
+
+
+def _lookup_whois(domain):
+    return _run_optional_command(["whois", domain], timeout=10, max_lines=30)
+
+
 # ============================================================
 # Test modules
 # ============================================================
@@ -192,39 +349,37 @@ def _looks_like_claude_code_client_gate(error) -> bool:
 def test_infrastructure(base_url, report):
     report.h2("1. Infrastructure Recon")
     domain = urlparse(base_url).hostname
-    q_domain = shlex.quote(domain)
-    q_url = shlex.quote(base_url)
 
     # DNS
     report.h3("1.1 DNS Records")
+    dns_records = _resolve_dns_records(domain)
     for rtype in ["A", "CNAME", "NS"]:
-        result = run_cmd(f"dig +short {q_domain} {rtype} 2>/dev/null || nslookup -type={rtype} {q_domain} 2>/dev/null")
-        report.p(f"**{rtype}**: `{result or '(empty)'}`")
+        report.p(f"**{rtype}**: `{dns_records.get(rtype, '(empty)')}`")
 
     # WHOIS
     report.h3("1.2 WHOIS")
     parts = domain.split(".")
     main_domain = ".".join(parts[-2:]) if len(parts) >= 2 else domain
-    q_main_domain = shlex.quote(main_domain)
-    whois = run_cmd(f"whois {q_main_domain} 2>/dev/null | head -30")
-    report.code(whois) if whois else report.p("whois not available")
+    whois = _lookup_whois(main_domain)
+    report.code(whois) if whois else report.p("whois not available on this host")
 
     # SSL
     report.h3("1.3 SSL Certificate")
-    ssl_info = run_cmd(
-        f"echo | openssl s_client -connect {q_domain}:443 -servername {q_domain} 2>/dev/null "
-        f"| openssl x509 -noout -subject -issuer -dates -ext subjectAltName 2>/dev/null"
-    )
+    ssl_info = _fetch_tls_certificate_summary(domain)
     report.code(ssl_info) if ssl_info else report.p("Unable to retrieve SSL certificate")
 
     # HTTP headers
     report.h3("1.4 HTTP Response Headers")
-    headers = run_cmd(f"curl -sI {q_url} 2>/dev/null | head -20")
+    headers_snapshot = _fetch_http_snapshot(base_url, method="HEAD")
+    if headers_snapshot.get("error"):
+        headers_snapshot = _fetch_http_snapshot(base_url, method="GET")
+    headers = _format_http_headers(headers_snapshot)
     report.code(headers) if headers else report.p("Unable to retrieve response headers")
 
     # System identification
     report.h3("1.5 System Identification")
-    homepage = run_cmd(f"curl -s {q_url} 2>/dev/null | head -5")
+    homepage_snapshot = _fetch_http_snapshot(base_url, method="GET")
+    homepage = homepage_snapshot.get("body_preview") if homepage_snapshot else None
     if homepage:
         report.code(homepage[:500])
 

--- a/tests/test_step1_cross_platform.py
+++ b/tests/test_step1_cross_platform.py
@@ -1,0 +1,82 @@
+"""Regression tests for Step 1 cross-platform infrastructure recon.
+
+The old implementation shell-piped through ``dig``, ``whois``, ``openssl``,
+``curl``, and ``head``. On Windows hosts missing those POSIX tools, the
+report surfaced raw shell failure text like ``The system cannot find the
+path specified.`` instead of a human-readable fallback.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load(module_path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def modular():
+    return _load(REPO_ROOT / "scripts" / "audit.py", "modular_audit_step1_xplat")
+
+
+@pytest.fixture(scope="module")
+def standalone():
+    return _load(REPO_ROOT / "audit.py", "standalone_audit_step1_xplat")
+
+
+def _render_step1(mod, monkeypatch):
+    monkeypatch.setattr(
+        mod,
+        "_resolve_dns_records",
+        lambda domain: {
+            "A": "203.0.113.10",
+            "CNAME": "nslookup not available on this host",
+            "NS": "nslookup not available on this host",
+        },
+    )
+    monkeypatch.setattr(mod, "_lookup_whois", lambda domain: None)
+    monkeypatch.setattr(mod, "_fetch_tls_certificate_summary", lambda domain: None)
+
+    def fake_http_snapshot(url, method="GET", max_body_chars=500):
+        if method == "HEAD":
+            return {"error": "method not allowed"}
+        return {
+            "status": 200,
+            "url": url,
+            "headers": {"server": "Caddy", "content-type": "text/html"},
+            "body_preview": "<html><title>relay</title></html>",
+        }
+
+    monkeypatch.setattr(mod, "_fetch_http_snapshot", fake_http_snapshot)
+
+    reporter = mod.Reporter()
+    mod.test_infrastructure("https://relay.example.com/v1", reporter)
+    return reporter.render(target_url="https://relay.example.com/v1", model="claude-opus-4-6")
+
+
+def test_modular_step1_uses_human_fallbacks(monkeypatch, modular):
+    md = _render_step1(modular, monkeypatch)
+    assert "whois not available on this host" in md
+    assert "nslookup not available on this host" in md
+    assert "Unable to retrieve SSL certificate" in md
+    assert "HTTP 200 https://relay.example.com/v1" in md
+    assert "<html><title>relay</title></html>" in md
+    assert "The system cannot find the path specified." not in md
+
+
+def test_standalone_step1_uses_human_fallbacks(monkeypatch, standalone):
+    md = _render_step1(standalone, monkeypatch)
+    assert "whois not available on this host" in md
+    assert "nslookup not available on this host" in md
+    assert "Unable to retrieve SSL certificate" in md
+    assert "HTTP 200 https://relay.example.com/v1" in md
+    assert "<html><title>relay</title></html>" in md
+    assert "The system cannot find the path specified." not in md

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">739</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">741</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## What changed

This PR rewrites Step 1 infrastructure recon to use cross-platform probes instead of POSIX shell pipelines.

Specifically:
- replace `dig ... || nslookup ...`, `whois | head`, `openssl s_client | openssl x509`, and `curl | head` in Step 1
- resolve A records with Python stdlib socket APIs
- use optional `nslookup` / `whois` only when present, with explicit human fallback text when missing
- fetch TLS certificate metadata with Python `ssl` + `socket`
- fetch HTTP headers and homepage preview with stdlib `urllib`
- add regression tests for modular + standalone distributions

## Why

On Windows hosts without POSIX tooling, Step 1 could dump raw shell failure text like `The system cannot find the path specified.` into the report. That looks broken and makes the infra section noisy even when the rest of the audit is fine.

The audit should degrade gracefully when optional host tools are absent.

## User impact

Step 1 now:
- works on Windows without requiring `dig`, `whois`, `openssl`, `curl`, or `head`
- still uses `nslookup` / `whois` when available
- emits clear fallback text like `whois not available on this host` instead of shell noise

## Validation

- `py scripts/build-standalone.py`
- `py -m pytest tests/test_step1_cross_platform.py tests/test_dual_distribution_parity.py -q`