### PR TITLE
[codex] Add relay error diagnosis reporting

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,9 @@ item has a short rationale so future contributors (including future
 iterations of the author) can quickly reconstruct why a thing is or is not
 on the list.
 
-**Last updated**: 2026-06-07 (roadmap hygiene pass: v1.9 follow-up test gaps,
-refusal/transport decouplings, and the protobuf-channel spike are no longer
-active near-term candidates)
+**Last updated**: 2026-06-07 (error diagnosis report layer added; roadmap
+hygiene pass: v1.9 follow-up test gaps, refusal/transport decouplings, and
+the protobuf-channel spike are no longer active near-term candidates)
 
 **Threat model anchor**: Liu et al., *Your Agent Is Mine: Measuring
 Malicious Intermediary Attacks on the LLM Supply Chain*, arXiv:2604.08407.
@@ -23,6 +23,25 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
 ---
 
 ## ✅ Shipped
+
+### 2026-06-07 follow-up — Error diagnosis report layer
+- **Productized operational error explanations**: added
+  `api_relay_audit/error_diagnosis.py`, a zero-dependency helper that maps
+  common HTTP/transport failures (`401`, `403`, `404`, `422`, `429`,
+  `5xx`, TLS, DNS/connect, timeout, CORS/browser fetch, non-JSON response,
+  format-detection failure) to a category, likely cause, and next action.
+- **Report integration without risk-matrix changes**: `APIClient.call()`
+  error results now include a `diagnosis` object, and the Markdown report
+  renders compact diagnosis lines wherever user-visible probe errors occur.
+  Step 9 deliberately diagnoses only transport failures because its `400` /
+  `422` responses are intentionally induced leakage probes, not user
+  configuration failures.
+- **Boundary held**: this is an explanatory/reporting layer, not a new
+  detector, not a hosted preflight service, not a new API family, and not a
+  change to LOW/MEDIUM/HIGH semantics. `inconclusive` remains
+  `inconclusive`.
+- **Final test count**: 743/743 passing (733 baseline → 743 after error
+  diagnosis unit, client, and standalone-parity coverage).
 
 ### v1.9 — Dual-distribution full generation (2026-06-01)
 - **Standalone product promise preserved**: root `audit.py` stays committed,

--- a/api_relay_audit/client.py
+++ b/api_relay_audit/client.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 import httpx
 
 from api_relay_audit import _transport
+from api_relay_audit.error_diagnosis import diagnose_error
 from api_relay_audit.stream_integrity import StreamSignals
 
 
@@ -332,6 +333,16 @@ class APIClient:
         return _transport.httpx_post_json(
             url, headers, body, self.timeout, httpx_module=httpx)
 
+    @staticmethod
+    def _error_result(error, **extra):
+        error_text = str(error)
+        result = {
+            "error": error_text,
+            "diagnosis": diagnose_error(error_text),
+        }
+        result.update(extra)
+        return result
+
     # -- Anthropic native format ----------------------------------------------
 
     def _call_anthropic(self, messages, system=None, max_tokens=512):
@@ -351,7 +362,7 @@ class APIClient:
 
         data = self._post(url, headers, body)
         if "_http_error" in data:
