### PR TITLE
[codex] fix curl loopback proxy routing

### DIFF
--- a/api_relay_audit/_transport.py
+++ b/api_relay_audit/_transport.py
@@ -9,8 +9,19 @@ import json
 import os
 import subprocess
 import tempfile
+from urllib.parse import urlparse
 
 import httpx
+
+LOOPBACK_NO_PROXY = "localhost,127.0.0.1,::1"
+LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def curl_loopback_no_proxy_args(url: str) -> list:
+    """Return curl args that keep loopback URLs out of proxy env routing."""
+    if urlparse(url).hostname in LOOPBACK_HOSTS:
+        return ["--noproxy", LOOPBACK_NO_PROXY]
+    return []
 
 
 def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
@@ -30,8 +41,8 @@ def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
             json.dump(body, tmp)
             body_path = tmp.name
 
-        cmd = ["curl", "-sk", "-X", "POST", url, "--max-time", str(timeout),
-               "--config", "-", "--data-binary", f"@{body_path}"]
+        cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), "-X", "POST", url,
+               "--max-time", str(timeout), "--config", "-", "--data-binary", f"@{body_path}"]
         config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
         r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
                                   timeout=timeout + 10)
@@ -59,7 +70,8 @@ def httpx_post_json(url: str, headers: dict, body: dict, timeout: int,
 def curl_get_json_data(url: str, headers: dict, timeout: int = 15,
                        subprocess_module=subprocess) -> list:
     """GET JSON through curl and return the top-level ``data`` list."""
-    cmd = ["curl", "-sk", url, "--max-time", str(timeout), "--config", "-"]
+    cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), url,
+           "--max-time", str(timeout), "--config", "-"]
     config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
     r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
                               timeout=timeout + 10)
@@ -104,7 +116,7 @@ def curl_raw_request(method: str, url: str, headers: dict, body: bytes,
                      subprocess_module=subprocess) -> dict:
     """Raw request through curl and parse ``curl -i`` output with ``parser``."""
     all_headers = {**headers, "content-type": content_type}
-    cmd = ["curl", "-sk", "-i", "-X", method, url,
+    cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), "-i", "-X", method, url,
            "--max-time", str(timeout), "--data-binary", "@-"]
     for k, v in all_headers.items():
         cmd.extend(["-H", f"{k}: {v}"])

--- a/api_relay_audit/client.py
+++ b/api_relay_audit/client.py
@@ -845,7 +845,8 @@ class APIClient:
         incremental stream.
         """
         cmd = [
-            "curl", "-sk", "-N", "--no-buffer", "-X", "POST", url,
+            "curl", "-sk", *_transport.curl_loopback_no_proxy_args(url),
+            "-N", "--no-buffer", "-X", "POST", url,
             "--max-time", str(timeout),
             "-w", f"\n{CURL_STATUS_SENTINEL}%{{http_code}}\n",
             "--data-binary", "@-",

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 49447d8ba16907a029aaf44fb92364e00eabbef083cfd68efedef200dbf24767
-# standalone_body_sha256: 7f03317771b8483a30f169ad76de55086660d4106fe43984f8a9c1d9f09a152c
+# source_sha256: 213c1893304b908d9beec00f7b0d48a465fc6aefe0510a102f5f1969fa4baf1f
+# standalone_body_sha256: 0418bf14fcedf7a7d3308f8a045c6ec1b4d1ec0a7eb0d9c3e141b4cda2febded
 # END GENERATED STANDALONE HEADER
 
 """
@@ -550,7 +550,18 @@ import json
 import os
 import subprocess
 import tempfile
+from urllib.parse import urlparse
 
+
+LOOPBACK_NO_PROXY = "localhost,127.0.0.1,::1"
+LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+
+def curl_loopback_no_proxy_args(url: str) -> list:
+    """Return curl args that keep loopback URLs out of proxy env routing."""
+    if urlparse(url).hostname in LOOPBACK_HOSTS:
+        return ["--noproxy", LOOPBACK_NO_PROXY]
+    return []
 
 
 def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
@@ -570,8 +581,8 @@ def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
             json.dump(body, tmp)
             body_path = tmp.name
 
-        cmd = ["curl", "-sk", "-X", "POST", url, "--max-time", str(timeout),
-               "--config", "-", "--data-binary", f"@{body_path}"]
+        cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), "-X", "POST", url,
+               "--max-time", str(timeout), "--config", "-", "--data-binary", f"@{body_path}"]
         config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
         r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
                                   timeout=timeout + 10)
