### PR TITLE
[codex] Add connectivity preflight mode

### DIFF
--- a/api_relay_audit/connectivity.py
+++ b/api_relay_audit/connectivity.py
@@ -1,0 +1,303 @@
+"""Fast API relay connectivity checks.
+
+This module is intentionally narrower than the full audit. It sends one
+low-token Anthropic-style chat request and one low-token OpenAI-chat request,
+then reports whether either format is usable. It does not make security
+claims or feed the audit risk matrix.
+"""
+
+import json
+import shlex
+import time
+from dataclasses import dataclass
+
+
+CONNECTIVITY_PROMPT = "Reply with the single word: ok"
+CONNECTIVITY_MAX_TOKENS = 8
+
+
+@dataclass
+class ConnectivityProbeResult:
+    """Result of one connectivity probe."""
+
+    format_name: str
+    endpoint: str
+    auth_style: str
+    status: int
+    elapsed_seconds: float
+    input_tokens: int | None
+    output_tokens: int | None
+    text_preview: str
+    diagnostic: str
+    success: bool
+
+
+def _redact(text: str, api_key: str) -> str:
+    if not text:
+        return ""
+    if api_key:
+        text = text.replace(api_key, "[redacted-api-key]")
+    return text
+
+
+def _markdown_escape(text: str) -> str:
+    text = _redact(str(text), "")
+    return (
+        text.replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("\n", " ")
+        .replace("\r", " ")
+        .strip()
+    )
+
+
+def _text_from_content(content) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts = []
+    for block in content:
+        if isinstance(block, dict):
+            text = block.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "".join(parts)
+
+
+def _parse_anthropic_response(data: dict) -> tuple[str, int | None, int | None]:
+    usage = data.get("usage", {}) if isinstance(data, dict) else {}
+    if not isinstance(usage, dict):
+        usage = {}
+    return (
+        _text_from_content(data.get("content")),
+        usage.get("input_tokens") if isinstance(usage.get("input_tokens"), int) else None,
+        usage.get("output_tokens") if isinstance(usage.get("output_tokens"), int) else None,
+    )
+
+
+def _parse_openai_response(data: dict) -> tuple[str, int | None, int | None]:
+    usage = data.get("usage", {}) if isinstance(data, dict) else {}
+    if not isinstance(usage, dict):
+        usage = {}
+    choices = data.get("choices", []) if isinstance(data, dict) else []
+    first_choice = choices[0] if choices and isinstance(choices[0], dict) else {}
+    message = first_choice.get("message", {})
+    text = ""
+    if isinstance(message, dict):
+        text = _text_from_content(message.get("content"))
+    if not text:
+        text = _text_from_content(first_choice.get("text"))
+    return (
+        text,
+        usage.get("prompt_tokens") if isinstance(usage.get("prompt_tokens"), int) else None,
+        usage.get("completion_tokens") if isinstance(usage.get("completion_tokens"), int) else None,
+    )
+
+
+def _headers_summary(headers: dict) -> str:
+    if not headers:
+        return "no response headers"
+    lowered = {str(k).lower(): str(v) for k, v in headers.items()}
+    parts = []
+    content_type = lowered.get("content-type")
+    if content_type:
+        parts.append(f"content-type {content_type.split(';', 1)[0]}")
+    request_headers = [
+        name for name in ("request-id", "x-request-id", "x-openai-request-id")
+        if name in lowered
+    ]
+    if request_headers:
+        parts.append("request id present")
+    return ", ".join(parts) if parts else f"{len(headers)} response headers"
+
+
+def _status_diagnostic(status: int, error: str | None) -> str:
+    if status == 0:
+        return f"Transport failure: {error or 'request did not complete'}"
+    if status in (401, 403):
+        return "Authentication or authorization failed; check key, model access, balance, and auth style."
+    if status == 404:
+        return "Endpoint not found; check the base URL and whether this relay supports the format."
+    if status == 429:
+        return "Rate limited or quota exhausted; check relay quota or retry later."
+    if status == 400:
+        return "Bad request; the relay may not support this format or model."
+    if status >= 500:
+        return "Relay or upstream server error."
+    if 200 <= status < 300:
+        return "HTTP 2xx received but no usable text was parsed."
+    return f"HTTP {status} received; inspect relay configuration and model access."
+
+
+def _probe(client, format_name: str, endpoint: str, auth_style: str,
+           headers: dict, body: dict, parser) -> ConnectivityProbeResult:
+    start = time.time()
+    response = client.raw_request(
+        "POST",
+        endpoint,
+        headers,
+        json.dumps(body).encode("utf-8"),
+        content_type="application/json",
+        timeout=client.timeout,
+    )
+    elapsed = time.time() - start
+    status = int(response.get("status", 0) or 0)
+    response_error = _redact(str(response.get("error") or ""), client.api_key)
+    diagnostic = _status_diagnostic(status, response_error)
+    text = ""
+    input_tokens = None
+    output_tokens = None
+    success = False
+
+    if 200 <= status < 300:
+        try:
+            data = json.loads(response.get("body") or "")
+        except json.JSONDecodeError:
+            diagnostic = "HTTP 2xx received but response was not valid JSON."
+        else:
+            text, input_tokens, output_tokens = parser(data)
+            text = _redact(text.strip(), client.api_key)
+            if text:
+                success = True
+                diagnostic = f"OK: parsed non-empty text; {_headers_summary(response.get('headers', {}))}."
+            else:
+                diagnostic = "HTTP 2xx received but response JSON did not contain parsed text."
+
+    return ConnectivityProbeResult(
+        format_name=format_name,
+        endpoint=endpoint,
+        auth_style=auth_style,
+        status=status,
+        elapsed_seconds=elapsed,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        text_preview=text[:80],
+        diagnostic=_redact(diagnostic, client.api_key),
+        success=success,
+    )
+
+
+def _render_token_count(value: int | None) -> str:
+    return str(value) if isinstance(value, int) else "-"
+
+
+def _render_status(status: int) -> str:
+    return str(status) if status else "transport"
+
+
+def _next_step(verdict: str, client) -> str:
+    url = shlex.quote(client.base_url)
+    model = shlex.quote(client.model)
+    if verdict in ("OK", "WARNING"):
+        return (
+            "Connectivity reached at least one chat format. For the full security audit, run:\n\n"
+            "```bash\n"
+            "export API_RELAY_AUDIT_KEY=sk-...\n"
+            f"python3 audit.py --key \"$API_RELAY_AUDIT_KEY\" --url {url} --model {model} --output report.md\n"
+            "```"
+        )
+    return (
+        "Connectivity failed for both chat formats. Check the base URL, API key, "
+        "model name, relay balance/quota, and whether the relay supports Anthropic "
+        "or OpenAI Chat endpoints before running the full audit."
+    )
+
+
+def render_connectivity_report(result: dict) -> str:
+    """Render a human-readable connectivity report."""
+    client = result["client"]
+    verdict = result["verdict"]
+    lines = [
+        "# API Relay Connectivity Report",
+        "",
+        f"**Target**: `{client.base_url}`",
+        f"**Model**: `{client.model}`",
+        f"**Timeout**: `{client.timeout}s`",
+        f"**Connectivity Verdict**: **{verdict}**",
+        "",
+        "This is a quick connectivity check, not a security audit. It does not produce a LOW/MEDIUM/HIGH risk rating.",
+        "",
+        "## Probe Results",
+        "",
+        "| Format | Endpoint | Auth style | HTTP status | Elapsed | Tokens | Text preview | Diagnostic |",
+        "|---|---|---|---:|---:|---:|---|---|",
+    ]
+    for probe in result["probes"]:
+        tokens = (
+            f"{_render_token_count(probe.input_tokens)}/"
+            f"{_render_token_count(probe.output_tokens)}"
+        )
+        lines.append(
+            "| "
+            f"{_markdown_escape(probe.format_name)} | "
+            f"`{_markdown_escape(probe.endpoint)}` | "
+            f"{_markdown_escape(probe.auth_style)} | "
+            f"{_render_status(probe.status)} | "
+            f"{probe.elapsed_seconds:.3f}s | "
+            f"{tokens} | "
+            f"{_markdown_escape(probe.text_preview) or '-'} | "
+            f"{_markdown_escape(probe.diagnostic)} |"
+        )
+    lines.extend([
+        "",
+        "## Next Step",
+        "",
+        _next_step(verdict, client),
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def run_connectivity_check(client) -> dict:
+    """Run fixed Anthropic and OpenAI Chat connectivity probes."""
+    common_messages = [{"role": "user", "content": CONNECTIVITY_PROMPT}]
+    probes = [
+        _probe(
+            client,
+            "Anthropic Chat",
+            "/v1/messages",
+            "x-api-key",
+            {
+                "x-api-key": client.api_key,
+                "anthropic-version": "2023-06-01",
+            },
+            {
+                "model": client.model,
+                "max_tokens": CONNECTIVITY_MAX_TOKENS,
+                "messages": common_messages,
+            },
+            _parse_anthropic_response,
+        ),
+        _probe(
+            client,
+            "OpenAI Chat",
+            "/v1/chat/completions",
+            "Authorization: Bearer",
+            {
+                "Authorization": f"Bearer {client.api_key}",
+            },
+            {
+                "model": client.model,
+                "max_tokens": CONNECTIVITY_MAX_TOKENS,
+                "messages": common_messages,
+            },
+            _parse_openai_response,
+        ),
+    ]
+    success_count = sum(1 for probe in probes if probe.success)
+    if success_count == len(probes):
+        verdict = "OK"
+    elif success_count:
+        verdict = "WARNING"
+    else:
+        verdict = "FAILED"
+    result = {
+        "client": client,
+        "probes": probes,
+        "verdict": verdict,
+        "success": success_count > 0,
+        "successful_formats": [probe.format_name for probe in probes if probe.success],
+    }
+    result["markdown"] = render_connectivity_report(result)
+    return result

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 22961a738b9ebc012d9a27931bf2cb002096e404626ee8cacdd6feb5bc412626
-# standalone_body_sha256: b958a39b4bd2b45bfdc13782488e384739424c5839625eb694956008de103015
+# source_sha256: 223e4f941de9b4fda1d1c8c440314de5ad3f5fc1fb6cad69d365c1aa38ff2a66
+# standalone_body_sha256: 54a80470c90fccf97e640b7831e05ca2dde72ef685e6ccc2e639a7fa73b6e25c
 # END GENERATED STANDALONE HEADER
 
 """
@@ -1726,6 +1726,315 @@ class Reporter:
             header += f"- {icon} {msg}\n"
         header += "\n---\n"
         return header + "\n".join(self.sections)
+
+
+# ============================================================
+# Connectivity check
+# ============================================================
+
+"""Fast API relay connectivity checks.
+
+This module is intentionally narrower than the full audit. It sends one
+low-token Anthropic-style chat request and one low-token OpenAI-chat request,
+then reports whether either format is usable. It does not make security
+claims or feed the audit risk matrix.
+"""
+
+import json
+import shlex
+import time
+from dataclasses import dataclass
+
+
+CONNECTIVITY_PROMPT = "Reply with the single word: ok"
+CONNECTIVITY_MAX_TOKENS = 8
+
+
+@dataclass
+class ConnectivityProbeResult:
+    """Result of one connectivity probe."""
+
+    format_name: str
+    endpoint: str
+    auth_style: str
+    status: int
+    elapsed_seconds: float
+    input_tokens: int | None
+    output_tokens: int | None
+    text_preview: str
+    diagnostic: str
+    success: bool
+
+
+def _redact(text: str, api_key: str) -> str:
+    if not text:
+        return ""
+    if api_key:
+        text = text.replace(api_key, "[redacted-api-key]")
+    return text
+
+
+def _markdown_escape(text: str) -> str:
+    text = _redact(str(text), "")
+    return (
+        text.replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("\n", " ")
+        .replace("\r", " ")
+        .strip()
+    )
+
+
+def _text_from_content(content) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts = []
+    for block in content:
+        if isinstance(block, dict):
+            text = block.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "".join(parts)
+
+
+def _parse_anthropic_response(data: dict) -> tuple[str, int | None, int | None]:
+    usage = data.get("usage", {}) if isinstance(data, dict) else {}
+    if not isinstance(usage, dict):
+        usage = {}
+    return (
+        _text_from_content(data.get("content")),
+        usage.get("input_tokens") if isinstance(usage.get("input_tokens"), int) else None,
+        usage.get("output_tokens") if isinstance(usage.get("output_tokens"), int) else None,
+    )
+
+
+def _parse_openai_response(data: dict) -> tuple[str, int | None, int | None]:
+    usage = data.get("usage", {}) if isinstance(data, dict) else {}
+    if not isinstance(usage, dict):
+        usage = {}
+    choices = data.get("choices", []) if isinstance(data, dict) else []
+    first_choice = choices[0] if choices and isinstance(choices[0], dict) else {}
+    message = first_choice.get("message", {})
+    text = ""
+    if isinstance(message, dict):
+        text = _text_from_content(message.get("content"))
+    if not text:
+        text = _text_from_content(first_choice.get("text"))
+    return (
+        text,
+        usage.get("prompt_tokens") if isinstance(usage.get("prompt_tokens"), int) else None,
+        usage.get("completion_tokens") if isinstance(usage.get("completion_tokens"), int) else None,
+    )
+
+
+def _headers_summary(headers: dict) -> str:
+    if not headers:
+        return "no response headers"
+    lowered = {str(k).lower(): str(v) for k, v in headers.items()}
+    parts = []
+    content_type = lowered.get("content-type")
+    if content_type:
+        parts.append(f"content-type {content_type.split(';', 1)[0]}")
+    request_headers = [
+        name for name in ("request-id", "x-request-id", "x-openai-request-id")
+        if name in lowered
+    ]
+    if request_headers:
+        parts.append("request id present")
+    return ", ".join(parts) if parts else f"{len(headers)} response headers"
+
+
+def _status_diagnostic(status: int, error: str | None) -> str:
+    if status == 0:
+        return f"Transport failure: {error or 'request did not complete'}"
+    if status in (401, 403):
+        return "Authentication or authorization failed; check key, model access, balance, and auth style."
+    if status == 404:
+        return "Endpoint not found; check the base URL and whether this relay supports the format."
+    if status == 429:
+        return "Rate limited or quota exhausted; check relay quota or retry later."
+    if status == 400:
+        return "Bad request; the relay may not support this format or model."
+    if status >= 500:
+        return "Relay or upstream server error."
+    if 200 <= status < 300:
+        return "HTTP 2xx received but no usable text was parsed."
+    return f"HTTP {status} received; inspect relay configuration and model access."
+
+
+def _probe(client, format_name: str, endpoint: str, auth_style: str,
+           headers: dict, body: dict, parser) -> ConnectivityProbeResult:
+    start = time.time()
+    response = client.raw_request(
+        "POST",
+        endpoint,
+        headers,
+        json.dumps(body).encode("utf-8"),
+        content_type="application/json",
+        timeout=client.timeout,
+    )
+    elapsed = time.time() - start
+    status = int(response.get("status", 0) or 0)
+    response_error = _redact(str(response.get("error") or ""), client.api_key)
+    diagnostic = _status_diagnostic(status, response_error)
+    text = ""
+    input_tokens = None
+    output_tokens = None
+    success = False
+
+    if 200 <= status < 300:
+        try:
+            data = json.loads(response.get("body") or "")
+        except json.JSONDecodeError:
+            diagnostic = "HTTP 2xx received but response was not valid JSON."
+        else:
+            text, input_tokens, output_tokens = parser(data)
+            text = _redact(text.strip(), client.api_key)
+            if text:
+                success = True
+                diagnostic = f"OK: parsed non-empty text; {_headers_summary(response.get('headers', {}))}."
+            else:
+                diagnostic = "HTTP 2xx received but response JSON did not contain parsed text."
+
+    return ConnectivityProbeResult(
+        format_name=format_name,
+        endpoint=endpoint,
+        auth_style=auth_style,
+        status=status,
+        elapsed_seconds=elapsed,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        text_preview=text[:80],
+        diagnostic=_redact(diagnostic, client.api_key),
+        success=success,
+    )
+
+
+def _render_token_count(value: int | None) -> str:
+    return str(value) if isinstance(value, int) else "-"
+
+
+def _render_status(status: int) -> str:
+    return str(status) if status else "transport"
+
+
+def _next_step(verdict: str, client) -> str:
+    url = shlex.quote(client.base_url)
+    model = shlex.quote(client.model)
+    if verdict in ("OK", "WARNING"):
+        return (
+            "Connectivity reached at least one chat format. For the full security audit, run:\n\n"
+            "```bash\n"
+            "export API_RELAY_AUDIT_KEY=sk-...\n"
+            f"python3 audit.py --key \"$API_RELAY_AUDIT_KEY\" --url {url} --model {model} --output report.md\n"
+            "```"
+        )
+    return (
+        "Connectivity failed for both chat formats. Check the base URL, API key, "
+        "model name, relay balance/quota, and whether the relay supports Anthropic "
+        "or OpenAI Chat endpoints before running the full audit."
+    )
+
+
+def render_connectivity_report(result: dict) -> str:
+    """Render a human-readable connectivity report."""
+    client = result["client"]
+    verdict = result["verdict"]
+    lines = [
+        "# API Relay Connectivity Report",
+        "",
+        f"**Target**: `{client.base_url}`",
+        f"**Model**: `{client.model}`",
+        f"**Timeout**: `{client.timeout}s`",
+        f"**Connectivity Verdict**: **{verdict}**",
+        "",
+        "This is a quick connectivity check, not a security audit. It does not produce a LOW/MEDIUM/HIGH risk rating.",
+        "",
+        "## Probe Results",
+        "",
+        "| Format | Endpoint | Auth style | HTTP status | Elapsed | Tokens | Text preview | Diagnostic |",
+        "|---|---|---|---:|---:|---:|---|---|",
+    ]
+    for probe in result["probes"]:
+        tokens = (
+            f"{_render_token_count(probe.input_tokens)}/"
+            f"{_render_token_count(probe.output_tokens)}"
+        )
+        lines.append(
+            "| "
+            f"{_markdown_escape(probe.format_name)} | "
+            f"`{_markdown_escape(probe.endpoint)}` | "
+            f"{_markdown_escape(probe.auth_style)} | "
+            f"{_render_status(probe.status)} | "
+            f"{probe.elapsed_seconds:.3f}s | "
+            f"{tokens} | "
+            f"{_markdown_escape(probe.text_preview) or '-'} | "
+            f"{_markdown_escape(probe.diagnostic)} |"
+        )
+    lines.extend([
+        "",
+        "## Next Step",
+        "",
+        _next_step(verdict, client),
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def run_connectivity_check(client) -> dict:
+    """Run fixed Anthropic and OpenAI Chat connectivity probes."""
+    common_messages = [{"role": "user", "content": CONNECTIVITY_PROMPT}]
+    probes = [
+        _probe(
+            client,
+            "Anthropic Chat",
+            "/v1/messages",
+            "x-api-key",
+            {
+                "x-api-key": client.api_key,
+                "anthropic-version": "2023-06-01",
+            },
+            {
+                "model": client.model,
+                "max_tokens": CONNECTIVITY_MAX_TOKENS,
+                "messages": common_messages,
+            },
+            _parse_anthropic_response,
+        ),
+        _probe(
+            client,
+            "OpenAI Chat",
+            "/v1/chat/completions",
+            "Authorization: Bearer",
+            {
+                "Authorization": f"Bearer {client.api_key}",
+            },
+            {
+                "model": client.model,
+                "max_tokens": CONNECTIVITY_MAX_TOKENS,
+                "messages": common_messages,
+            },
+            _parse_openai_response,
+        ),
+    ]
+    success_count = sum(1 for probe in probes if probe.success)
+    if success_count == len(probes):
+        verdict = "OK"
+    elif success_count:
+        verdict = "WARNING"
+    else:
+        verdict = "FAILED"
+    result = {
+        "client": client,
+        "probes": probes,
+        "verdict": verdict,
+        "success": success_count > 0,
+        "successful_formats": [probe.format_name for probe in probes if probe.success],
+    }
+    result["markdown"] = render_connectivity_report(result)
+    return result
 
 
 # ============================================================
@@ -4322,6 +4631,9 @@ def parse_args():
     p.add_argument("--key", required=True, help="API Key")
     p.add_argument("--url", required=True, help="Base URL (e.g. https://xxx.com/v1)")
     p.add_argument("--model", default="claude-opus-4-6", help="Model name")
+    p.add_argument("--connectivity", action="store_true",
+                   help="Run a quick Anthropic/OpenAI Chat connectivity check "
+                        "and exit without running the full 14-step audit.")
     p.add_argument("--skip-infra", action="store_true", help="Skip infrastructure recon")
     p.add_argument("--skip-context", action="store_true", help="Skip context length test")
     p.add_argument("--fast-context", action="store_true",
@@ -5739,13 +6051,35 @@ def _run_step(name, reporter, step_fn, *args, default=None, crashes=None):
 def main():
     args = parse_args()
     client = APIClient(args.url, args.key, args.model, timeout=args.timeout)
-    report = Reporter()
 
     # v1.7.7: transparent forensic log (arXiv §7.3)
     _transparent_logger = None
     if args.transparent_log:
         _transparent_logger = TransparentLogger(args.transparent_log)
         client.set_transparent_logger(_transparent_logger)
+
+    if args.connectivity:
+        print(f"\n{'=' * 60}")
+        print("  API Relay Connectivity Check")
+        print(f"  Target: {client.base_url}")
+        print(f"  Model:  {args.model}")
+        print(f"{'=' * 60}\n")
+
+        result = run_connectivity_check(client)
+        md = result["markdown"]
+        if args.output:
+            Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.output).write_text(md, encoding="utf-8")
+            print(f"  Connectivity report saved: {args.output}")
+        else:
+            print(md)
+
+        if _transparent_logger is not None:
+            _transparent_logger.close()
+            print(f"\n  Transparent log: {args.transparent_log}")
+        return 0 if result["success"] else 1
+
+    report = Reporter()
 
     print(f"\n{'=' * 60}")
     print(f"  API Relay Security Audit")
@@ -6071,7 +6405,8 @@ def main():
     print(f"\n{'=' * 60}")
     print("  Audit complete")
     print(f"{'=' * 60}\n")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,23 +16,24 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **741** | `pytest --collect-only` |
-| 测试数 (static) | 722 | grep `def test_*` in tests/ |
-| CLI flag 数 | 20 | grep `add_argument("--*")` |
+| 测试数 (pytest) | **754** | `pytest --collect-only` |
+| 测试数 (static) | 730 | grep `def test_*` in tests/ |
+| CLI flag 数 | 21 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-07 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `7d90163` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `03392b0` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-07 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
-- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 741。要么 ROADMAP 漏更新，要么有未记录的新测试。
+- ℹ️ pytest (754) vs 静态 (730) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
+- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 754。要么 ROADMAP 漏更新，要么有未记录的新测试。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -35,6 +35,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from api_relay_audit.channel_classifier import run_channel_classifier
 from api_relay_audit.client import APIClient
+from api_relay_audit.connectivity import run_connectivity_check
 from api_relay_audit.context import run_context_scan
 from api_relay_audit.error_leakage import run_error_leakage_test
 from api_relay_audit.identity_patterns import find_non_claude_identities
@@ -88,6 +89,9 @@ def parse_args():
     p.add_argument("--key", required=True, help="API Key")
     p.add_argument("--url", required=True, help="Base URL (e.g. https://xxx.com/v1)")
     p.add_argument("--model", default="claude-opus-4-6", help="Model name")
+    p.add_argument("--connectivity", action="store_true",
+                   help="Run a quick Anthropic/OpenAI Chat connectivity check "
+                        "and exit without running the full 14-step audit.")
     p.add_argument("--skip-infra", action="store_true", help="Skip infrastructure recon")
     p.add_argument("--skip-context", action="store_true", help="Skip context length test")
     p.add_argument("--fast-context", action="store_true",
@@ -1505,7 +1509,6 @@ def _run_step(name, reporter, step_fn, *args, default=None, crashes=None):
 def main():
     args = parse_args()
     client = APIClient(args.url, args.key, args.model, timeout=args.timeout)
-    report = Reporter()
 
     # v1.7.7: transparent forensic log (arXiv §7.3)
     _transparent_logger = None
@@ -1513,6 +1516,29 @@ def main():
         from api_relay_audit.transparent_log import TransparentLogger
         _transparent_logger = TransparentLogger(args.transparent_log)
         client.set_transparent_logger(_transparent_logger)
+
+    if args.connectivity:
+        print(f"\n{'=' * 60}")
+        print("  API Relay Connectivity Check")
+        print(f"  Target: {client.base_url}")
+        print(f"  Model:  {args.model}")
+        print(f"{'=' * 60}\n")
+
+        result = run_connectivity_check(client)
+        md = result["markdown"]
+        if args.output:
+            Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+            Path(args.output).write_text(md, encoding="utf-8")
+            print(f"  Connectivity report saved: {args.output}")
+        else:
+            print(md)
+
+        if _transparent_logger is not None:
+            _transparent_logger.close()
+            print(f"\n  Transparent log: {args.transparent_log}")
+        return 0 if result["success"] else 1
+
+    report = Reporter()
 
     print(f"\n{'=' * 60}")
     print(f"  API Relay Security Audit")
@@ -1838,7 +1864,8 @@ def main():
     print(f"\n{'=' * 60}")
     print("  Audit complete")
     print(f"{'=' * 60}\n")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/build-standalone.py
+++ b/scripts/build-standalone.py
@@ -369,6 +369,10 @@ SECTIONS = (
         "api_relay_audit/reporter.py",
     ),
     Section(
+        "Connectivity check",
+        "api_relay_audit/connectivity.py",
+    ),
+    Section(
         "Context length scan",
         "api_relay_audit/context.py",
     ),

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -1,0 +1,182 @@
+import json
+
+import pytest
+
+from api_relay_audit import connectivity
+from api_relay_audit.connectivity import CONNECTIVITY_PROMPT, run_connectivity_check
+
+
+class FakeClient:
+    def __init__(self, responses, api_key="sk-secret-connectivity"):
+        self.base_url = "https://relay.example.com/v1"
+        self.api_key = api_key
+        self.model = "claude-test"
+        self.timeout = 17
+        self._responses = list(responses)
+        self.calls = []
+
+    def raw_request(self, method, path, headers, body, content_type, timeout):
+        self.calls.append({
+            "method": method,
+            "path": path,
+            "headers": headers,
+            "body": body,
+            "content_type": content_type,
+            "timeout": timeout,
+        })
+        return self._responses.pop(0)
+
+
+def response(status, body, headers=None, error=None):
+    if isinstance(body, (dict, list)):
+        body = json.dumps(body)
+    return {
+        "status": status,
+        "headers": headers or {"content-type": "application/json"},
+        "body": body,
+        "error": error,
+    }
+
+
+def anthropic_ok(text="ok"):
+    return response(
+        200,
+        {
+            "content": [{"type": "text", "text": text}],
+            "usage": {"input_tokens": 9, "output_tokens": 1},
+        },
+        headers={"content-type": "application/json", "x-request-id": "req_1"},
+    )
+
+
+def openai_ok(text="ok"):
+    return response(
+        200,
+        {
+            "choices": [{"message": {"content": text}}],
+            "usage": {"prompt_tokens": 8, "completion_tokens": 1},
+        },
+        headers={"content-type": "application/json", "x-request-id": "req_2"},
+    )
+
+
+@pytest.fixture(autouse=True)
+def deterministic_time(monkeypatch):
+    ticks = iter([1.0, 1.125, 2.0, 2.250])
+    monkeypatch.setattr(connectivity.time, "time", lambda: next(ticks))
+
+
+def test_anthropic_success_openai_failure_reports_warning_and_request_shape():
+    client = FakeClient([anthropic_ok(), response(404, {"error": {"message": "missing"}})])
+
+    result = run_connectivity_check(client)
+
+    assert result["success"] is True
+    assert result["verdict"] == "WARNING"
+    assert result["successful_formats"] == ["Anthropic Chat"]
+    assert len(client.calls) == 2
+
+    anthropic_call = client.calls[0]
+    assert anthropic_call["method"] == "POST"
+    assert anthropic_call["path"] == "/v1/messages"
+    assert anthropic_call["headers"] == {
+        "x-api-key": client.api_key,
+        "anthropic-version": "2023-06-01",
+    }
+    assert anthropic_call["content_type"] == "application/json"
+    assert anthropic_call["timeout"] == client.timeout
+    anthropic_body = json.loads(anthropic_call["body"])
+    assert anthropic_body["max_tokens"] == 8
+    assert anthropic_body["messages"][0]["content"] == CONNECTIVITY_PROMPT
+
+    openai_call = client.calls[1]
+    assert openai_call["path"] == "/v1/chat/completions"
+    assert openai_call["headers"] == {"Authorization": f"Bearer {client.api_key}"}
+    assert "API Relay Connectivity Report" in result["markdown"]
+    assert "WARNING" in result["markdown"]
+    assert "LOW RISK" not in result["markdown"]
+
+
+def test_openai_success_anthropic_failure_reports_openai_format():
+    client = FakeClient([response(400, {"error": {"message": "bad format"}}), openai_ok()])
+
+    result = run_connectivity_check(client)
+
+    assert result["success"] is True
+    assert result["verdict"] == "WARNING"
+    assert result["successful_formats"] == ["OpenAI Chat"]
+    assert "Bad request" in result["markdown"]
+    assert "OpenAI Chat" in result["markdown"]
+
+
+def test_both_formats_success_reports_ok():
+    client = FakeClient([anthropic_ok("ok anthropic"), openai_ok("ok openai")])
+
+    result = run_connectivity_check(client)
+
+    assert result["success"] is True
+    assert result["verdict"] == "OK"
+    assert result["successful_formats"] == ["Anthropic Chat", "OpenAI Chat"]
+    assert "9/1" in result["markdown"]
+    assert "8/1" in result["markdown"]
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (401, "Authentication or authorization failed"),
+        (403, "Authentication or authorization failed"),
+        (404, "Endpoint not found"),
+        (429, "Rate limited or quota exhausted"),
+        (500, "Relay or upstream server error"),
+        (0, "Transport failure"),
+    ],
+)
+def test_both_formats_fail_with_common_status_diagnostics(status, expected):
+    client = FakeClient([
+        response(status, {"error": {"message": "fail"}}, error="network failure"),
+        response(status, {"error": {"message": "fail"}}, error="network failure"),
+    ])
+
+    result = run_connectivity_check(client)
+
+    assert result["success"] is False
+    assert result["verdict"] == "FAILED"
+    assert expected in result["markdown"]
+
+
+def test_malformed_json_warns_when_other_format_succeeds():
+    client = FakeClient([response(200, "not json"), openai_ok()])
+
+    result = run_connectivity_check(client)
+
+    assert result["success"] is True
+    assert result["verdict"] == "WARNING"
+    assert "response was not valid JSON" in result["markdown"]
+
+
+def test_malformed_or_empty_2xx_without_success_fails():
+    client = FakeClient([
+        response(200, "not json"),
+        response(200, {"choices": [{"message": {"content": ""}}]}),
+    ])
+
+    result = run_connectivity_check(client)
+
+    assert result["success"] is False
+    assert result["verdict"] == "FAILED"
+    assert "response was not valid JSON" in result["markdown"]
+    assert "did not contain parsed text" in result["markdown"]
+
+
+def test_report_does_not_leak_api_key_from_errors_or_body():
+    key = "sk-secret-connectivity"
+    client = FakeClient([
+        response(0, f"server echoed {key}", error=f"curl failed with {key}"),
+        response(401, {"error": {"message": f"bad key {key}"}}),
+    ], api_key=key)
+
+    result = run_connectivity_check(client)
+
+    assert key not in result["markdown"]
+    assert "[redacted-api-key]" in result["markdown"]

--- a/tests/test_dual_distribution_parity.py
+++ b/tests/test_dual_distribution_parity.py
@@ -426,7 +426,97 @@ def test_public_help_flags_parity():
     CLI flags even when their implementations differ internally."""
     modular_flags = _help_option_set(REPO_ROOT / "scripts" / "audit.py")
     standalone_flags = _help_option_set(REPO_ROOT / "audit.py")
+    assert "--connectivity" in modular_flags
     assert modular_flags == standalone_flags
+
+
+def test_connectivity_mode_exits_before_full_audit(monkeypatch, tmp_path):
+    """--connectivity must not run warmup or any of the 14 audit steps."""
+    import scripts.audit as modular
+
+    standalone = _load_standalone_audit()
+
+    audit_functions = [
+        "run_warmup",
+        "test_infrastructure",
+        "test_models",
+        "test_token_injection",
+        "test_prompt_extraction",
+        "test_instruction_conflict",
+        "test_jailbreak",
+        "test_context_length",
+        "test_tool_substitution",
+        "test_error_leakage",
+        "test_stream_integrity",
+        "test_web3_injection",
+        "test_infra_fingerprint",
+        "test_latency_variance",
+        "test_channel_classifier",
+    ]
+
+    class FakeClient:
+        def __init__(self, base_url, api_key, model, timeout=120):
+            self.base_url = base_url.rstrip("/")
+            self.api_key = api_key
+            self.model = model
+            self.timeout = timeout
+
+        def set_transparent_logger(self, logger):
+            pass
+
+        def raw_request(self, method, path, headers, body, content_type, timeout):
+            if path == "/v1/messages":
+                return {
+                    "status": 200,
+                    "headers": {"content-type": "application/json"},
+                    "body": json.dumps({
+                        "content": [{"type": "text", "text": "ok"}],
+                        "usage": {"input_tokens": 8, "output_tokens": 1},
+                    }),
+                    "error": None,
+                }
+            return {
+                "status": 404,
+                "headers": {"content-type": "application/json"},
+                "body": json.dumps({"error": {"message": "not found"}}),
+                "error": None,
+            }
+
+    for module in (modular, standalone):
+        monkeypatch.setattr(module, "APIClient", FakeClient)
+
+        def forbidden(*args, **kwargs):
+            raise AssertionError("--connectivity should exit before full audit steps")
+
+        for name in audit_functions:
+            monkeypatch.setattr(module, name, forbidden)
+
+        output = tmp_path / f"{module.__name__.replace('.', '_')}-connectivity.md"
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "audit.py",
+                "--connectivity",
+                "--key",
+                "sk-test",
+                "--url",
+                "https://relay.example.com/v1",
+                "--model",
+                "claude-test",
+                "--warmup",
+                "3",
+                "--skip-infra",
+                "--output",
+                str(output),
+            ],
+        )
+
+        assert module.main() == 0
+        markdown = output.read_text(encoding="utf-8")
+        assert "API Relay Connectivity Report" in markdown
+        assert "Security Audit Report" not in markdown
+        assert "LOW RISK" not in markdown
 
 
 def _extract_overall_rating(markdown):

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">741</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">754</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## Summary

- add `--connectivity` as a CLI-only fast preflight mode for Anthropic Chat and OpenAI Chat relays
- render a human-readable Connectivity Report without LOW/MEDIUM/HIGH security risk language
- include the generated standalone `audit.py`, dual-distribution coverage, and public metrics updates

## Behavior

`--connectivity` sends one low-token Anthropic `/v1/messages` probe and one OpenAI `/v1/chat/completions` probe via `APIClient.raw_request()`. It exits `0` when at least one format returns 2xx with parsed non-empty text, and exits `1` when both formats fail.

The report includes status, elapsed time, token counts when available, parsed text preview, and generic diagnostics. It does not render raw response bodies or API keys.

## Validation

- `python3 scripts/build-standalone.py --check`
- `python3 scripts/collect-metrics.py --check`
- `python3 -m pytest tests/ -q` (`746 passed`)
- `git diff --check`