-            return {"error": data["_http_error"]}
+            return self._error_result(data["_http_error"])
         text = _extract_anthropic_text(data.get("content"))
         usage = data.get("usage", {})
         return {
@@ -381,7 +392,7 @@ class APIClient:
 
         data = self._post(url, headers, body)
         if "_http_error" in data:
-            return {"error": data["_http_error"]}
+            return self._error_result(data["_http_error"])
         choice = data.get("choices", [{}])[0]
         text = choice.get("message", {}).get("content", "")
         usage = data.get("usage", {})
@@ -468,7 +479,7 @@ class APIClient:
             self._log_transparent(
                 "call", self._resolve_call_url(), "POST",
                 request_body, None, 0, None, elapsed, str(e))
-            return {"error": str(e), "time": elapsed}
+            return self._error_result(e, time=elapsed)
 
     def _resolve_call_url(self) -> str:
         """Reconstruct the URL used by the last ``call()`` based on detected format."""
@@ -530,7 +541,7 @@ class APIClient:
         if openai_result and "error" not in openai_result:
             self._format = "openai"
             return openai_result
-        return anthropic_result or openai_result or {"error": "Both formats failed"}
+        return anthropic_result or openai_result or self._error_result("Both formats failed")
 
     def _handle_ssl_error(self, e: Exception) -> bool:
         """Switch to curl on SSL errors. Returns True if retry is warranted."""

--- a/api_relay_audit/error_diagnosis.py
+++ b/api_relay_audit/error_diagnosis.py
@@ -1,0 +1,212 @@
+"""User-facing diagnosis helpers for relay/API errors.
+
+This module turns terse transport or HTTP errors into a stable, reportable
+explanation. It is intentionally informational: diagnoses help users fix
+connectivity/configuration problems but do not change any detector verdict or
+overall risk-matrix branch.
+"""
+
+import re
+
+
+_HTTP_STATUS_RE = re.compile(r"\bHTTP\s+(\d{3})\b", re.IGNORECASE)
+
+
+def _coerce_status(status):
+    if status is None:
+        return None
+    try:
+        value = int(status)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _status_from_error(error):
+    match = _HTTP_STATUS_RE.search(str(error or ""))
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
+def _diagnosis(category, summary, likely_cause, suggested_action):
+    return {
+        "category": category,
+        "summary": summary,
+        "likely_cause": likely_cause,
+        "suggested_action": suggested_action,
+    }
+
+
+def diagnose_error(error=None, status=None):
+    """Return a structured diagnosis for an HTTP/transport error.
+
+    Args:
+        error: Error string from ``APIClient.call()``, ``raw_request()``, or a
+            stream transport failure.
+        status: Optional numeric HTTP status. When present, it takes priority
+            over status text parsed from ``error``.
+
+    Returns:
+        Dict with ``category``, ``summary``, ``likely_cause``, and
+        ``suggested_action``. The function never raises and never treats an
+        error as safe; it only explains the most likely operational cause.
+    """
+    text = str(error or "").strip()
+    text_lower = text.lower()
+    status_code = _coerce_status(status) or _status_from_error(text)
+
+    if status_code == 400:
+        return _diagnosis(
+            "bad-request",
+            "Request shape rejected by the relay.",
+            "The selected API format, model name, message schema, or content-type may not match this relay.",
+            "Verify the base URL, model id, and whether the relay expects Anthropic messages or OpenAI chat completions.",
+        )
+    if status_code == 401:
+        return _diagnosis(
+            "auth",
+            "Authentication failed.",
+            "The API key is invalid, expired, copied with extra whitespace, or not accepted by this relay.",
+            "Check the key in the provider dashboard and retry with a freshly copied key.",
+        )
+    if status_code == 403:
+        return _diagnosis(
+            "permission",
+            "The relay rejected an authenticated request.",
+            "The account may lack model access, have billing/credit problems, or be blocked from this API format.",
+            "Check account balance, model permissions, regional restrictions, and relay-side allowlists.",
+        )
+    if status_code == 404:
+        return _diagnosis(
+            "endpoint",
+            "Endpoint not found.",
+            "The base URL may be missing or duplicating a /v1 prefix, or the relay may not expose this route.",
+            "Try the relay's documented base URL and avoid appending /messages or /chat/completions manually.",
+        )
+    if status_code == 408:
+        return _diagnosis(
+            "timeout",
+            "The relay timed out the request.",
+            "The relay or upstream provider did not answer before the HTTP timeout.",
+            "Retry once, then increase --timeout or run with slower steps skipped to isolate the failing probe.",
+        )
+    if status_code == 413:
+        return _diagnosis(
+            "payload-too-large",
+            "Request body is too large for the relay.",
+            "The relay may enforce a smaller payload/context limit than the advertised model.",
+            "Retry with --fast-context or --skip-context, then run the full context test only if the relay supports it.",
+        )
+    if status_code == 422:
+        return _diagnosis(
+            "unprocessable",
+            "Request schema was understood but rejected.",
+            "Common causes are unsupported system prompts, unsupported model ids, or a relay-specific schema restriction.",
+            "Verify model access and whether this relay accepts custom system prompts for the selected format.",
+        )
+    if status_code == 429:
+        return _diagnosis(
+            "rate-limit",
+            "Rate limit or quota was hit.",
+            "The relay or upstream provider is throttling this key, account, or model.",
+            "Wait and retry with --skip-context or a lower --latency-probe-count, or upgrade the relay/provider quota.",
+        )
+    if status_code in (500, 502, 503, 504):
+        return _diagnosis(
+            "upstream-or-relay",
+            "Relay or upstream provider error.",
+            "The relay backend, gateway, or upstream model provider failed while handling the request.",
+            "Retry later; if it repeats, share the redacted report with the relay operator and inspect Step 9 for leakage.",
+        )
+    if status_code is not None and status_code >= 400:
+        return _diagnosis(
+            "http-error",
+            f"HTTP {status_code} error from the relay.",
+            "The relay returned a non-success status that is not mapped to a more specific diagnosis.",
+            "Check the raw response, relay documentation, selected model, and account state.",
+        )
+
+    if "both formats failed" in text_lower:
+        return _diagnosis(
+            "format-detection",
+            "Neither Anthropic nor OpenAI chat format produced a usable response.",
+            "The base URL may be wrong, the key may be invalid, or the relay may require a different API family.",
+            "Run a minimal vendor curl command from the relay docs, then retry with the documented base URL and model id.",
+        )
+    if "cors" in text_lower or "failed to fetch" in text_lower:
+        return _diagnosis(
+            "browser-cors",
+            "Browser access was blocked before a normal API response was available.",
+            "The relay likely does not allow browser-origin requests or hides responses from frontend JavaScript.",
+            "Run the generated curl command in a terminal; terminal requests are not subject to browser CORS.",
+        )
+    if "ssl" in text_lower or "certificate" in text_lower or "tls" in text_lower:
+        return _diagnosis(
+            "tls",
+            "TLS/SSL connection failed.",
+            "The relay certificate may be self-signed, expired, misconfigured, or blocked by the local trust store.",
+            "Retry once; the audit client may fall back to curl, but treat persistent TLS failures as operator-quality evidence.",
+        )
+    if "timed out" in text_lower or "timeout" in text_lower:
+        return _diagnosis(
+            "timeout",
+            "Request timed out before a response was received.",
+            "The relay, upstream model, or local network path is too slow for the current timeout.",
+            "Retry with --timeout increased, or skip long-running probes to determine whether only one step is slow.",
+        )
+    if (
+        "connecterror" in text_lower
+        or "connection refused" in text_lower
+        or "connection reset" in text_lower
+        or "name or service not known" in text_lower
+        or "nodename nor servname" in text_lower
+        or "could not resolve" in text_lower
+        or "temporary failure in name resolution" in text_lower
+    ):
+        return _diagnosis(
+            "network",
+            "Network connection to the relay failed.",
+            "DNS, firewall, proxy, VPN, or relay availability may be preventing any HTTP response.",
+            "Check the base URL in a browser or with curl -I, then retry from the same network path.",
+        )
+    if "expecting value" in text_lower or "jsondecodeerror" in text_lower:
+        return _diagnosis(
+            "non-json",
+            "Relay returned a non-JSON response where API JSON was expected.",
+            "The endpoint may be an HTML landing page, reverse-proxy error page, or non-API route.",
+            "Check the base URL and inspect the raw response with curl before running the full audit.",
+        )
+    if "empty curl output" in text_lower or "no header/body separator" in text_lower:
+        return _diagnosis(
+            "curl-output",
+            "curl did not receive a parseable HTTP response.",
+            "The relay closed the connection, returned malformed output, or an intermediary stripped the response.",
+            "Retry with curl -i against the same URL and inspect whether any HTTP status line is present.",
+        )
+    if "curl failed" in text_lower:
+        return _diagnosis(
+            "curl",
+            "curl transport failed.",
+            "The fallback transport could not complete the request, often due to network, TLS, DNS, or proxy issues.",
+            "Run curl --version and a minimal curl request to the relay, then retry the audit.",
+        )
+
+    return _diagnosis(
+        "unknown",
+        "Unmapped relay/API error.",
+        "The audit received an error string that does not match a known operational bucket.",
+        "Inspect the raw error, verify the key/base URL/model, and include the redacted report when asking the relay operator.",
+    )
+
+
+def format_diagnosis(diagnosis):
+    """Render a diagnosis dict as one compact Markdown line."""
+    return (
+        f"**Diagnosis**: {diagnosis['summary']} "
+        f"Likely cause: {diagnosis['likely_cause']} "
+        f"Next step: {diagnosis['suggested_action']}"
+    )

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 223e4f941de9b4fda1d1c8c440314de5ad3f5fc1fb6cad69d365c1aa38ff2a66
-# standalone_body_sha256: 54a80470c90fccf97e640b7831e05ca2dde72ef685e6ccc2e639a7fa73b6e25c
+# source_sha256: 8b832d50481029fa972bf0772bed8119f6e1fd13c2cfe38082c34aaded25b98b
+# standalone_body_sha256: 664a23e101a5b0f598a3273e97911cc3a3b13da975c105afb7882cd6ff177640
 # END GENERATED STANDALONE HEADER
 
 """
@@ -1033,6 +1033,16 @@ class APIClient:
         return _transport.httpx_post_json(
             url, headers, body, self.timeout)
 
+    @staticmethod
+    def _error_result(error, **extra):
+        error_text = str(error)
+        result = {
+            "error": error_text,
+            "diagnosis": diagnose_error(error_text),
+        }
+        result.update(extra)
+        return result
+
     # -- Anthropic native format ----------------------------------------------
 
     def _call_anthropic(self, messages, system=None, max_tokens=512):
@@ -1052,7 +1062,7 @@ class APIClient:
 
         data = self._post(url, headers, body)
         if "_http_error" in data:
-            return {"error": data["_http_error"]}
+            return self._error_result(data["_http_error"])
         text = _extract_anthropic_text(data.get("content"))
         usage = data.get("usage", {})
         return {
@@ -1082,7 +1092,7 @@ class APIClient:
 
         data = self._post(url, headers, body)
         if "_http_error" in data:
-            return {"error": data["_http_error"]}
+            return self._error_result(data["_http_error"])
         choice = data.get("choices", [{}])[0]
         text = choice.get("message", {}).get("content", "")
         usage = data.get("usage", {})
@@ -1169,7 +1179,7 @@ class APIClient:
             self._log_transparent(
                 "call", self._resolve_call_url(), "POST",
                 request_body, None, 0, None, elapsed, str(e))
-            return {"error": str(e), "time": elapsed}
+            return self._error_result(e, time=elapsed)
 
     def _resolve_call_url(self) -> str:
         """Reconstruct the URL used by the last ``call()`` based on detected format."""
@@ -1231,7 +1241,7 @@ class APIClient:
         if openai_result and "error" not in openai_result:
             self._format = "openai"
             return openai_result
-        return anthropic_result or openai_result or {"error": "Both formats failed"}
+        return anthropic_result or openai_result or self._error_result("Both formats failed")
 
     def _handle_ssl_error(self, e: Exception) -> bool:
         """Switch to curl on SSL errors. Returns True if retry is warranted."""
@@ -2294,6 +2304,224 @@ def run_tool_substitution_test(client, sleep: float = 1.0):
     detected = any(r["verdict"] == "substituted" for r in results)
     inconclusive = all(r["verdict"] == "error" for r in results)
     return results, detected, inconclusive
+
+
+# ============================================================
+# Error diagnosis helpers
+# ============================================================
+
+"""User-facing diagnosis helpers for relay/API errors.
+
+This module turns terse transport or HTTP errors into a stable, reportable
+explanation. It is intentionally informational: diagnoses help users fix
+connectivity/configuration problems but do not change any detector verdict or
+overall risk-matrix branch.
+"""
+
+import re
+
+
+_HTTP_STATUS_RE = re.compile(r"\bHTTP\s+(\d{3})\b", re.IGNORECASE)
+
+
+def _coerce_status(status):
+    if status is None:
+        return None
+    try:
+        value = int(status)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _status_from_error(error):
+    match = _HTTP_STATUS_RE.search(str(error or ""))
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
+def _diagnosis(category, summary, likely_cause, suggested_action):
+    return {
+        "category": category,
+        "summary": summary,
+        "likely_cause": likely_cause,
+        "suggested_action": suggested_action,
+    }
+
+
+def diagnose_error(error=None, status=None):
+    """Return a structured diagnosis for an HTTP/transport error.
+
+    Args:
+        error: Error string from ``APIClient.call()``, ``raw_request()``, or a
+            stream transport failure.
+        status: Optional numeric HTTP status. When present, it takes priority
+            over status text parsed from ``error``.
+
+    Returns:
+        Dict with ``category``, ``summary``, ``likely_cause``, and
+        ``suggested_action``. The function never raises and never treats an
+        error as safe; it only explains the most likely operational cause.
+    """
+    text = str(error or "").strip()
+    text_lower = text.lower()
+    status_code = _coerce_status(status) or _status_from_error(text)
+
+    if status_code == 400:
+        return _diagnosis(
+            "bad-request",
+            "Request shape rejected by the relay.",
+            "The selected API format, model name, message schema, or content-type may not match this relay.",
+            "Verify the base URL, model id, and whether the relay expects Anthropic messages or OpenAI chat completions.",
+        )
+    if status_code == 401:
+        return _diagnosis(
+            "auth",
+            "Authentication failed.",
+            "The API key is invalid, expired, copied with extra whitespace, or not accepted by this relay.",
+            "Check the key in the provider dashboard and retry with a freshly copied key.",
+        )
+    if status_code == 403:
+        return _diagnosis(
+            "permission",
+            "The relay rejected an authenticated request.",
+            "The account may lack model access, have billing/credit problems, or be blocked from this API format.",
+            "Check account balance, model permissions, regional restrictions, and relay-side allowlists.",
+        )
+    if status_code == 404:
+        return _diagnosis(
+            "endpoint",
+            "Endpoint not found.",
+            "The base URL may be missing or duplicating a /v1 prefix, or the relay may not expose this route.",
+            "Try the relay's documented base URL and avoid appending /messages or /chat/completions manually.",
+        )
+    if status_code == 408:
+        return _diagnosis(
+            "timeout",
+            "The relay timed out the request.",
+            "The relay or upstream provider did not answer before the HTTP timeout.",
+            "Retry once, then increase --timeout or run with slower steps skipped to isolate the failing probe.",
+        )
+    if status_code == 413:
+        return _diagnosis(
+            "payload-too-large",
+            "Request body is too large for the relay.",
+            "The relay may enforce a smaller payload/context limit than the advertised model.",
+            "Retry with --fast-context or --skip-context, then run the full context test only if the relay supports it.",
+        )
+    if status_code == 422:
+        return _diagnosis(
+            "unprocessable",
+            "Request schema was understood but rejected.",
+            "Common causes are unsupported system prompts, unsupported model ids, or a relay-specific schema restriction.",
+            "Verify model access and whether this relay accepts custom system prompts for the selected format.",
+        )
+    if status_code == 429:
+        return _diagnosis(
+            "rate-limit",
+            "Rate limit or quota was hit.",
+            "The relay or upstream provider is throttling this key, account, or model.",
+            "Wait and retry with --skip-context or a lower --latency-probe-count, or upgrade the relay/provider quota.",
+        )
+    if status_code in (500, 502, 503, 504):
+        return _diagnosis(
+            "upstream-or-relay",
+            "Relay or upstream provider error.",
+            "The relay backend, gateway, or upstream model provider failed while handling the request.",
+            "Retry later; if it repeats, share the redacted report with the relay operator and inspect Step 9 for leakage.",
+        )
+    if status_code is not None and status_code >= 400:
+        return _diagnosis(
+            "http-error",
+            f"HTTP {status_code} error from the relay.",
+            "The relay returned a non-success status that is not mapped to a more specific diagnosis.",
+            "Check the raw response, relay documentation, selected model, and account state.",
+        )
+
+    if "both formats failed" in text_lower:
+        return _diagnosis(
+            "format-detection",
+            "Neither Anthropic nor OpenAI chat format produced a usable response.",
+            "The base URL may be wrong, the key may be invalid, or the relay may require a different API family.",
+            "Run a minimal vendor curl command from the relay docs, then retry with the documented base URL and model id.",
+        )
+    if "cors" in text_lower or "failed to fetch" in text_lower:
+        return _diagnosis(
+            "browser-cors",
+            "Browser access was blocked before a normal API response was available.",
+            "The relay likely does not allow browser-origin requests or hides responses from frontend JavaScript.",
+            "Run the generated curl command in a terminal; terminal requests are not subject to browser CORS.",
+        )
+    if "ssl" in text_lower or "certificate" in text_lower or "tls" in text_lower:
+        return _diagnosis(
+            "tls",
+            "TLS/SSL connection failed.",
+            "The relay certificate may be self-signed, expired, misconfigured, or blocked by the local trust store.",
+            "Retry once; the audit client may fall back to curl, but treat persistent TLS failures as operator-quality evidence.",
+        )
+    if "timed out" in text_lower or "timeout" in text_lower:
+        return _diagnosis(
+            "timeout",
+            "Request timed out before a response was received.",
+            "The relay, upstream model, or local network path is too slow for the current timeout.",
+            "Retry with --timeout increased, or skip long-running probes to determine whether only one step is slow.",
+        )
+    if (
+        "connecterror" in text_lower
+        or "connection refused" in text_lower
+        or "connection reset" in text_lower
+        or "name or service not known" in text_lower
+        or "nodename nor servname" in text_lower
+        or "could not resolve" in text_lower
+        or "temporary failure in name resolution" in text_lower
+    ):
+        return _diagnosis(
+            "network",
+            "Network connection to the relay failed.",
+            "DNS, firewall, proxy, VPN, or relay availability may be preventing any HTTP response.",
+            "Check the base URL in a browser or with curl -I, then retry from the same network path.",
+        )
+    if "expecting value" in text_lower or "jsondecodeerror" in text_lower:
+        return _diagnosis(
+            "non-json",
+            "Relay returned a non-JSON response where API JSON was expected.",
+            "The endpoint may be an HTML landing page, reverse-proxy error page, or non-API route.",
+            "Check the base URL and inspect the raw response with curl before running the full audit.",
+        )
+    if "empty curl output" in text_lower or "no header/body separator" in text_lower:
+        return _diagnosis(
+            "curl-output",
+            "curl did not receive a parseable HTTP response.",
+            "The relay closed the connection, returned malformed output, or an intermediary stripped the response.",
+            "Retry with curl -i against the same URL and inspect whether any HTTP status line is present.",
+        )
+    if "curl failed" in text_lower:
+        return _diagnosis(
+            "curl",
+            "curl transport failed.",
+            "The fallback transport could not complete the request, often due to network, TLS, DNS, or proxy issues.",
+            "Run curl --version and a minimal curl request to the relay, then retry the audit.",
+        )
+
+    return _diagnosis(
+        "unknown",
+        "Unmapped relay/API error.",
+        "The audit received an error string that does not match a known operational bucket.",
+        "Inspect the raw error, verify the key/base URL/model, and include the redacted report when asking the relay operator.",
+    )
+
+
+def format_diagnosis(diagnosis):
+    """Render a diagnosis dict as one compact Markdown line."""
+    return (
+        f"**Diagnosis**: {diagnosis['summary']} "
+        f"Likely cause: {diagnosis['likely_cause']} "
+        f"Next step: {diagnosis['suggested_action']}"
+    )
 
 
 # ============================================================
@@ -4622,6 +4850,21 @@ def _format_identity_inconsistency(non_claude_matches):
     )
 
 
+def _diagnosis_for_error(error, status=None):
+    """Return the best available user-facing diagnosis for an error."""
+    return diagnose_error(error, status=status)
+
+
+def _report_error(report, error, status=None):
+    """Render a terse error plus an operational diagnosis.
+
+    The diagnosis is informational only: it helps the user fix auth, model,
+    endpoint, quota, or network problems but does not affect the risk matrix.
+    """
+    report.p(f"Error: {error}")
+    report.p(format_diagnosis(_diagnosis_for_error(error, status=status)))
+
+
 # ============================================================
 # CLI
 # ============================================================
@@ -4960,12 +5203,14 @@ def test_token_injection(client, report):
     injection_size = 0
     errors = []
     success_count = 0
+    error_diagnostics = []
     for name, sys_prompt, user_msg, expected in tests:
         r = client.call([{"role": "user", "content": user_msg}],
                         system=sys_prompt, max_tokens=100)
         if "error" in r:
             report.p(f"| {name} | ERROR | ~{expected} | - |")
             errors.append(r.get("error", ""))
+            error_diagnostics.append((name, r["error"]))
         else:
             success_count += 1
             actual = r["input_tokens"]
@@ -4973,6 +5218,11 @@ def test_token_injection(client, report):
             injection_size = max(injection_size, diff)
             report.p(f"| {name} | **{actual}** | ~{expected} | **~{diff}** |")
         time.sleep(1)
+
+    if error_diagnostics:
+        report.p("\n**Error diagnostics:**")
+        for name, error in error_diagnostics:
+            report.p(f"- {name}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     if success_count == 0:
         if errors and all(_looks_like_claude_code_client_gate(err) for err in errors):
@@ -5022,7 +5272,7 @@ def test_prompt_extraction(client, report):
         report.h3(f"Test {name}")
         r = client.call([{"role": "user", "content": prompt}], max_tokens=1024)
         if "error" in r:
-            report.p(f"Error: {r['error']}")
+            _report_error(report, r["error"])
             inconclusive = True
             inconclusive_names.append(name)
         else:
@@ -5115,7 +5365,7 @@ def test_instruction_conflict(client, report):
 
     overridden = False
     if "error" in r:
-        report.p(f"Error: {r['error']}")
+        _report_error(report, r["error"])
         # 422 typically means relay rejects custom system prompts — user has no control
         if "422" in str(r.get("error", "")):
             overridden = True
@@ -5152,7 +5402,7 @@ def test_instruction_conflict(client, report):
     )
 
     if "error" in r:
-        report.p(f"Error: {r['error']}")
+        _report_error(report, r["error"])
         if "422" in str(r.get("error", "")):
             overridden = True
             report.flag("red", "Identity test blocked: relay rejects custom system prompts (HTTP 422)")
@@ -5229,7 +5479,7 @@ def test_jailbreak(client, report):
         report.h3(f"Test {name}")
         r = client.call([{"role": "user", "content": prompt}], max_tokens=1024)
         if "error" in r:
-            report.p(f"Error: {r['error']}")
+            _report_error(report, r["error"])
             error_messages.append(r.get("error", ""))
         else:
             success_count += 1
@@ -5324,10 +5574,12 @@ def test_tool_substitution(client, report):
     report.p("| Manager | Expected | Received | Verdict |")
     report.p("|---------|----------|----------|---------|")
     error_count = 0
+    error_diagnostics = []
     for r in results:
         expected = r["expected"]
         if r["verdict"] == "error":
             error_count += 1
+            error_diagnostics.append((r["manager"], r.get("error") or ""))
             err_short = (r.get("error") or "")[:60].replace("|", "\\|").replace("\n", " ")
             received_cell = f"ERROR: {err_short}"
             icon = "\u26aa skipped"
@@ -5341,6 +5593,11 @@ def test_tool_substitution(client, report):
             else:
                 icon = "\U0001f534 SUBSTITUTED"
         report.p(f"| {r['manager']} | `{expected}` | {received_cell} | {icon} |")
+
+    if error_diagnostics:
+        report.p("\n**Error diagnostics:**")
+        for manager, error in error_diagnostics:
+            report.p(f"- {manager}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     if detected:
         subs = sum(1 for r in results if r["verdict"] == "substituted")
@@ -5402,10 +5659,12 @@ def test_error_leakage(client, args, report):
 
     report.p("| Trigger | HTTP Status | Severity | Leaks |")
     report.p("|---------|-------------|----------|-------|")
+    transport_error_diagnostics = []
     for r in results:
         name = r["trigger"]
         status_cell = str(r["status"]) if r["status"] else "—"
         if r["error"]:
+            transport_error_diagnostics.append((name, r["error"]))
             status_cell = f"ERR: {r['error'][:40]}"
         sev = r["severity"]
         if sev == "critical":
@@ -5419,6 +5678,11 @@ def test_error_leakage(client, args, report):
         leak_kinds = sorted({h["kind"] for h in r["hits"]})
         leaks_cell = ", ".join(leak_kinds) if leak_kinds else "—"
         report.p(f"| {name} | {status_cell} | {sev_cell} | {leaks_cell} |")
+
+    if transport_error_diagnostics:
+        report.p("\n**Transport error diagnostics:**")
+        for name, error in transport_error_diagnostics:
+            report.p(f"- {name}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     # Per-trigger detail subsections for any probe with at least one hit.
     any_hits = [r for r in results if r["hits"]]
@@ -5532,6 +5796,9 @@ def test_stream_integrity(client, report):
         report.p("\n**Findings**:")
         for finding in analysis["findings"]:
             report.p(f"- {finding}")
+    if signals.transport_error:
+        report.p("\n**Transport error diagnosis:**")
+        report.p(format_diagnosis(_diagnosis_for_error(signals.transport_error)))
 
     if verdict == "anomaly":
         report.flag(
@@ -5587,8 +5854,10 @@ def test_web3_injection(client, report):
 
     report.p("| Probe | Verdict | Safe markers | Unsafe markers |")
     report.p("|-------|---------|--------------|----------------|")
+    error_diagnostics = []
     for r in results:
         if r.error:
+            error_diagnostics.append((r.name, r.error))
             report.p(f"| {r.name} | ERR: {r.error[:40]} | — | — |")
             continue
         if r.verdict == "safe":
@@ -5600,6 +5869,11 @@ def test_web3_injection(client, report):
         safe_summary = ", ".join(r.safe_markers_found[:3]) if r.safe_markers_found else "—"
         unsafe_summary = ", ".join(r.unsafe_markers_found[:3]) if r.unsafe_markers_found else "—"
         report.p(f"| {r.name} | {v} | {safe_summary} | {unsafe_summary} |")
+
+    if error_diagnostics:
+        report.p("\n**Error diagnostics:**")
+        for name, error in error_diagnostics:
+            report.p(f"- {name}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     # Per-probe details for any injected or inconclusive-with-response
     for r in results:
@@ -5721,11 +5995,13 @@ def test_infra_fingerprint(client, report):
 
     report.p("| Probe | Path | Status | Framework | Signals |")
     report.p("|-------|------|--------|-----------|---------|")
+    error_diagnostics = []
     for r in results:
         name = r["probe"]
         path = r["path"]
         status_cell = str(r["status"]) if r["status"] else "—"
         if r["error"]:
+            error_diagnostics.append((name, r["error"]))
             status_cell = f"ERR: {r['error'][:40]}"
         framework = r["framework"] or "—"
         if r["signals"]:
@@ -5734,6 +6010,11 @@ def test_infra_fingerprint(client, report):
         else:
             signals_cell = "—"
         report.p(f"| {name} | `{path}` | {status_cell} | `{framework}` | {signals_cell} |")
+
+    if error_diagnostics:
+        report.p("\n**Transport error diagnostics:**")
+        for name, error in error_diagnostics:
+            report.p(f"- {name}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     # Informative headers across all probes, de-duplicated per (name, value)
     merged_headers = {}
@@ -5811,6 +6092,13 @@ def test_latency_variance(client, report, probe_count=10):
     stats = result["stats"]
 
     if not latencies:
+        if errors:
+            report.p("\n**Error diagnostics:**")
+            for idx, error in enumerate(errors, start=1):
+                report.p(
+                    f"- probe {idx}: "
+                    f"{format_diagnosis(_diagnosis_for_error(error))}"
+                )
         report.flag(
             "yellow",
             f"Latency variance test inconclusive: all {len(errors)} "
@@ -5832,6 +6120,11 @@ def test_latency_variance(client, report, probe_count=10):
     report.p(f"| coefficient of variation | {stats['cv']:.3f} |")
     report.p(f"| largest-gap / median | {result['gap_ratio']:.3f} |")
     report.p(f"| verdict | `{result['verdict']}` |")
+
+    if errors:
+        report.p("\n**Error diagnostics:**")
+        for idx, error in enumerate(errors, start=1):
+            report.p(f"- failed probe {idx}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     verdict = result["verdict"]
     if verdict == "bimodal":
@@ -5940,6 +6233,13 @@ def test_channel_classifier(client, report):
         report.p(f"| evidence | {ev_str} |")
     else:
         report.p("| evidence | — |")
+
+    if error:
+        report.p("\n**Transport error diagnosis:**")
+        report.p(format_diagnosis(_diagnosis_for_error(error)))
+    elif verdict == "inconclusive" and raw_status:
+        report.p("\n**HTTP status diagnosis:**")
+        report.p(format_diagnosis(_diagnosis_for_error(None, status=raw_status)))
 
     if verdict == "inconclusive":
         if error:

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,24 +16,24 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **754** | `pytest --collect-only` |
-| 测试数 (static) | 730 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **764** | `pytest --collect-only` |
+| 测试数 (static) | 740 | grep `def test_*` in tests/ |
 | CLI flag 数 | 21 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-07 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
-| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `03392b0` | recent reachable commit; `--check` allows follow-up metrics commits |
+| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 743] | grep `Final test count: N/N passing` |
+| Recorded commit SHA | `d0528e6` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-07 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
-- ℹ️ pytest (754) vs 静态 (730) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
-- ⚠️ ROADMAP 最新记录 700 个测试，但当前 pytest 是 754。要么 ROADMAP 漏更新，要么有未记录的新测试。
+- ℹ️ pytest (764) vs 静态 (740) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
+- ⚠️ ROADMAP 最新记录 743 个测试，但当前 pytest 是 764。要么 ROADMAP 漏更新，要么有未记录的新测试。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -37,6 +37,7 @@ from api_relay_audit.channel_classifier import run_channel_classifier
 from api_relay_audit.client import APIClient
 from api_relay_audit.connectivity import run_connectivity_check
 from api_relay_audit.context import run_context_scan
+from api_relay_audit.error_diagnosis import diagnose_error, format_diagnosis
 from api_relay_audit.error_leakage import run_error_leakage_test
 from api_relay_audit.identity_patterns import find_non_claude_identities
 from api_relay_audit.infra_fingerprint import (
@@ -78,6 +79,21 @@ def _format_identity_inconsistency(non_claude_matches):
         "of the actual upstream model; preserve the full response JSON, "
         "request id, provider/model metadata, and platform logs for attribution."
     )
+
+
+def _diagnosis_for_error(error, status=None):
+    """Return the best available user-facing diagnosis for an error."""
+    return diagnose_error(error, status=status)
+
+
+def _report_error(report, error, status=None):
+    """Render a terse error plus an operational diagnosis.
+
+    The diagnosis is informational only: it helps the user fix auth, model,
+    endpoint, quota, or network problems but does not affect the risk matrix.
+    """
+    report.p(f"Error: {error}")
+    report.p(format_diagnosis(_diagnosis_for_error(error, status=status)))
 
 
 # ============================================================
@@ -418,12 +434,14 @@ def test_token_injection(client, report):
     injection_size = 0
     errors = []
     success_count = 0
+    error_diagnostics = []
     for name, sys_prompt, user_msg, expected in tests:
         r = client.call([{"role": "user", "content": user_msg}],
                         system=sys_prompt, max_tokens=100)
         if "error" in r:
             report.p(f"| {name} | ERROR | ~{expected} | - |")
             errors.append(r.get("error", ""))
+            error_diagnostics.append((name, r["error"]))
         else:
             success_count += 1
             actual = r["input_tokens"]
@@ -431,6 +449,11 @@ def test_token_injection(client, report):
             injection_size = max(injection_size, diff)
             report.p(f"| {name} | **{actual}** | ~{expected} | **~{diff}** |")
         time.sleep(1)
+
+    if error_diagnostics:
+        report.p("\n**Error diagnostics:**")
+        for name, error in error_diagnostics:
+            report.p(f"- {name}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     if success_count == 0:
         if errors and all(_looks_like_claude_code_client_gate(err) for err in errors):
@@ -480,7 +503,7 @@ def test_prompt_extraction(client, report):
         report.h3(f"Test {name}")
         r = client.call([{"role": "user", "content": prompt}], max_tokens=1024)
         if "error" in r:
-            report.p(f"Error: {r['error']}")
+            _report_error(report, r["error"])
             inconclusive = True
             inconclusive_names.append(name)
         else:
@@ -573,7 +596,7 @@ def test_instruction_conflict(client, report):
 
     overridden = False
     if "error" in r:
-        report.p(f"Error: {r['error']}")
+        _report_error(report, r["error"])
         # 422 typically means relay rejects custom system prompts — user has no control
         if "422" in str(r.get("error", "")):
             overridden = True
@@ -610,7 +633,7 @@ def test_instruction_conflict(client, report):
     )
 
     if "error" in r:
-        report.p(f"Error: {r['error']}")
+        _report_error(report, r["error"])
         if "422" in str(r.get("error", "")):
             overridden = True
             report.flag("red", "Identity test blocked: relay rejects custom system prompts (HTTP 422)")
@@ -687,7 +710,7 @@ def test_jailbreak(client, report):
         report.h3(f"Test {name}")
         r = client.call([{"role": "user", "content": prompt}], max_tokens=1024)
         if "error" in r:
-            report.p(f"Error: {r['error']}")
+            _report_error(report, r["error"])
             error_messages.append(r.get("error", ""))
         else:
             success_count += 1
@@ -782,10 +805,12 @@ def test_tool_substitution(client, report):
     report.p("| Manager | Expected | Received | Verdict |")
     report.p("|---------|----------|----------|---------|")
     error_count = 0
+    error_diagnostics = []
     for r in results:
         expected = r["expected"]
         if r["verdict"] == "error":
             error_count += 1
+            error_diagnostics.append((r["manager"], r.get("error") or ""))
             err_short = (r.get("error") or "")[:60].replace("|", "\\|").replace("\n", " ")
             received_cell = f"ERROR: {err_short}"
             icon = "\u26aa skipped"
@@ -799,6 +824,11 @@ def test_tool_substitution(client, report):
             else:
                 icon = "\U0001f534 SUBSTITUTED"
         report.p(f"| {r['manager']} | `{expected}` | {received_cell} | {icon} |")
+
+    if error_diagnostics:
+        report.p("\n**Error diagnostics:**")
+        for manager, error in error_diagnostics:
+            report.p(f"- {manager}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     if detected:
         subs = sum(1 for r in results if r["verdict"] == "substituted")
@@ -860,10 +890,12 @@ def test_error_leakage(client, args, report):
 
     report.p("| Trigger | HTTP Status | Severity | Leaks |")
     report.p("|---------|-------------|----------|-------|")
+    transport_error_diagnostics = []
     for r in results:
         name = r["trigger"]
         status_cell = str(r["status"]) if r["status"] else "—"
         if r["error"]:
+            transport_error_diagnostics.append((name, r["error"]))
             status_cell = f"ERR: {r['error'][:40]}"
         sev = r["severity"]
         if sev == "critical":
@@ -877,6 +909,11 @@ def test_error_leakage(client, args, report):
         leak_kinds = sorted({h["kind"] for h in r["hits"]})
         leaks_cell = ", ".join(leak_kinds) if leak_kinds else "—"
         report.p(f"| {name} | {status_cell} | {sev_cell} | {leaks_cell} |")
+
+    if transport_error_diagnostics:
+        report.p("\n**Transport error diagnostics:**")
+        for name, error in transport_error_diagnostics:
+            report.p(f"- {name}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     # Per-trigger detail subsections for any probe with at least one hit.
     any_hits = [r for r in results if r["hits"]]
@@ -990,6 +1027,9 @@ def test_stream_integrity(client, report):
         report.p("\n**Findings**:")
         for finding in analysis["findings"]:
             report.p(f"- {finding}")
+    if signals.transport_error:
+        report.p("\n**Transport error diagnosis:**")
+        report.p(format_diagnosis(_diagnosis_for_error(signals.transport_error)))
 
     if verdict == "anomaly":
         report.flag(
@@ -1045,8 +1085,10 @@ def test_web3_injection(client, report):
 
     report.p("| Probe | Verdict | Safe markers | Unsafe markers |")
     report.p("|-------|---------|--------------|----------------|")
+    error_diagnostics = []
     for r in results:
         if r.error:
+            error_diagnostics.append((r.name, r.error))
             report.p(f"| {r.name} | ERR: {r.error[:40]} | — | — |")
             continue
         if r.verdict == "safe":
@@ -1058,6 +1100,11 @@ def test_web3_injection(client, report):
         safe_summary = ", ".join(r.safe_markers_found[:3]) if r.safe_markers_found else "—"
         unsafe_summary = ", ".join(r.unsafe_markers_found[:3]) if r.unsafe_markers_found else "—"
         report.p(f"| {r.name} | {v} | {safe_summary} | {unsafe_summary} |")
+
+    if error_diagnostics:
+        report.p("\n**Error diagnostics:**")
+        for name, error in error_diagnostics:
+            report.p(f"- {name}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     # Per-probe details for any injected or inconclusive-with-response
     for r in results:
@@ -1179,11 +1226,13 @@ def test_infra_fingerprint(client, report):
 
     report.p("| Probe | Path | Status | Framework | Signals |")
     report.p("|-------|------|--------|-----------|---------|")
+    error_diagnostics = []
     for r in results:
         name = r["probe"]
         path = r["path"]
         status_cell = str(r["status"]) if r["status"] else "—"
         if r["error"]:
+            error_diagnostics.append((name, r["error"]))
             status_cell = f"ERR: {r['error'][:40]}"
         framework = r["framework"] or "—"
         if r["signals"]:
@@ -1192,6 +1241,11 @@ def test_infra_fingerprint(client, report):
         else:
             signals_cell = "—"
         report.p(f"| {name} | `{path}` | {status_cell} | `{framework}` | {signals_cell} |")
+
+    if error_diagnostics:
+        report.p("\n**Transport error diagnostics:**")
+        for name, error in error_diagnostics:
+            report.p(f"- {name}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     # Informative headers across all probes, de-duplicated per (name, value)
     merged_headers = {}
@@ -1269,6 +1323,13 @@ def test_latency_variance(client, report, probe_count=10):
     stats = result["stats"]
 
     if not latencies:
+        if errors:
+            report.p("\n**Error diagnostics:**")
+            for idx, error in enumerate(errors, start=1):
+                report.p(
+                    f"- probe {idx}: "
+                    f"{format_diagnosis(_diagnosis_for_error(error))}"
+                )
         report.flag(
             "yellow",
             f"Latency variance test inconclusive: all {len(errors)} "
@@ -1290,6 +1351,11 @@ def test_latency_variance(client, report, probe_count=10):
     report.p(f"| coefficient of variation | {stats['cv']:.3f} |")
     report.p(f"| largest-gap / median | {result['gap_ratio']:.3f} |")
     report.p(f"| verdict | `{result['verdict']}` |")
+
+    if errors:
+        report.p("\n**Error diagnostics:**")
+        for idx, error in enumerate(errors, start=1):
+            report.p(f"- failed probe {idx}: {format_diagnosis(_diagnosis_for_error(error))}")
 
     verdict = result["verdict"]
     if verdict == "bimodal":
@@ -1398,6 +1464,13 @@ def test_channel_classifier(client, report):
         report.p(f"| evidence | {ev_str} |")
     else:
         report.p("| evidence | — |")
+
+    if error:
+        report.p("\n**Transport error diagnosis:**")
+        report.p(format_diagnosis(_diagnosis_for_error(error)))
+    elif verdict == "inconclusive" and raw_status:
+        report.p("\n**HTTP status diagnosis:**")
+        report.p(format_diagnosis(_diagnosis_for_error(None, status=raw_status)))
 
     if verdict == "inconclusive":
         if error:

--- a/scripts/build-standalone.py
+++ b/scripts/build-standalone.py
@@ -35,6 +35,7 @@ SOURCE_PATHS = (
     "api_relay_audit/_transport.py",
     "api_relay_audit/client.py",
     "api_relay_audit/context.py",
+    "api_relay_audit/error_diagnosis.py",
     "api_relay_audit/error_leakage.py",
     "api_relay_audit/identity_patterns.py",
     "api_relay_audit/infra_fingerprint.py",
@@ -291,6 +292,7 @@ def transform_client(text: str) -> str:
     text = drop_import_blocks(text, (
         "import httpx",
         "from api_relay_audit import _transport",
+        "from api_relay_audit.error_diagnosis import ",
         "from api_relay_audit.stream_integrity import StreamSignals",
         "from api_relay_audit.transparent_log import ",
     ))
@@ -379,6 +381,10 @@ SECTIONS = (
     Section(
         "Tool-call substitution detector",
         "api_relay_audit/tool_substitution.py",
+    ),
+    Section(
+        "Error diagnosis helpers",
+        "api_relay_audit/error_diagnosis.py",
     ),
     Section(
         "Non-Claude identity detector",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -118,6 +118,7 @@ class TestCallAnthropic:
 
         result = client._call_anthropic([{"role": "user", "content": "x"}])
         assert "error" in result
+        assert result["diagnosis"]["category"] == "upstream-or-relay"
 
     @patch("api_relay_audit.client.httpx.post")
     def test_empty_content(self, mock_post, client):
@@ -273,6 +274,7 @@ class TestCallOpenAI:
 
         result = client._call_openai([{"role": "user", "content": "x"}])
         assert "error" in result
+        assert result["diagnosis"]["category"] == "bad-request"
 
 
 # ---------------------------------------------------------------------------
@@ -515,6 +517,7 @@ class TestAutoDetection:
         result = client.call([{"role": "user", "content": "x"}])
         assert "error" in result
         assert "time" in result
+        assert result["diagnosis"]["category"] == "format-detection"
         assert result["time"] >= 0
 
 

--- a/tests/test_dual_distribution_parity.py
+++ b/tests/test_dual_distribution_parity.py
@@ -70,6 +70,24 @@ def _load_standalone_audit():
     return module
 
 
+def test_error_diagnosis_standalone_parity():
+    """Error diagnosis is part of the user-facing report contract."""
+    from api_relay_audit.error_diagnosis import diagnose_error as modular_diagnose
+
+    standalone = _load_standalone_audit()
+    cases = [
+        ("HTTP 401: invalid key", None),
+        ("HTTP 422: unsupported system prompt", None),
+        ("Both formats failed", None),
+        ("TypeError: Failed to fetch because of CORS", None),
+        ("upstream body did not include status", 403),
+    ]
+    for error, status in cases:
+        assert standalone.diagnose_error(error, status=status) == modular_diagnose(
+            error, status=status
+        )
+
+
 def test_identity_keywords_standalone_parity():
     """Regression (v1.7.6): the non-Claude identity keyword tuple and the
     strict-keyword frozenset in the standalone audit.py must match the

--- a/tests/test_error_diagnosis.py
+++ b/tests/test_error_diagnosis.py
@@ -1,0 +1,49 @@
+"""Tests for user-facing relay/API error diagnosis helpers."""
+
+from api_relay_audit.error_diagnosis import diagnose_error, format_diagnosis
+
+
+class TestDiagnoseError:
+    def test_401_auth_failure(self):
+        diagnosis = diagnose_error("HTTP 401: invalid api key")
+        assert diagnosis["category"] == "auth"
+        assert "Authentication failed" in diagnosis["summary"]
+        assert "freshly copied key" in diagnosis["suggested_action"]
+
+    def test_422_schema_rejection(self):
+        diagnosis = diagnose_error("HTTP 422: unsupported system")
+        assert diagnosis["category"] == "unprocessable"
+        assert "unsupported system prompts" in diagnosis["likely_cause"]
+
+    def test_429_rate_limit(self):
+        diagnosis = diagnose_error("HTTP 429: too many requests")
+        assert diagnosis["category"] == "rate-limit"
+        assert "--latency-probe-count" in diagnosis["suggested_action"]
+
+    def test_status_argument_takes_priority(self):
+        diagnosis = diagnose_error("upstream body did not include status", status=403)
+        assert diagnosis["category"] == "permission"
+
+    def test_both_formats_failed(self):
+        diagnosis = diagnose_error("Both formats failed")
+        assert diagnosis["category"] == "format-detection"
+        assert "Anthropic nor OpenAI" in diagnosis["summary"]
+
+    def test_browser_cors(self):
+        diagnosis = diagnose_error("TypeError: Failed to fetch because of CORS")
+        assert diagnosis["category"] == "browser-cors"
+        assert "terminal" in diagnosis["suggested_action"].lower()
+
+    def test_network_connect_error(self):
+        diagnosis = diagnose_error("ConnectError: connection refused")
+        assert diagnosis["category"] == "network"
+
+    def test_non_json_error(self):
+        diagnosis = diagnose_error("Expecting value: line 1 column 1 (char 0)")
+        assert diagnosis["category"] == "non-json"
+
+    def test_format_diagnosis_markdown(self):
+        rendered = format_diagnosis(diagnose_error("HTTP 404: missing"))
+        assert rendered.startswith("**Diagnosis**:")
+        assert "Endpoint not found" in rendered
+        assert "Next step:" in rendered

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">754</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">764</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## Summary
- add a zero-dependency error diagnosis helper for common HTTP and transport failures
- include diagnosis objects on `APIClient.call()` errors and render compact diagnosis lines in the Markdown report
- wire the helper into the generated standalone artifact and update public test-count metrics

## Why
Users currently see terse errors such as HTTP 401, HTTP 422, JSON parse failures, TLS errors, or format-detection failures without a clear next step. This PR turns those failures into operational guidance while preserving the existing detector verdicts and LOW/MEDIUM/HIGH risk semantics.

## Boundary
This is an explanatory/reporting layer only. It does not add a new detector, hosted preflight flow, new API family, or risk-matrix dimension. Step 9 only diagnoses transport failures because its HTTP error statuses are intentionally induced leakage probes.

## Validation
- `python3 -m pytest tests/ -q` (743 passed)
- `python3 scripts/collect-metrics.py --check`
- `python3 scripts/build-standalone.py --check`
- `git diff --check`