@@ -592,7 +603,8 @@ def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
 def curl_get_json_data(url: str, headers: dict, timeout: int = 15,
                        subprocess_module=subprocess) -> list:
     """GET JSON through curl and return the top-level ``data`` list."""
-    cmd = ["curl", "-sk", url, "--max-time", str(timeout), "--config", "-"]
+    cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), url,
+           "--max-time", str(timeout), "--config", "-"]
     config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
     r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
                               timeout=timeout + 10)
@@ -610,7 +622,7 @@ def curl_raw_request(method: str, url: str, headers: dict, body: bytes,
                      subprocess_module=subprocess) -> dict:
     """Raw request through curl and parse ``curl -i`` output with ``parser``."""
     all_headers = {**headers, "content-type": content_type}
-    cmd = ["curl", "-sk", "-i", "-X", method, url,
+    cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), "-i", "-X", method, url,
            "--max-time", str(timeout), "--data-binary", "@-"]
     for k, v in all_headers.items():
         cmd.extend(["-H", f"{k}: {v}"])
@@ -1507,7 +1519,8 @@ class APIClient:
         incremental stream.
         """
         cmd = [
-            "curl", "-sk", "-N", "--no-buffer", "-X", "POST", url,
+            "curl", "-sk", *_transport.curl_loopback_no_proxy_args(url),
+            "-N", "--no-buffer", "-X", "POST", url,
             "--max-time", str(timeout),
             "-w", f"\n{CURL_STATUS_SENTINEL}%{{http_code}}\n",
             "--data-binary", "@-",

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 213c1893304b908d9beec00f7b0d48a465fc6aefe0510a102f5f1969fa4baf1f
-# standalone_body_sha256: 0418bf14fcedf7a7d3308f8a045c6ec1b4d1ec0a7eb0d9c3e141b4cda2febded
+# source_sha256: 04b7aa16a85d6094d6b0d5f1fd16e110bc1db1d84c33b59231776ffd2e7da60c
+# standalone_body_sha256: 30cecedb64e88021d8876affa1104de2dfbe431913e19c37ad524e2edb38a614
 # END GENERATED STANDALONE HEADER
 
 """
@@ -645,7 +645,10 @@ def httpx_post_json(url: str, headers: dict, body: dict, timeout: int) -> dict:
 
 def httpx_get_json_data(url: str, headers: dict, timeout: int = 15):
     """Standalone compatibility wrapper: GET JSON through curl -i."""
