### PR TITLE
[codex] fix Hermes Windows platform metadata

### DIFF
--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,8 +16,8 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **714** | `pytest --collect-only` |
-| 测试数 (static) | 695 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **715** | `pytest --collect-only` |
+| 测试数 (static) | 696 | grep `def test_*` in tests/ |
 | CLI flag 数 | 20 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-01 | `ROADMAP.md` 头部 |
@@ -25,14 +25,14 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `0d87641` | recent reachable commit; `--check` allows follow-up metrics commits |
-| Recorded commit date | 2026-06-05 | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `df621b4` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit date | 2026-06-06 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
-- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 714。要么 ROADMAP 漏更新，要么有未记录的新测试。
+- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 715。要么 ROADMAP 漏更新，要么有未记录的新测试。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/docs/skill-distribution.md
+++ b/docs/skill-distribution.md
@@ -18,6 +18,10 @@ Both files must stay aligned with the current audit surface:
 - local-first execution
 - API key not repeated in chat, logs, filenames, or public comments
 - no claim that a relay is certified safe
+- Hermes platform support includes Linux, macOS, and Windows. The Windows
+  contract is Python 3 + `curl` with Git Bash or an equivalent POSIX shell for
+  the one-shot recipe; direct local `python audit.py ...` commands can also run
+  from PowerShell.
 
 The skill files are versioned distribution artifacts, so their `audit.py`
 download commands must use an immutable tag or commit SHA. Do not publish a
@@ -101,6 +105,10 @@ Post-publish verification:
 hermes skills list | grep api-relay-audit
 hermes chat --toolsets skills -q "Use the api-relay-audit skill to explain how to audit a relay without exposing my API key."
 ```
+
+Windows dogfood must also verify that Hermes can load the installed skill, not
+just install it. A successful direct install followed by a platform-gated
+`skill_view` failure is a distribution bug.
 
 ## Search Positioning
 

--- a/skills/api-relay-audit/SKILL.md
+++ b/skills/api-relay-audit/SKILL.md
@@ -4,7 +4,7 @@ description: Use when auditing third-party AI API relays, proxy APIs, or API-key
 version: 2.3.0
 author: Toby Bridges
 license: AGPL-3.0-only
-platforms: [linux, macos]
+platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [security, red-teaming, ai-safety, api-relay, web3]
@@ -22,7 +22,7 @@ required_environment_variables:
 
 This skill runs `api-relay-audit`, a zero-dependency security audit for third-party AI API relays and proxy services. It checks whether the relay tampers with prompts, truncates context, rewrites package-install instructions, leaks upstream credentials or internal headers, corrupts Anthropic SSE streams, changes the upstream channel, or injects unsafe Web3 wallet behavior.
 
-Use the standalone `audit.py` path by default. It only needs Python 3 and `curl`, which makes it suitable for local Hermes terminal sessions and sandboxed execution.
+Use the standalone `audit.py` path by default. It only needs Python 3 and `curl`, which makes it suitable for local Hermes terminal sessions and sandboxed execution. On Windows, run the POSIX shell recipes from Git Bash or an equivalent shell; direct `python audit.py ...` invocations also work from PowerShell when the environment variables are set.
 
 ## When to Use
 
@@ -70,6 +70,10 @@ Never print the raw API key in summaries, filenames, reports, shell traces, or G
 ## One-Shot Audit Recipe
 
 Use this when the user provides a base URL and wants a normal audit:
+
+This recipe is POSIX shell. On Windows Hermes hosts, use Git Bash for this
+one-shot form; if the repository already has `audit.py`, PowerShell can run the
+direct local command shown after the recipe.
 
 ```bash
 set -euo pipefail

--- a/tests/test_skill_distribution.py
+++ b/tests/test_skill_distribution.py
@@ -41,6 +41,7 @@ def test_skill_frontmatter_declares_required_distribution_fields():
     assert _has_line(hermes, r"^name:\s+api-relay-audit$")
     assert _has_line(hermes, r"^description:\s+Use when")
     assert _has_line(hermes, r"^version:\s+2\.3\.0$")
+    assert _has_line(hermes, r"^platforms:\s+\[linux,\s+macos,\s+windows\]$")
     for field in [
         "author: Toby Bridges",
         "license: AGPL-3.0-only",
@@ -107,3 +108,11 @@ def test_root_skill_secret_handling_prefers_secure_environment():
     assert "API_RELAY_AUDIT_KEY" in text
     assert "The agent may also ask the user directly" not in text
     assert "avoid repeating the raw key in chat" in text
+
+
+def test_hermes_skill_supports_windows_git_bash_contract():
+    text = _read(HERMES_SKILL)
+    frontmatter = _frontmatter(HERMES_SKILL)
+    assert "windows" in frontmatter
+    assert "Git Bash" in text
+    assert "PowerShell" in text

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">714</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">715</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## What changed

This PR updates the Hermes skill distribution contract so the installed skill can load on Windows hosts.

- Adds `windows` to `skills/api-relay-audit/SKILL.md` `platforms` metadata.
- Documents the Windows runtime contract: Python 3 + curl, with Git Bash or an equivalent POSIX shell for the one-shot recipe; direct local `python audit.py ...` can run from PowerShell when env vars are set.
- Adds regression coverage so the Hermes skill cannot silently drop Windows support again.
- Updates skill distribution docs to require Windows dogfood to verify skill loading, not just install success.

## Why

Hermes direct install from GitHub `master` succeeded on Windows, but `skill_view("api-relay-audit")` refused to load because the skill frontmatter only declared `platforms: [linux, macos]`.

Dogfood showed the actual runtime path works on Windows/Git Bash: `audit.py --help`, static distribution tests, and live audit execution all completed. The metadata was narrower than the supported behavior.

## Validation

- `python -m pytest tests\test_skill_distribution.py tests\test_dual_distribution_parity.py -q`
- Result: `34 passed`
- `python audit.py --help`
- Result: exits successfully and shows the expected CLI, including `--transparent-log`.

Dogfood trace artifacts and relay audit outputs are intentionally not committed.

## Follow-ups from dogfood, not in this PR

- Windows/Git-Bash infrastructure recon reports `The system cannot find the path specified.` and needs a Windows fallback or explicit unavailable state.
- Step 8 should distinguish package-name rewrites from empty/suppressed responses and parser failures.
- Step 10 should classify CC official-client-gated channels more explicitly.
- The dogfood trace layout is now mature enough to turn into a reusable template.