-    cmd = ["curl", "-sk", "-i", url, "--max-time", str(timeout), "--config", "-"]
+    cmd = [
+        "curl", "-sk", *curl_loopback_no_proxy_args(url),
+        "-i", url, "--max-time", str(timeout), "--config", "-"
+    ]
     config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
     r = subprocess.run(
         cmd,
@@ -683,6 +686,7 @@ def httpx_raw_request(method: str, url: str, headers: dict, body: bytes,
 
 
 class _StandaloneTransport:
+    curl_loopback_no_proxy_args = staticmethod(curl_loopback_no_proxy_args)
     curl_post_json = staticmethod(curl_post_json)
     httpx_post_json = staticmethod(httpx_post_json)
     curl_get_json_data = staticmethod(curl_get_json_data)

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,8 +16,8 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **708** | `pytest --collect-only` |
-| 测试数 (static) | 689 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **709** | `pytest --collect-only` |
+| 测试数 (static) | 690 | grep `def test_*` in tests/ |
 | CLI flag 数 | 20 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-01 | `ROADMAP.md` 头部 |
@@ -25,14 +25,14 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `d6a2967` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `2c1dd3c` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-03 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
-- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 708。要么 ROADMAP 漏更新，要么有未记录的新测试。
+- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 709。要么 ROADMAP 漏更新，要么有未记录的新测试。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,8 +16,8 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **709** | `pytest --collect-only` |
-| 测试数 (static) | 690 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **714** | `pytest --collect-only` |
+| 测试数 (static) | 695 | grep `def test_*` in tests/ |
 | CLI flag 数 | 20 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-01 | `ROADMAP.md` 头部 |
@@ -25,14 +25,14 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `2c1dd3c` | recent reachable commit; `--check` allows follow-up metrics commits |
-| Recorded commit date | 2026-06-03 | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `0d87641` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit date | 2026-06-05 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
-- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 709。要么 ROADMAP 漏更新，要么有未记录的新测试。
+- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 714。要么 ROADMAP 漏更新，要么有未记录的新测试。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/scripts/build-standalone.py
+++ b/scripts/build-standalone.py
@@ -87,7 +87,10 @@ def httpx_post_json(url: str, headers: dict, body: dict, timeout: int) -> dict:
 
 def httpx_get_json_data(url: str, headers: dict, timeout: int = 15):
     """Standalone compatibility wrapper: GET JSON through curl -i."""
-    cmd = ["curl", "-sk", "-i", url, "--max-time", str(timeout), "--config", "-"]
+    cmd = [
+        "curl", "-sk", *curl_loopback_no_proxy_args(url),
+        "-i", url, "--max-time", str(timeout), "--config", "-"
+    ]
     config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
     r = subprocess.run(
         cmd,
@@ -125,6 +128,7 @@ def httpx_raw_request(method: str, url: str, headers: dict, body: bytes,
 
 
 class _StandaloneTransport:
+    curl_loopback_no_proxy_args = staticmethod(curl_loopback_no_proxy_args)
     curl_post_json = staticmethod(curl_post_json)
     httpx_post_json = staticmethod(httpx_post_json)
     curl_get_json_data = staticmethod(curl_get_json_data)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -320,12 +320,31 @@ class TestCurlFallback:
         assert "https://relay.example.com/v1/messages" in cmd
         assert "--config" in cmd
         assert "-" in cmd
+        assert "--noproxy" not in cmd
         assert "--data-binary" in cmd
         body_arg = cmd[cmd.index("--data-binary") + 1]
         assert body_arg.startswith("@")
         assert '{"model": "test"}' not in cmd
         config_input = mock_run.call_args[1].get("input", "")
         assert "x-api-key: sk-test" in config_input
+
+    @patch("api_relay_audit.client.subprocess.run")
+    def test_curl_post_bypasses_proxy_for_loopback(self, mock_run, client):
+        client._use_curl = True
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='{"ok": true}',
+        )
+
+        client._curl_post(
+            "http://127.0.0.1:8765/v1/messages",
+            {"content-type": "application/json"},
+            {"model": "test"},
+        )
+
+        cmd = mock_run.call_args[0][0]
+        assert "--noproxy" in cmd
+        assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -346,6 +346,52 @@ class TestCurlFallback:
         assert "--noproxy" in cmd
         assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
 
+    @patch("api_relay_audit.client.subprocess.run")
+    def test_curl_get_models_bypasses_proxy_for_loopback(self, mock_run):
+        client = APIClient(
+            base_url="http://localhost:8765/v1",
+            api_key="sk-test-key",
+            model="claude-3-haiku",
+            timeout=30,
+            verbose=False,
+        )
+        client._use_curl = True
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"data": [{"id": "claude-opus-4-6"}]}),
+        )
+
+        assert client.get_models() == [{"id": "claude-opus-4-6"}]
+
+        cmd = mock_run.call_args[0][0]
+        assert "--noproxy" in cmd
+        assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
+
+    @patch("api_relay_audit.client.subprocess.run")
+    def test_curl_raw_request_bypasses_proxy_for_loopback(self, mock_run):
+        client = APIClient(
+            base_url="http://127.0.0.1:8765/v1",
+            api_key="sk-test-key",
+            model="claude-3-haiku",
+            timeout=30,
+            verbose=False,
+        )
+        client._use_curl = True
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=b"HTTP/1.1 400 Bad Request\r\nX-Test: yes\r\n\r\nbad",
+            stderr=b"",
+        )
+
+        result = client.raw_request(
+            "POST", "/v1/messages", {}, b"{}", timeout=3,
+        )
+
+        assert result["status"] == 400
+        cmd = mock_run.call_args[0][0]
+        assert "--noproxy" in cmd
+        assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
+
 
 # ---------------------------------------------------------------------------
 # Auto-detection flow

--- a/tests/test_client_stream.py
+++ b/tests/test_client_stream.py
@@ -600,6 +600,39 @@ class TestCurlNonzeroExitHandling:
         assert signals.has_message_start is True
         assert signals.raw_event_count == 1
 
+    def test_curl_stream_bypasses_proxy_for_loopback(self):
+        captured_cmds = []
+
+        def mock_popen_factory(cmd, *args, **kwargs):
+            captured_cmds.append(cmd)
+            proc = MagicMock()
+            proc.stdin = MagicMock()
+            proc.stdout = BytesIO(
+                b'data: {"type":"message_start","message":{"model":"claude-opus-4-6"}}\n'
+                b"\n"
+                b"data: [DONE]\n\n"
+            )
+            proc.stderr = BytesIO(b"")
+            proc.wait = MagicMock(return_value=None)
+            proc.returncode = 0
+            return proc
+
+        with patch("api_relay_audit.client.subprocess.Popen",
+                   side_effect=mock_popen_factory):
+            client = APIClient(
+                "http://localhost:8765/v1", "sk-test", "claude-opus-4-6",
+                verbose=False,
+            )
+            client._use_curl = True
+            signals = client.stream_call(
+                [{"role": "user", "content": "hi"}],
+            )
+
+        assert signals.transport_error is None
+        cmd = captured_cmds[0]
+        assert "--noproxy" in cmd
+        assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
+
 
 # ---------------------------------------------------------------------------
 # APIClient.stream_call (integration tests with mocked httpx)

--- a/tests/test_dual_distribution_parity.py
+++ b/tests/test_dual_distribution_parity.py
@@ -665,3 +665,77 @@ def test_standalone_curl_post_keeps_large_body_out_of_argv(monkeypatch):
     assert "x" * 100 not in cmd_text
     assert "sk-test" not in cmd_text
     assert "x-api-key: sk-test" in kwargs["input"]
+
+
+def test_standalone_get_models_bypasses_proxy_for_loopback(monkeypatch):
+    """Standalone model-list GET must keep loopback URLs out of proxy env routing."""
+    standalone = _load_standalone_audit()
+    calls = []
+
+    class FakeRunResult:
+        returncode = 0
+        stdout = (
+            'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n'
+            '{"data":[{"id":"claude-opus-4-6"}]}'
+        )
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return FakeRunResult()
+
+    monkeypatch.setattr(standalone.subprocess, "run", fake_run)
+
+    status, data, text, headers = standalone.httpx_get_json_data(
+        "http://localhost:8765/v1/models",
+        {"Authorization": "Bearer sk-test"},
+        timeout=3,
+    )
+
+    assert status == 200
+    assert data == [{"id": "claude-opus-4-6"}]
+    cmd, _kwargs = calls[0]
+    assert "--noproxy" in cmd
+    assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
+    assert standalone._transport.curl_loopback_no_proxy_args(
+        "http://127.0.0.1:8765/v1/messages"
+    ) == ["--noproxy", "localhost,127.0.0.1,::1"]
+
+
+def test_standalone_stream_bypasses_proxy_for_loopback(monkeypatch):
+    """Standalone SSE curl path uses the same loopback proxy bypass facade."""
+    from io import BytesIO
+    from unittest.mock import MagicMock
+
+    standalone = _load_standalone_audit()
+    captured_cmds = []
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured_cmds.append(cmd)
+        proc = MagicMock()
+        proc.stdin = MagicMock()
+        proc.stdout = BytesIO(
+            b'data: {"type":"message_start","message":{"model":"claude-opus-4-6"}}\n'
+            b"\n"
+            b"data: [DONE]\n\n"
+        )
+        proc.stderr = BytesIO(b"")
+        proc.wait = MagicMock(return_value=None)
+        proc.returncode = 0
+        return proc
+
+    monkeypatch.setattr(standalone.subprocess, "Popen", fake_popen)
+
+    client = standalone.APIClient(
+        "http://localhost:8765/v1",
+        "sk-test",
+        "claude-opus-4-6",
+        verbose=False,
+    )
+    client._use_curl = True
+    signals = client.stream_call([{"role": "user", "content": "hi"}])
+
+    assert signals.transport_error is None
+    cmd = captured_cmds[0]
+    assert "--noproxy" in cmd
+    assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">709</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">714</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">708</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">709</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## Summary
- add loopback-only `--noproxy localhost,127.0.0.1,::1` args for curl transports
- apply the bypass to JSON POST, JSON GET, raw curl requests, and streaming curl calls
- add a focused regression test and refresh standalone/metrics generated outputs

## Root cause
On Windows machines with `HTTP_PROXY` / `HTTPS_PROXY` set and no `NO_PROXY`, real curl honors the proxy environment even for `http://127.0.0.1:<port>`. The loopback SSE test server never receives the request, so the curl streaming path exits with a transport error.

This is not a Windows loopback networking impossibility. Direct curl succeeds when proxy routing is bypassed with `--noproxy` or when `NO_PROXY` includes loopback hosts.

## Validation
- `python -m pytest tests/test_client.py::TestCurlFallback -q`
- `python -m pytest tests/test_client_stream.py::TestStreamCallCurlIntegration::test_real_curl_handles_short_sse_frames_from_loopback_server -q`
- `python -m pytest tests/test_dual_distribution_parity.py tests/test_client.py tests/test_client_stream.py -q`
- `python scripts/build-standalone.py --check`
- `python scripts/collect-metrics.py --check`
- `python -m pytest -q` (`709 passed`)