### PR TITLE
Clarify query families and harden growth feedback surfaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/audit-report.yml
+++ b/.github/ISSUE_TEMPLATE/audit-report.yml
@@ -24,6 +24,31 @@ body:
       required: true
 
   - type: input
+    id: claimed_provider
+    attributes:
+      label: Claimed Provider / 声称供应商
+      description: "What provider/channel did the relay claim or advertise? Use unknown if unclear."
+      placeholder: "Anthropic / OpenAI / OpenRouter / unknown"
+
+  - type: dropdown
+    id: api_format
+    attributes:
+      label: API Format / API 格式
+      options:
+        - unknown
+        - openai-compatible
+        - anthropic-native
+        - both
+        - other
+
+  - type: input
+    id: model_tested
+    attributes:
+      label: Model Tested / 测试模型
+      description: "The model name used for this audit run, if shown in your command or report."
+      placeholder: "claude-opus-4-6"
+
+  - type: input
     id: tool_version
     attributes:
       label: Tool Version / 工具版本
@@ -60,6 +85,49 @@ body:
         - HIGH
     validations:
       required: true
+
+  - type: dropdown
+    id: evidence_level
+    attributes:
+      label: Evidence Level / 证据等级
+      options:
+        - redacted-report
+        - screenshot-only
+        - transparent-log-hash
+        - reproducible-run
+        - unknown
+
+  - type: textarea
+    id: step_summary
+    attributes:
+      label: Step Summary / 步骤摘要
+      description: |
+        Optional structured summary for key steps. Keep it redacted.
+        可选：填写关键步骤三态结果，请保持脱敏。
+      placeholder: |
+        Step 3 prompt injection: anomaly
+        Step 5 identity consistency: inconclusive
+        Step 8 tool-call substitution: clean
+        Step 11 Web3 prompt injection: not run
+
+  - type: dropdown
+    id: operator_contacted
+    attributes:
+      label: Operator Contacted / 是否联系运营方
+      options:
+        - unknown
+        - no
+        - yes
+        - operator-response-submitted
+
+  - type: dropdown
+    id: false_positive_suspected
+    attributes:
+      label: False Positive Suspected / 是否怀疑误报
+      options:
+        - unsure
+        - no
+        - yes
 
   - type: textarea
     id: report_image

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img alt="API Relay Audit - AI API Relay Security Audit. Prompt Injection, Model Substitution, Tool Rewriting, SSE Anomalies. Runs locally; your API key is sent only to the relay URL you choose." src="./assets/readme-banner.png">
+  <img alt="API Relay Audit - local AI API relay security audit with separate query families for relay audit, prompt injection audit, model substitution signals, and Web3 relay audit." src="./assets/readme-banner.png">
 </p>
 
 # API Relay Audit
@@ -23,15 +23,26 @@
 
 ## What Is API Relay Audit?
 
-API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Your API key is sent only to the relay URL you choose.
+API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It keeps API relay audit, prompt injection audit, model substitution signals, and Web3 relay audit as separate query families so each result keeps a clean evidence boundary. Your API key is sent only to the relay URL you choose.
 
 Use it when you rely on a third-party AI API relay, OpenAI-compatible proxy, Claude-compatible proxy, or Web3 agent workflow and want a repeatable Markdown report before trusting that relay with production or wallet-related traffic.
 
 ## AI API Relay Security Audit
 
-- **Detect relay tampering:** prompt injection, prompt extraction, identity substitution, context truncation, tool-call rewriting, error-response leakage, and SSE stream anomalies.
+- **Detect relay tampering:** prompt injection, prompt extraction, identity consistency signals, context truncation, tool-call rewriting, error-response leakage, and SSE stream anomalies.
 - **Run locally:** the standalone `audit.py` uses only Python stdlib plus `curl`; your API key is sent only to the relay URL you choose.
 - **Produce reviewable evidence:** each run generates a structured Markdown report with per-step findings and a final `LOW / MEDIUM / HIGH` verdict.
+
+## Query Family Boundaries
+
+| Query family | User intent | Profile / steps | Evidence boundary |
+|---|---|---|---|
+| API relay audit | Audit a third-party relay, mirror, gateway, LLM proxy, or resale API before trusting traffic. | `general` by default; `full` for every probe | Produces a local report, not a safety certificate. |
+| Prompt injection audit | Detect hidden prompt injection, prompt leakage, instruction override, and extraction behavior. | `general`; Steps 3-6 | Records prompt evidence without publishing private prompts or secrets. |
+| Model substitution signals | Collect model identity, stream, latency, and upstream channel signals. | `general`; Steps 5, 10, 13, 14 | Self-ID, latency, and channel fingerprints are signals, not standalone proof of provider substitution. |
+| Web3 relay audit | Check wallet-sensitive relay behavior before agent workflows touch signing or transactions. | `web3` or `full`; Step 11 | Profile-gated; general relay audits do not imply wallet safety. |
+
+The canonical contract lives in [docs/query-families.md](./docs/query-families.md). README headings, Pages cards, issue templates, and skill descriptions should preserve these boundaries instead of flattening them into one slogan.
 
 ## Quick Start
 
@@ -46,13 +57,13 @@ python audit.py --key <YOUR_KEY> --url <BASE_URL> --profile web3 --output report
 
 See a public-safe fixture report: [sanitized audit report](./docs/examples/sanitized-audit-report.md).
 
-## Detect Prompt Injection and Model Substitution
+## Coverage
 
 API Relay Audit checks whether a relay modifies the request or response path between you and the model:
 
 - Prompt safety: token injection, prompt extraction, instruction override, jailbreak resistance
 - Relay integrity: context truncation, tool-call substitution, error leakage, stream integrity
-- Model identity: non-Claude identity leaks, model substitution, Claude/OpenAI-compatible relay behavior
+- Model identity: non-Claude identity leaks, model substitution signals, Claude/OpenAI-compatible relay behavior
 - Web3 wallet safety: transfer guidance, signed-transaction refusal, private-key refusal
 
 ## Audit LLM Proxies Locally
@@ -94,6 +105,12 @@ local, reviewable Markdown report before trusting a relay path.
 - It does not replace manual security review or operational monitoring.
 - It does not treat `inconclusive` as `clean`; blocked probes and ambiguous responses stay visible in the report.
 
+## Evidence Boundaries
+
+Natural-language self-identification is treated as a consistency signal, not upstream proof. A response saying it is Qwen, DeepSeek, GPT, or Claude can indicate a mismatch, but it does not by itself prove that a provider substituted the upstream model.
+
+Stronger claims require corroborating evidence such as raw response JSON, request IDs, provider/model metadata, stream signatures, transparent-log hashes, and reproducible runs. Public submissions should use redacted report artifacts and never include API keys, raw headers, full response bodies, wallet material, private relay traffic, or user data.
+
 ## Web3 Wallet Safety Checks
 
 With `--profile web3` or `--profile full`, API Relay Audit adds wallet-oriented prompt injection probes inspired by signature-isolation risks:
@@ -103,6 +120,29 @@ With `--profile web3` or `--profile full`, API Relay Audit adds wallet-oriented 
 - Private-key leak refusal checks
 
 These probes are model-agnostic, but they are intentionally profile-gated so general relay audits stay focused.
+
+## Working Model
+
+```text
+your machine
+  -> audit.py / scripts/audit.py
+  -> chosen relay endpoint
+  -> Markdown report + optional hash-only transparent log
+  -> optional: redacted evidence issue for maintainer review
+```
+
+Community evidence is shape-checked by GitHub Actions, but publication still requires maintainer review. Operators keep a separate response path, and sensitive vulnerabilities belong in the disclosure path described in [SECURITY.md](./SECURITY.md).
+
+## Project Status
+
+| Metric | Current value |
+|---|---:|
+| Version | `v2.3` |
+| Audit steps | 14 |
+| Risk matrix | 6D |
+| pytest collected tests | 764 |
+| CLI flags | 21 |
+| Runtime profiles | `general`, `web3`, `full` |
 
 ## Example Report And Live Page
 
@@ -137,7 +177,7 @@ Prompt injection means the relay may prepend or insert hidden instructions into 
 
 ### What is model substitution?
 
-Model substitution means the relay claims to provide one model but routes you to another model or leaks a different model identity. API Relay Audit checks non-Claude identity patterns, anchor phrases, and stream model identity signals where available.
+Model substitution means the relay claims to provide one model but may expose evidence signals for another model identity, route, or upstream channel. API Relay Audit checks non-Claude identity patterns, anchor phrases, stream model identity, latency variance, and channel evidence where available; those signals require corroboration before making provider-level claims.
 
 ### What is tool-call rewriting?
 
@@ -198,7 +238,7 @@ to one behavior or document.
 
 ## API Relay Audit 是什么？
 
-`api-relay-audit` 是一个本地运行的 AI API 中转站 / LLM proxy 安全审计工具。它检测 prompt injection、模型替换、工具调用改写、SSE 流异常、错误响应泄漏，以及 Web3 钱包相关风险；你的 API Key 只会发送到你指定的中转站 URL。
+`api-relay-audit` 是一个本地运行的 AI API 中转站 / LLM proxy 安全审计工具。它把 API relay audit、prompt injection audit、model substitution signals、Web3 relay audit 拆成独立查询意图，避免把不同风险压成一个口号；你的 API Key 只会发送到你指定的中转站 URL。
 
 当你使用第三方 AI API 中转站、OpenAI-compatible proxy、Claude-compatible proxy，或者 Web3 agent 工作流时，可以用它在信任该中转站之前生成一份可复查的 Markdown 审计报告。
 
@@ -208,6 +248,17 @@ to one behavior or document.
 - 双分发形态: `audit.py` 单文件零依赖版 + `api_relay_audit/` 模块化开发版
 - `--profile general|web3|full` 三种运行模式
 - `LOW / MEDIUM / HIGH` 总结论，加每一步的细项结果
+
+## 查询意图边界
+
+| Query family | 用户意图 | Profile / Steps | 证据边界 |
+|---|---|---|---|
+| API relay audit | 审计第三方中转站、镜像、网关、LLM proxy 或 resale API。 | 默认 `general`；完整覆盖用 `full` | 输出本地报告，不是安全认证。 |
+| Prompt injection audit | 检测隐藏 prompt 注入、prompt 泄漏、指令覆盖和提取行为。 | `general`；Step 3-6 | 记录 prompt 证据，但不公开私有 prompt 或 secret。 |
+| Model substitution signals | 收集模型身份、stream、延迟和上游 channel 信号。 | `general`；Step 5、10、13、14 | self-ID、延迟和 channel fingerprint 是信号，不能单独证明 provider 替换。 |
+| Web3 relay audit | 在 agent 接触签名、交易或钱包相关内容前检查中转行为。 | `web3` 或 `full`；Step 11 | profile-gated；普通 relay audit 不等于钱包安全。 |
+
+正式契约在 [docs/query-families.md](./docs/query-families.md)。README、Pages、issue template 和 skill description 都应该保留这些边界。
 
 ## 30 秒快速开始
 
@@ -224,7 +275,7 @@ python audit.py --key <YOUR_KEY> --url <BASE_URL> --profile web3 --output report
 
 - Prompt 安全: token injection、prompt extraction、instruction override、jailbreak
 - Relay 完整性: context truncation、tool-call substitution、error leakage、stream integrity
-- 模型身份: 非 Claude 身份泄漏、模型替换、Claude / OpenAI 兼容中转行为
+- 模型身份: 非 Claude 身份泄漏、模型替换信号、Claude / OpenAI 兼容中转行为
 - Web3 风险: 转账指引、签名拒绝、私钥泄漏拒绝
 
 ## Agent Skill 支持
@@ -248,6 +299,35 @@ API Relay Audit 也可以作为 agent skill 使用。
 - 它不为任何中转站颁发“安全认证”。
 - 它不替代人工安全审查或线上监控。
 - 它不会把 `inconclusive` 当成 `clean`；被拦截或无法判断的探针会保留在报告里。
+
+## 证据边界
+
+模型自然语言自称 Qwen、DeepSeek、GPT 或 Claude，只能作为 identity consistency signal，不能单独证明真实上游供应商或平台替换了模型。
+
+更强的结论需要 raw response JSON、request id、provider/model metadata、stream signature、transparent-log hash 和可复现实验共同支撑。公开提交只接受脱敏报告证据；不要提交 API Key、raw headers、完整 response body、钱包材料、私有中转流量或用户数据。
+
+## 工作方式
+
+```text
+你的机器
+  -> audit.py / scripts/audit.py
+  -> 你指定的 relay endpoint
+  -> Markdown report + 可选 hash-only transparent log
+  -> 可选：脱敏 evidence issue，等待 maintainer review
+```
+
+社区证据会被 GitHub Actions 做格式检查，但公开发布仍需要 maintainer review。运营方回应走单独通道，敏感漏洞走 [SECURITY.md](./SECURITY.md) 的 disclosure 路径。
+
+## 项目状态
+
+| 指标 | 当前值 |
+|---|---:|
+| 版本 | `v2.3` |
+| 审计步骤 | 14 |
+| 风险矩阵 | 6D |
+| pytest collected tests | 764 |
+| CLI flags | 21 |
+| Runtime profiles | `general`, `web3`, `full` |
 
 ## 如何贡献
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,32 @@ Please include:
 Do not include live credentials, private relay URLs, wallet seed phrases,
 private keys, or user traffic captures.
 
+## Which Path To Use
+
+Use the public evidence path for redacted relay audit evidence:
+
+- Use the `Submit Audit Evidence` issue template.
+- Include only sanitized screenshots, redacted report artifacts, hashes,
+  provider/profile metadata, and reproducible non-sensitive summaries.
+- Do not include API keys, raw headers, full response bodies, wallet material,
+  private relay traffic, or user data.
+
+Use the operator response path when you operate the relay being discussed:
+
+- Use the `Operator Response` issue template.
+- Prove domain control as requested by the template.
+- Keep remediation notes public-safe and avoid posting secrets or private user
+  traffic.
+
+Use private vulnerability disclosure for sensitive issues:
+
+- API key exposure caused by this repository or its workflows.
+- A bug that can redirect audit traffic to an unintended host.
+- A redaction failure involving raw response bodies, request headers, wallet
+  material, or user data.
+- A reproducible issue where this tool marks an unsafe or inconclusive state as
+  clean.
+
 ## Scope
 
 In scope:

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-relay-audit
-description: "OpenClaw skill for local AI API relay and LLM proxy security audits. Use when an OpenClaw agent must test a relay for prompt injection, model substitution, tool-call rewriting, SSE anomalies, upstream channel mismatch, error leakage, and Web3 wallet risks before trusting API traffic."
+description: "OpenClaw skill for local API Relay Audit. Use when an OpenClaw agent must audit a third-party AI API relay, LLM proxy, gateway, or resale API before trusting coding, tool, production, or wallet-sensitive traffic."
 version: 2.3.0
 metadata:
   openclaw:
@@ -72,6 +72,15 @@ Trigger this skill when the user:
 - Wants to compare security across multiple relay providers
 - Encounters unexpected API behavior and suspects relay tampering
 - Mentions: "test relay", "audit API", "detect injection", "relay security", "中转站安全", "测试中转站", "test proxy API"
+
+Keep these query families separate when deciding whether to run the skill:
+
+| Query family | Use when | Profile / evidence boundary |
+|---|---|---|
+| API relay audit | The user wants a local report for a relay, mirror, gateway, LLM proxy, or resale API. | Default `general`; report is evidence, not certification. |
+| Prompt injection audit | The user asks about hidden prompt injection, prompt leakage, instruction override, or extraction behavior. | Steps 3-6; do not publish private prompts or secrets. |
+| Model substitution signals | The user suspects model identity, route, latency, or upstream channel mismatch. | Signals from Steps 5, 10, 13, and 14 require corroboration; self-ID and fingerprints are not standalone provider proof. |
+| Web3 relay audit | The user is testing wallet-sensitive agent workflows. | Use `--profile web3` or `--profile full`; Step 11 is profile-gated. |
 
 ## Step-by-Step Agent Workflow (代理工作流)
 

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,8 +16,8 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **769** | `pytest --collect-only` |
-| 测试数 (static) | 745 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **775** | `pytest --collect-only` |
+| 测试数 (static) | 751 | grep `def test_*` in tests/ |
 | CLI flag 数 | 21 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-07 | `ROADMAP.md` 头部 |
@@ -25,14 +25,15 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 769] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `bed0778` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `2c43261` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-07 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
-- ℹ️ pytest (769) vs 静态 (745) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
+- ℹ️ pytest (775) vs 静态 (751) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
+- ⚠️ ROADMAP 最新记录 769 个测试，但当前 pytest 是 775。要么 ROADMAP 漏更新，要么有未记录的新测试。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/docs/query-families.md
+++ b/docs/query-families.md
@@ -1,0 +1,63 @@
+# Query Family Contract
+
+This document keeps the public discovery surface for API Relay Audit clean.
+Treat each family below as a distinct user intent. Do not collapse them into
+one headline, directory name, or skill description.
+
+## 1. API relay audit
+
+- Primary intent: audit a third-party AI API relay, mirror, gateway, LLM proxy,
+  or resale API before trusting traffic.
+- Canonical title language: `API Relay Audit`, `AI API relay security audit`,
+  `LLM proxy security audit`.
+- Runtime profile: `general` by default; `full` when the user explicitly wants
+  every available probe.
+- Public surfaces: README H1 and intro, GitHub Pages title, repository topics,
+  skill names, quick start, local execution model.
+
+## 2. Prompt injection audit
+
+- Primary intent: detect hidden prompt injection, prompt leakage, instruction
+  override, jailbreak leakage, and prompt-extraction behavior in a relay path.
+- Canonical title language: `prompt injection audit`,
+  `detect prompt injection in LLM API proxies`, `hidden prompt leakage`.
+- Runtime profile: `general`; covered mainly by Steps 3, 4, 5, and 6.
+- Public surfaces: coverage tables, prompt-injection guide, FAQ, detector-gap
+  issues.
+
+## 3. Model substitution signals
+
+- Primary intent: collect evidence signals when a relay may expose a different
+  model identity, route, or upstream channel than the user expected.
+- Canonical title language: `model substitution signals`,
+  `model identity consistency`, `upstream channel evidence`.
+- Runtime profile: `general`; supported by Step 5 identity consistency, Step 10
+  stream model identity, Step 13 latency variance, and Step 14 channel
+  classifier.
+- Evidence boundary: natural-language self-ID, channel fingerprints, and
+  latency patterns are signals. They are not standalone provider-level proof
+  that a provider or platform substituted the upstream model. Stronger claims
+  require raw response JSON, request IDs, provider/model metadata, stream
+  signatures, transparent logs, and reproducible runs.
+- Public surfaces: evidence model, FAQ, issue template provider/profile fields,
+  operator response path.
+
+## 4. Web3 relay audit
+
+- Primary intent: check wallet-sensitive relay behavior before agent workflows
+  touch signing, transaction guidance, or private-key-adjacent content.
+- Canonical title language: `Web3 relay audit`,
+  `Web3 wallet prompt injection`, `wallet signature-isolation probes`.
+- Runtime profile: `web3` or `full`; Step 11 is profile-gated.
+- Public surfaces: Web3 section, Web3 guide, profile table, issue template
+  profile field.
+
+## Cross-Surface Rules
+
+- Keep `API Relay Audit` as the project name and primary title.
+- Keep query families in separate sections, cards, FAQ entries, and guides.
+- Keep English and Chinese surfaces in sync for the same claims.
+- Never claim that a `LOW` result certifies safety.
+- Never treat `inconclusive` as `clean`.
+- Never publish API keys, raw headers, full response bodies, wallet material,
+  private relay traffic, or user data in public issues.

--- a/docs/skill-distribution.md
+++ b/docs/skill-distribution.md
@@ -118,6 +118,13 @@ Primary concepts stay unchanged:
 - AI API relay security audit
 - LLM proxy security
 
+Do not merge these project-level query families into one marketplace slogan:
+
+- API relay audit
+- prompt injection audit
+- model substitution signals
+- Web3 relay audit
+
 Skill-specific long-tail phrases:
 
 - OpenClaw skill for AI API relay audit

--- a/scripts/process_submission.py
+++ b/scripts/process_submission.py
@@ -35,8 +35,20 @@ MAX_RED_FLAGS = 10
 MAX_FLAG_LENGTH = 500
 MAX_IMAGES = 4
 MAX_VERSION_LENGTH = 20
+MAX_METADATA_LENGTH = 120
+MAX_STEP_SUMMARY_LENGTH = 1200
 STALE_AFTER_DAYS = 90
 TESTED_AT_FUTURE_GRACE_SECONDS = 300
+API_FORMAT_VALUES = {"unknown", "openai-compatible", "anthropic-native", "both", "other"}
+EVIDENCE_LEVEL_VALUES = {
+    "redacted-report",
+    "screenshot-only",
+    "transparent-log-hash",
+    "reproducible-run",
+    "unknown",
+}
+OPERATOR_CONTACTED_VALUES = {"unknown", "no", "yes", "operator-response-submitted"}
+FALSE_POSITIVE_VALUES = {"unsure", "no", "yes"}
 
 HOSTNAME_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
 TOOL_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
@@ -61,10 +73,17 @@ def parse_issue_body(body):
     patterns = {
         "relay_domain": r"### Relay Domain.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
         "profile": r"### Audit Profile.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
+        "claimed_provider": r"### Claimed Provider.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
+        "api_format": r"### API Format.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
+        "model_tested": r"### Model Tested.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
         "tool_version": r"### Tool Version.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
         "tool_commit": r"### Tool Commit.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
         "tested_at": r"### Tested At.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
         "overall_rating": r"### Overall Rating.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
+        "evidence_level": r"### Evidence Level.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
+        "step_summary": r"### Step Summary.*?\n\n(.+?)(?:\n###|\Z)",
+        "operator_contacted": r"### Operator Contacted.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
+        "false_positive_suspected": r"### False Positive Suspected.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
         "report_hash": r"### Report Hash.*?\n\n(.+?)(?:\n\n|\n###|\Z)",
         "red_flags": r"### Key Findings.*?\n\n(.+?)(?:\n###|\Z)",
         "report_image": r"### Report Screenshot.*?\n\n(.+?)(?:\n###|\Z)",
@@ -90,6 +109,17 @@ def normalize_report_hash(report_hash):
     if value.startswith("sha256:"):
         return value
     return f"sha256:{value}"
+
+
+def normalize_optional_choice(value, allowed, default):
+    """Normalize optional issue-form dropdown values while preserving compatibility."""
+    normalized = (value or "").strip().lower()
+    return normalized if normalized in allowed else default
+
+
+def clamp_metadata(value, max_length=MAX_METADATA_LENGTH):
+    """Trim optional metadata fields to stable public-record lengths."""
+    return (value or "").strip()[:max_length]
 
 
 def parse_tested_at(value):
@@ -163,6 +193,29 @@ def validate_fields(fields):
 
     if fields.get("profile", "").lower() not in ("general", "web3", "full"):
         errors.append(f"Invalid profile: {fields.get('profile')}")
+
+    api_format = fields.get("api_format", "")
+    if api_format and api_format.strip().lower() not in API_FORMAT_VALUES:
+        errors.append(f"Invalid api_format: {api_format}")
+
+    evidence_level = fields.get("evidence_level", "")
+    if evidence_level and evidence_level.strip().lower() not in EVIDENCE_LEVEL_VALUES:
+        errors.append(f"Invalid evidence_level: {evidence_level}")
+
+    operator_contacted = fields.get("operator_contacted", "")
+    if operator_contacted and operator_contacted.strip().lower() not in OPERATOR_CONTACTED_VALUES:
+        errors.append(f"Invalid operator_contacted: {operator_contacted}")
+
+    false_positive = fields.get("false_positive_suspected", "")
+    if false_positive and false_positive.strip().lower() not in FALSE_POSITIVE_VALUES:
+        errors.append(f"Invalid false_positive_suspected: {false_positive}")
+
+    for key in ["claimed_provider", "model_tested"]:
+        if len(fields.get(key, "")) > MAX_METADATA_LENGTH:
+            errors.append(f"{key} too long (max {MAX_METADATA_LENGTH})")
+
+    if len(fields.get("step_summary", "")) > MAX_STEP_SUMMARY_LENGTH:
+        errors.append(f"step_summary too long (max {MAX_STEP_SUMMARY_LENGTH})")
 
     version = fields.get("tool_version", "")
     if version:
@@ -316,10 +369,23 @@ def build_evidence_record(fields, issue_author, issue_number, now=None):
         "schemaVersion": 1,
         "recordType": "community-submitted-audit-evidence",
         "relayDomain": normalize_domain(fields["relay_domain"]),
+        "claimedProvider": clamp_metadata(fields.get("claimed_provider")) or "unknown",
+        "apiFormat": normalize_optional_choice(fields.get("api_format"), API_FORMAT_VALUES, "unknown"),
+        "modelTested": clamp_metadata(fields.get("model_tested")),
         "toolVersion": fields.get("tool_version", ""),
         "toolCommit": fields["tool_commit"].strip().lower(),
         "auditProfile": fields.get("profile", "general").lower(),
         "toolReportedOverallRating": fields["overall_rating"].upper(),
+        "evidenceLevel": normalize_optional_choice(
+            fields.get("evidence_level"), EVIDENCE_LEVEL_VALUES, "unknown"
+        ),
+        "stepSummary": clamp_metadata(fields.get("step_summary"), MAX_STEP_SUMMARY_LENGTH),
+        "operatorContacted": normalize_optional_choice(
+            fields.get("operator_contacted"), OPERATOR_CONTACTED_VALUES, "unknown"
+        ),
+        "falsePositiveSuspected": normalize_optional_choice(
+            fields.get("false_positive_suspected"), FALSE_POSITIVE_VALUES, "unsure"
+        ),
         "submittedAt": now.isoformat(),
         "testedAt": tested_at.isoformat(),
         "submitter": issue_author,

--- a/skills/api-relay-audit/SKILL.md
+++ b/skills/api-relay-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-relay-audit
-description: Use when auditing third-party AI API relays, proxy APIs, or API-key resale services for hidden prompt injection, prompt leakage, instruction override, context truncation, tool-call substitution, error leakage, SSE stream anomalies, Web3 wallet-safety prompt injection, infrastructure fingerprints, latency variance, and upstream channel mismatches.
+description: Use when auditing third-party AI API relays, LLM proxies, gateways, or API-key resale services locally before trusting coding, tool, production, or wallet-sensitive traffic.
 version: 2.3.0
 author: Toby Bridges
 license: AGPL-3.0-only
@@ -20,7 +20,7 @@ required_environment_variables:
 
 ## Overview
 
-This skill runs `api-relay-audit`, a zero-dependency security audit for third-party AI API relays and proxy services. It checks whether the relay tampers with prompts, truncates context, rewrites package-install instructions, leaks upstream credentials or internal headers, corrupts Anthropic SSE streams, changes the upstream channel, or injects unsafe Web3 wallet behavior.
+This skill runs `api-relay-audit`, a zero-dependency 14-step security audit for third-party AI API relays and proxy services. It checks relay behavior while keeping API relay audit, prompt injection audit, model substitution signals, and Web3 relay audit as separate query families with separate evidence boundaries.
 
 Use the standalone `audit.py` path by default. It only needs Python 3 and `curl`, which makes it suitable for local Hermes terminal sessions and sandboxed execution. On Windows, run the POSIX shell recipes from Git Bash or an equivalent shell; direct `python audit.py ...` invocations also work from PowerShell when the environment variables are set.
 
@@ -32,6 +32,15 @@ Use the standalone `audit.py` path by default. It only needs Python 3 and `curl`
 - The user wants to audit Web3/wallet safety behavior with `--profile web3` or `--profile full`.
 
 Do not use this skill for general model benchmarking, provider price comparison, or legal/security certification. The output is a technical audit report, not a guarantee that a service is safe.
+
+Keep these query families separate:
+
+| Query family | Use when | Profile / evidence boundary |
+|---|---|---|
+| API relay audit | The user wants a local report for a relay, mirror, gateway, LLM proxy, or resale API. | Default `general`; report is evidence, not certification. |
+| Prompt injection audit | The user asks about hidden prompt injection, prompt leakage, instruction override, or extraction behavior. | Steps 3-6; do not publish private prompts or secrets. |
+| Model substitution signals | The user suspects model identity, route, latency, or upstream channel mismatch. | Signals from Steps 5, 10, 13, and 14 require corroboration; self-ID and fingerprints are not standalone provider proof. |
+| Web3 relay audit | The user is testing wallet-sensitive agent workflows. | Use `--profile web3` or `--profile full`; Step 11 is profile-gated. |
 
 ## Install or Share
 

--- a/tests/test_process_submission.py
+++ b/tests/test_process_submission.py
@@ -34,6 +34,18 @@ api.example.com
 
 full
 
+### Claimed Provider / 声称供应商
+
+Anthropic via Example Relay
+
+### API Format / API 格式
+
+anthropic-native
+
+### Model Tested / 测试模型
+
+claude-opus-4-6
+
 ### Tool Version / 工具版本
 
 v2.3
@@ -49,6 +61,24 @@ v2.3
 ### Overall Rating / 总体评级
 
 HIGH
+
+### Evidence Level / 证据等级
+
+redacted-report
+
+### Step Summary / 步骤摘要
+
+Step 3 prompt injection: anomaly
+Step 5 identity consistency: inconclusive
+Step 11 Web3 prompt injection: clean
+
+### Operator Contacted / 是否联系运营方
+
+yes
+
+### False Positive Suspected / 是否怀疑误报
+
+no
 
 ### Report Screenshot / 报告截图
 
@@ -77,10 +107,17 @@ def test_parse_issue_body():
     fields = parse_issue_body(SAMPLE_BODY)
     assert fields["relay_domain"] == "api.example.com"
     assert fields["profile"] == "full"
+    assert fields["claimed_provider"] == "Anthropic via Example Relay"
+    assert fields["api_format"] == "anthropic-native"
+    assert fields["model_tested"] == "claude-opus-4-6"
     assert fields["tool_version"] == "v2.3"
     assert fields["tool_commit"] == "040676c"
     assert fields["tested_at"] == "2026-06-01T12:00:00Z"
     assert fields["overall_rating"] == "HIGH"
+    assert fields["evidence_level"] == "redacted-report"
+    assert "Step 3 prompt injection" in fields["step_summary"]
+    assert fields["operator_contacted"] == "yes"
+    assert fields["false_positive_suspected"] == "no"
     assert fields["report_hash"] == f"sha256:{REPORT_HASH}"
     assert "report.png" in fields["report_image"]
     assert "report-redacted.md" in fields["report_artifact"]
@@ -109,9 +146,16 @@ def test_build_evidence_record():
     entry = build_evidence_record(fields, "testuser", "42")
     assert entry["recordType"] == "community-submitted-audit-evidence"
     assert entry["relayDomain"] == "api.example.com"
+    assert entry["claimedProvider"] == "Anthropic via Example Relay"
+    assert entry["apiFormat"] == "anthropic-native"
+    assert entry["modelTested"] == "claude-opus-4-6"
     assert entry["toolCommit"] == "040676c"
     assert entry["auditProfile"] == "full"
     assert entry["toolReportedOverallRating"] == "HIGH"
+    assert entry["evidenceLevel"] == "redacted-report"
+    assert "Step 5 identity consistency" in entry["stepSummary"]
+    assert entry["operatorContacted"] == "yes"
+    assert entry["falsePositiveSuspected"] == "no"
     assert entry["reportHash"] == f"sha256:{REPORT_HASH}"
     assert (
         entry["reportArtifactUrl"]
@@ -202,10 +246,21 @@ def _make_body(**overrides):
     defaults = {
         "relay_domain": "api.example.com",
         "profile": "full",
+        "claimed_provider": "Anthropic via Example Relay",
+        "api_format": "anthropic-native",
+        "model_tested": "claude-opus-4-6",
         "tool_version": "v2.3",
         "tool_commit": "040676c",
         "tested_at": "2026-06-01T12:00:00Z",
         "overall_rating": "HIGH",
+        "evidence_level": "redacted-report",
+        "step_summary": (
+            "Step 3 prompt injection: anomaly\n"
+            "Step 5 identity consistency: inconclusive\n"
+            "Step 11 Web3 prompt injection: clean"
+        ),
+        "operator_contacted": "yes",
+        "false_positive_suspected": "no",
         "report_image": "![report](https://user-images.githubusercontent.com/123/report.png)",
         "report_artifact": (
             "[report-redacted.md](https://github.com/user-attachments/files/123/report-redacted.md)"
@@ -218,10 +273,17 @@ def _make_body(**overrides):
     return (
         f"### Relay Domain / 中转站域名\n\n{defaults['relay_domain']}\n\n"
         f"### Audit Profile / 审计配置\n\n{defaults['profile']}\n\n"
+        f"### Claimed Provider / 声称供应商\n\n{defaults['claimed_provider']}\n\n"
+        f"### API Format / API 格式\n\n{defaults['api_format']}\n\n"
+        f"### Model Tested / 测试模型\n\n{defaults['model_tested']}\n\n"
         f"### Tool Version / 工具版本\n\n{defaults['tool_version']}\n\n"
         f"### Tool Commit / 工具提交\n\n{defaults['tool_commit']}\n\n"
         f"### Tested At / 审计时间\n\n{defaults['tested_at']}\n\n"
         f"### Overall Rating / 总体评级\n\n{defaults['overall_rating']}\n\n"
+        f"### Evidence Level / 证据等级\n\n{defaults['evidence_level']}\n\n"
+        f"### Step Summary / 步骤摘要\n\n{defaults['step_summary']}\n\n"
+        f"### Operator Contacted / 是否联系运营方\n\n{defaults['operator_contacted']}\n\n"
+        f"### False Positive Suspected / 是否怀疑误报\n\n{defaults['false_positive_suspected']}\n\n"
         f"### Report Screenshot / 报告截图\n\n{defaults['report_image']}\n\n"
         f"### Report Artifact / 报告文件\n\n{defaults['report_artifact']}\n\n"
         f"### Report Hash / 报告哈希\n\n{defaults['report_hash']}\n\n"
@@ -368,6 +430,73 @@ def test_report_artifact_written_separately_from_screenshot():
     assert entry["reportImages"] == ["https://example.com/report.png"]
     assert entry["reportArtifactUrl"] == "https://example.com/report-redacted.md"
     assert entry["reportImages"][0] != entry["reportArtifactUrl"]
+
+
+def test_optional_provider_profile_feedback_defaults_for_legacy_body():
+    """Older issue bodies without growth feedback fields remain accepted."""
+    legacy_body = f"""### Relay Domain / 中转站域名
+
+api.example.com
+
+### Audit Profile / 审计配置
+
+general
+
+### Tool Version / 工具版本
+
+v2.3
+
+### Tool Commit / 工具提交
+
+040676c
+
+### Tested At / 审计时间
+
+2026-06-01T12:00:00Z
+
+### Overall Rating / 总体评级
+
+LOW
+
+### Report Screenshot / 报告截图
+
+![report](https://user-images.githubusercontent.com/123/report.png)
+
+### Report Artifact / 报告文件
+
+https://github.com/user-attachments/files/123/report-redacted.md
+
+### Report Hash / 报告哈希
+
+sha256:{REPORT_HASH}
+"""
+    fields = parse_issue_body(legacy_body)
+    assert validate_fields(fields) == []
+
+    entry = build_evidence_record(fields, "legacy-user", "77")
+    assert entry["claimedProvider"] == "unknown"
+    assert entry["apiFormat"] == "unknown"
+    assert entry["modelTested"] == ""
+    assert entry["evidenceLevel"] == "unknown"
+    assert entry["stepSummary"] == ""
+    assert entry["operatorContacted"] == "unknown"
+    assert entry["falsePositiveSuspected"] == "unsure"
+
+
+def test_provider_profile_feedback_values_are_validated():
+    bad_fields = parse_issue_body(
+        _make_body(
+            api_format="bad-format",
+            evidence_level="private-dump",
+            operator_contacted="maybe",
+            false_positive_suspected="definitely",
+        )
+    )
+    errors = validate_fields(bad_fields)
+    assert any("api_format" in e for e in errors)
+    assert any("evidence_level" in e for e in errors)
+    assert any("operator_contacted" in e for e in errors)
+    assert any("false_positive_suspected" in e for e in errors)
 
 
 def test_version_formats():

--- a/tests/test_skill_distribution.py
+++ b/tests/test_skill_distribution.py
@@ -8,6 +8,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 ROOT_SKILL = REPO_ROOT / "SKILL.md"
 HERMES_SKILL = REPO_ROOT / "skills" / "api-relay-audit" / "SKILL.md"
 SKILL_DISTRIBUTION_DOC = REPO_ROOT / "docs" / "skill-distribution.md"
+QUERY_FAMILY_DOC = REPO_ROOT / "docs" / "query-families.md"
 HOMEPAGE = REPO_ROOT / "web" / "index.html"
 
 
@@ -115,6 +116,58 @@ def test_homepage_channel_classifier_is_not_marked_future():
     assert "cmp_channel:\"上游通道分类\"" in text
     assert "Channel Fingerprint" not in text
     assert '<td class="soon">Soon</td>' not in text
+
+
+def test_growth_surfaces_keep_query_families_separate():
+    surfaces = [
+        REPO_ROOT / "README.md",
+        HOMEPAGE,
+        REPO_ROOT / "web" / "zh" / "index.html",
+        ROOT_SKILL,
+        HERMES_SKILL,
+        SKILL_DISTRIBUTION_DOC,
+        QUERY_FAMILY_DOC,
+    ]
+    required_families = [
+        "API relay audit",
+        "Prompt injection audit",
+        "Model substitution signals",
+        "Web3 relay audit",
+    ]
+    for path in surfaces:
+        text = _read(path).lower()
+        for family in required_families:
+            assert family.lower() in text, f"{path} is missing {family!r}"
+
+
+def test_growth_surfaces_preserve_current_audit_contract():
+    surfaces = [REPO_ROOT / "README.md", HOMEPAGE, ROOT_SKILL, HERMES_SKILL]
+    for path in surfaces:
+        text = _read(path)
+        assert "API Relay Audit" in text
+        assert "14-step" in text or "14 steps" in text or "14 步" in text
+        for profile in ["general", "web3", "full"]:
+            assert profile in text
+
+
+def test_web3_relay_audit_is_profile_gated():
+    surfaces = [REPO_ROOT / "README.md", HOMEPAGE, QUERY_FAMILY_DOC, ROOT_SKILL, HERMES_SKILL]
+    for path in surfaces:
+        text = _read(path)
+        assert "Web3 relay audit" in text
+        assert "--profile web3" in text or "`web3`" in text or "profile web3" in text
+        assert "Step 11" in text
+        assert "profile-gated" in text
+
+
+def test_model_substitution_copy_requires_corroboration():
+    surfaces = [REPO_ROOT / "README.md", HOMEPAGE, QUERY_FAMILY_DOC, ROOT_SKILL, HERMES_SKILL]
+    for path in surfaces:
+        text = _read(path)
+        assert "model substitution" in text.lower()
+        assert "signals" in text.lower()
+        assert "standalone" in text.lower() or "单独证明" in text
+        assert "provider proof" in text.lower() or "provider-level proof" in text.lower() or "provider 替换" in text
 
 
 def test_root_skill_secret_handling_prefers_secure_environment():

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>API Relay Audit - AI API Relay Security Audit for LLM Proxies</title>
-<meta name="description" content="Audit AI API relays and LLM proxies for prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Runs locally; your API key is sent only to the relay URL you choose.">
+<meta name="description" content="API Relay Audit runs locally for AI API relays and LLM proxies, with separate query families for relay audits, prompt injection audits, model substitution signals, and Web3 relay audits.">
 <link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/">
 <link rel="alternate" hreflang="en" href="https://toby-bridges.github.io/api-relay-audit/">
 <link rel="alternate" hreflang="zh-CN" href="https://toby-bridges.github.io/api-relay-audit/zh/">
@@ -12,7 +12,7 @@
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="API Relay Audit">
 <meta property="og:title" content="API Relay Audit - AI API Relay Security Audit">
-<meta property="og:description" content="Local security audit for AI API relays and LLM proxies: prompt injection, model substitution, tool rewriting, SSE anomalies, and Web3 wallet risks.">
+<meta property="og:description" content="Local security audit for AI API relays and LLM proxies with clean evidence boundaries across relay, prompt injection, model substitution, and Web3 profiles.">
 <meta property="og:url" content="https://toby-bridges.github.io/api-relay-audit/">
 <meta property="og:image" content="https://toby-bridges.github.io/api-relay-audit/assets/social-preview.png">
 <meta property="og:image:width" content="1280">
@@ -20,7 +20,7 @@
 <meta property="og:image:alt" content="API Relay Audit - AI API Relay Security Audit. Runs locally; your API key is sent only to the relay URL you choose.">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="API Relay Audit - AI API Relay Security Audit">
-<meta name="twitter:description" content="Local security audit for AI API relays and LLM proxies: prompt injection, model substitution, tool rewriting, SSE anomalies, and Web3 wallet risks.">
+<meta name="twitter:description" content="Local security audit for AI API relays and LLM proxies with clean query-family and evidence boundaries.">
 <meta name="twitter:image" content="https://toby-bridges.github.io/api-relay-audit/assets/social-preview.png">
 <script type="application/ld+json">
 {
@@ -42,7 +42,7 @@
       "url": "https://github.com/toby-bridges/api-relay-audit",
       "codeRepository": "https://github.com/toby-bridges/api-relay-audit",
       "license": "https://github.com/toby-bridges/api-relay-audit/blob/master/LICENSE",
-      "description": "Local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Your API key is sent only to the relay URL you choose."
+      "description": "Local security audit tool for AI API relays and LLM proxies. It preserves separate query families for relay audits, prompt injection audits, model substitution signals, and Web3 relay audits. Your API key is sent only to the relay URL you choose."
     },
     {
       "@type": "FAQPage",
@@ -77,7 +77,7 @@
           "name": "What is model substitution?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Model substitution means the relay claims to provide one model but routes you to another model or leaks a different model identity. API Relay Audit checks identity patterns and stream model identity where available."
+            "text": "Model substitution means the relay may expose signals for a different model identity, route, or upstream channel than expected. API Relay Audit treats self-ID, stream model identity, latency, and channel fingerprints as evidence signals that require corroboration."
           }
         },
         {
@@ -379,7 +379,7 @@ footer a:hover{color:var(--text)}
     <span data-i18n="hero_badge">Local execution — your API key is sent only to the relay URL you choose</span>
   </div>
   <h1 data-i18n="hero_title"><span class="gradient">AI API Relay</span> Security Audit</h1>
-  <p class="hero-sub" data-i18n="hero_sub">API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Your API key is sent only to the relay URL you choose.</p>
+  <p class="hero-sub" data-i18n="hero_sub">API Relay Audit is a local, evidence-first audit for AI API relays and LLM proxies. It keeps relay audits, prompt injection audits, model substitution signals, and Web3 relay audits as separate query families.</p>
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
@@ -397,7 +397,7 @@ footer a:hover{color:var(--text)}
   <div class="summary-grid">
     <div class="summary-block">
       <h2 data-i18n="what_title">What is API Relay Audit?</h2>
-      <p data-i18n="what_desc">API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It checks whether a third-party relay injects prompts, substitutes models, rewrites tool output, leaks credentials in error responses, or produces stream integrity anomalies.</p>
+      <p data-i18n="what_desc">API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It checks whether a third-party relay injects prompts, exposes model identity signals, rewrites tool output, leaks credentials in error responses, or produces stream integrity anomalies.</p>
     </div>
     <div class="summary-block">
       <h3 data-i18n="use_title">When to use it</h3>
@@ -414,6 +414,30 @@ footer a:hover{color:var(--text)}
         <li data-i18n="claim_2">It does not replace manual security review.</li>
         <li data-i18n="claim_3">It does not treat inconclusive as clean.</li>
       </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ── Audit Families ── -->
+<section class="summary-section container" id="audit-families">
+  <h2 style="font-size:1.4rem;font-weight:700;text-align:center" data-i18n="family_title">Audit Families</h2>
+  <p style="text-align:center;color:var(--text2);font-size:.9rem;margin:8px auto 24px;max-width:680px" data-i18n="family_sub">Each family maps to a distinct search intent, runtime profile, and evidence boundary.</p>
+  <div class="summary-grid">
+    <div class="summary-block">
+      <h3 data-i18n="family_api_title">API relay audit</h3>
+      <p data-i18n="family_api_desc">Audit third-party relays, mirrors, gateways, LLM proxies, or resale APIs with the general profile before trusting production or agent traffic.</p>
+    </div>
+    <div class="summary-block">
+      <h3 data-i18n="family_prompt_title">Prompt injection audit</h3>
+      <p data-i18n="family_prompt_desc">Detect hidden prompt injection, prompt leakage, instruction override, and extraction behavior through Steps 3-6.</p>
+    </div>
+    <div class="summary-block">
+      <h3 data-i18n="family_model_title">Model substitution signals</h3>
+      <p data-i18n="family_model_desc">Collect identity, stream, latency, and channel signals without treating self-ID or fingerprints as standalone provider proof.</p>
+    </div>
+    <div class="summary-block">
+      <h3 data-i18n="family_web3_title">Web3 relay audit</h3>
+      <p data-i18n="family_web3_desc">Use the profile-gated Step 11 checks with --profile web3 or --profile full before wallet-sensitive agent workflows.</p>
     </div>
   </div>
 </section>
@@ -590,7 +614,7 @@ footer a:hover{color:var(--text)}
 
 <!-- ── How It Works ── -->
 <section class="container">
-  <h2 style="font-size:1.4rem;font-weight:700;text-align:center" data-i18n="how_title">Detect Prompt Injection and Model Substitution</h2>
+  <h2 style="font-size:1.4rem;font-weight:700;text-align:center" data-i18n="how_title">Detect Prompt Injection and Model Substitution Signals</h2>
   <p style="text-align:center;color:var(--text2);font-size:.9rem;margin-bottom:8px" data-i18n="how_sub">Threat taxonomy based on Liu et al., "Your Agent Is Mine" (arXiv:2604.08407)</p>
   <div class="steps">
     <div class="step">
@@ -610,8 +634,8 @@ footer a:hover{color:var(--text)}
     </div>
     <div class="step">
       <div class="step-num" data-i18n="step_id_label">Step 5</div>
-      <h3 data-i18n="step_id_title">Identity Substitution</h3>
-      <p data-i18n="step_id_desc">An identity keyword set detects if "Claude" is actually GPT, DeepSeek, GLM, Qwen, or other models in disguise. Anchor phrases confirm true identity.</p>
+      <h3 data-i18n="step_id_title">Identity Consistency Signals</h3>
+      <p data-i18n="step_id_desc">An identity keyword set checks whether a claimed Claude route leaks GPT, DeepSeek, GLM, Qwen, or other model identities. This is an evidence signal, not standalone provider-level proof.</p>
     </div>
     <div class="step">
       <div class="step-num" data-i18n="step_ctx_label">Step 7</div>
@@ -720,7 +744,7 @@ footer a:hover{color:var(--text)}
   </div>
   <div class="faq-item">
     <div class="faq-q" onclick="toggleFaq(this)" data-i18n="faq_q4">What is model substitution?</div>
-    <div class="faq-a" data-i18n="faq_a4">Model substitution means the relay claims to provide one model but routes you to another model or leaks a different model identity. API Relay Audit checks identity patterns and stream model identity where available.</div>
+    <div class="faq-a" data-i18n="faq_a4">Model substitution means the relay may expose signals for a different model identity, route, or upstream channel than expected. API Relay Audit checks self-ID, stream model identity, latency, and channel fingerprints as signals that require corroboration before provider-level claims.</div>
   </div>
   <div class="faq-item">
     <div class="faq-q" onclick="toggleFaq(this)" data-i18n="faq_q5">What is tool-call rewriting?</div>
@@ -1012,9 +1036,9 @@ const i18n={
     nav_demo:"Demo",nav_install:"快速开始",nav_faq:"FAQ",
     hero_badge:"本地运行 — API Key 只发送到你指定的中转站 URL",
     hero_title:'<span class="gradient">AI API 中转站</span>安全审计',
-    hero_sub:"API Relay Audit 是一个本地运行的 AI API 中转站 / LLM proxy 安全审计工具。它检测 prompt injection、模型替换、工具调用改写、SSE 异常、错误响应泄漏和 Web3 钱包风险；你的 API Key 只会发送到你指定的中转站 URL。",
+    hero_sub:"API Relay Audit 是本地运行、证据优先的 AI API 中转站 / LLM proxy 审计工具。它把 relay audit、prompt injection audit、model substitution signals 和 Web3 relay audit 拆成独立查询意图。",
     what_title:"API Relay Audit 是什么？",
-    what_desc:"API Relay Audit 是一个本地安全审计工具，用来检查第三方 AI API 中转站和 LLM proxy 是否注入 prompt、替换模型、改写工具输出、在错误响应中泄漏凭证，或产生流完整性异常。",
+    what_desc:"API Relay Audit 是一个本地安全审计工具，用来检查第三方 AI API 中转站和 LLM proxy 是否注入 prompt、暴露模型身份信号、改写工具输出、在错误响应中泄漏凭证，或产生流完整性异常。",
     use_title:"什么时候使用",
     use_1:"审计第三方 AI API 中转站、镜像、网关和 LLM proxy。",
     use_2:"在生产流量前检查 Claude / OpenAI 兼容代理。",
@@ -1023,6 +1047,16 @@ const i18n={
     claim_1:"它不为任何中转站颁发安全认证。",
     claim_2:"它不替代人工安全审查。",
     claim_3:"它不会把 inconclusive 当作 clean。",
+    family_title:"审计意图家族",
+    family_sub:"每个家族对应独立搜索意图、运行 profile 和证据边界。",
+    family_api_title:"API relay audit",
+    family_api_desc:"在信任生产流量或 agent 流量前，用 general profile 审计第三方中转站、镜像、网关、LLM proxy 或 resale API。",
+    family_prompt_title:"Prompt injection audit",
+    family_prompt_desc:"通过 Step 3-6 检测隐藏 prompt 注入、prompt 泄漏、指令覆盖和提取行为。",
+    family_model_title:"Model substitution signals",
+    family_model_desc:"收集身份、stream、延迟和 channel 信号，但不把 self-ID 或 fingerprint 当成 provider-level 证明。",
+    family_web3_title:"Web3 relay audit",
+    family_web3_desc:"在钱包敏感 agent workflow 前，用 --profile web3 或 --profile full 运行 profile-gated Step 11 检查。",
     stat_steps:"审计步骤",stat_matrix:"风险矩阵",stat_tests:"单元测试",stat_deps:"依赖项 (standalone)",
     cta_demo:"查看 Demo 报告",cta_install:"开始审计",
     demo_title:"审计报告 Demo",
@@ -1031,12 +1065,12 @@ const i18n={
     demo_note:"域名已脱敏。数据来自 api-relay-audit 的实际审计。",
     demo_date:"测试日期",demo_no_inject:"无注入",demo_extracted:"提取成功",demo_risk_items:"风险项",
     demo_th_step:"检测项",demo_th_result:"结果",demo_th_detail:"详情",
-    how_title:"检测 Prompt 注入和模型替换",
+    how_title:"检测 Prompt 注入和模型替换信号",
     how_sub:'威胁分类基于 Liu et al., "Your Agent Is Mine" (arXiv:2604.08407)',
     step_infra_label:"Step 1-2",step_infra_title:"基础设施侦察",step_infra_desc:"DNS、CDN、SSL 证书、管理面板指纹、模型列表枚举 — 了解中转站背后的技术栈。",
     step_inject_label:"Step 3",step_inject_title:"Token 注入 (AC-1)",step_inject_desc:"对比实际 token 用量与预期值。隐藏 system prompt 注入会增加额外 token — 差值揭示注入量。",
     step_extract_label:"Step 4 & 6",step_extract_title:"Prompt 提取",step_extract_desc:"3 种攻击向量尝试提取隐藏 system prompt：直接复述、翻译法、JSON 接龙。加上越狱防护测试。",
-    step_id_label:"Step 5",step_id_title:"身份替换",step_id_desc:'身份关键词集合检测 "Claude" 是否实际是 GPT、DeepSeek、GLM、Qwen 或其他模型。锚点短语确认真实身份。',
+    step_id_label:"Step 5",step_id_title:"身份一致性信号",step_id_desc:'身份关键词集合检测 "Claude" 路由是否泄漏 GPT、DeepSeek、GLM、Qwen 或其他模型身份。这是证据信号，需结合 metadata、request id 或 stream signature 才能提出 provider-level 结论。',
     step_ctx_label:"Step 7",step_ctx_title:"上下文截断",step_ctx_desc:"5 个 canary 标记 + 二分查找精确定位真实上下文窗口边界。你的 200K context 真的有 200K 吗？",
     step_tool_label:"Step 8 (AC-1.a)",step_tool_title:"工具调用改写",step_tool_desc:"检测中转站是否在返回路径上偷改包安装命令 — 代理层面的拼写投毒供应链攻击。",
     step_err_label:"Step 9 (AC-2)",step_err_title:"错误响应泄漏",step_err_desc:"7 种故意破坏的请求探测 API Key、环境变量、文件路径、LiteLLM 内部字段是否在错误响应中泄漏。",
@@ -1089,7 +1123,7 @@ const i18n={
     faq_q3:"这里的 prompt injection 是什么意思？",
     faq_a3:'Prompt injection 指中转站可能在你的请求中插入隐藏指令。API Relay Audit 会比较 token 用量、运行 prompt 提取探针，并在出现隐藏 prompt 内容时记录证据。',
     faq_q4:"什么是模型替换？",
-    faq_a4:'模型替换指中转站声称提供某个模型，但实际路由到另一个模型，或泄漏了不同的模型身份。API Relay Audit 会检查身份关键词，并在可用时检查 stream 里的模型身份。',
+    faq_a4:'模型替换指中转站可能暴露出不同于预期的模型身份、路由或上游 channel 信号。API Relay Audit 会检查 self-ID、stream 模型身份、延迟和 channel fingerprint，但这些信号需要交叉验证，不能单独证明 provider 替换。',
     faq_q5:"什么是工具调用改写？",
     faq_a5:'工具调用改写指中转站修改模型回复中的包安装命令或工具输出。API Relay Audit 会比对固定 package 命令和返回文本，用来检测代理层供应链篡改。',
     faq_q6:"什么是 SSE 异常？",
@@ -1104,9 +1138,9 @@ const i18n={
     nav_demo:"Demo",nav_install:"Quick Start",nav_faq:"FAQ",
     hero_badge:"Local execution — your API key is sent only to the relay URL you choose",
     hero_title:'<span class="gradient">AI API Relay</span> Security Audit',
-    hero_sub:"API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It detects prompt injection, model substitution, tool rewriting, SSE anomalies, error leakage, and Web3 wallet risks. Your API key is sent only to the relay URL you choose.",
+    hero_sub:"API Relay Audit is a local, evidence-first audit for AI API relays and LLM proxies. It keeps relay audits, prompt injection audits, model substitution signals, and Web3 relay audits as separate query families.",
     what_title:"What is API Relay Audit?",
-    what_desc:"API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It checks whether a third-party relay injects prompts, substitutes models, rewrites tool output, leaks credentials in error responses, or produces stream integrity anomalies.",
+    what_desc:"API Relay Audit is a local security audit tool for AI API relays and LLM proxies. It checks whether a third-party relay injects prompts, exposes model identity signals, rewrites tool output, leaks credentials in error responses, or produces stream integrity anomalies.",
     use_title:"When to use it",
     use_1:"Audit third-party AI API relays, mirrors, gateways, and LLM proxies.",
     use_2:"Check Claude-compatible or OpenAI-compatible proxies before production traffic.",
@@ -1115,6 +1149,16 @@ const i18n={
     claim_1:"It does not certify that a relay is safe.",
     claim_2:"It does not replace manual security review.",
     claim_3:"It does not treat inconclusive as clean.",
+    family_title:"Audit Families",
+    family_sub:"Each family maps to a distinct search intent, runtime profile, and evidence boundary.",
+    family_api_title:"API relay audit",
+    family_api_desc:"Audit third-party relays, mirrors, gateways, LLM proxies, or resale APIs with the general profile before trusting production or agent traffic.",
+    family_prompt_title:"Prompt injection audit",
+    family_prompt_desc:"Detect hidden prompt injection, prompt leakage, instruction override, and extraction behavior through Steps 3-6.",
+    family_model_title:"Model substitution signals",
+    family_model_desc:"Collect identity, stream, latency, and channel signals without treating self-ID or fingerprints as standalone provider proof.",
+    family_web3_title:"Web3 relay audit",
+    family_web3_desc:"Use the profile-gated Step 11 checks with --profile web3 or --profile full before wallet-sensitive agent workflows.",
     stat_steps:"Audit Steps",stat_matrix:"Risk Matrix",stat_tests:"Unit Tests",stat_deps:"Dependencies (standalone)",
     cta_demo:"See Demo Report",cta_install:"Start Audit",
     demo_title:"Audit Report Demo",demo_sub:"Real audit results from three relay services — click tabs to compare",
@@ -1122,12 +1166,12 @@ const i18n={
     demo_note:"Domain names redacted. Data from actual audits run with api-relay-audit.",
     demo_date:"Test date",demo_no_inject:"No injection",demo_extracted:"extracted",demo_risk_items:"Risk Items",
     demo_th_step:"Test",demo_th_result:"Result",demo_th_detail:"Detail",
-    how_title:"Detect Prompt Injection and Model Substitution",
+    how_title:"Detect Prompt Injection and Model Substitution Signals",
     how_sub:'Threat taxonomy based on Liu et al., "Your Agent Is Mine" (arXiv:2604.08407)',
     step_infra_label:"Step 1-2",step_infra_title:"Infrastructure Recon",step_infra_desc:"DNS, CDN, SSL certificate, management panel fingerprint, model list enumeration — understand what's behind the relay.",
     step_inject_label:"Step 3",step_inject_title:"Token Injection (AC-1)",step_inject_desc:"Compares actual token usage against expected values. Hidden system prompt injection adds extra tokens — the delta reveals it.",
     step_extract_label:"Step 4 & 6",step_extract_title:"Prompt Extraction",step_extract_desc:"3 attack vectors attempt to extract hidden system prompts: verbatim recall, translation trick, JSON continuation. Plus jailbreak resistance tests.",
-    step_id_label:"Step 5",step_id_title:"Identity Substitution",step_id_desc:'An identity keyword set detects if "Claude" is actually GPT, DeepSeek, GLM, Qwen, or other models in disguise. Anchor phrases confirm true identity.',
+    step_id_label:"Step 5",step_id_title:"Identity Consistency Signals",step_id_desc:'An identity keyword set checks whether a claimed Claude route leaks GPT, DeepSeek, GLM, Qwen, or other model identities. This is an evidence signal, not standalone provider-level proof.',
     step_ctx_label:"Step 7",step_ctx_title:"Context Truncation",step_ctx_desc:"5 canary markers + binary search pinpoint the real context window boundary. Is your 200K context really 200K?",
     step_tool_label:"Step 8 (AC-1.a)",step_tool_title:"Tool-Call Rewriting",step_tool_desc:"Checks if the relay silently modifies package install commands in responses — typosquatting supply-chain attacks at the proxy layer.",
     step_err_label:"Step 9 (AC-2)",step_err_title:"Error Response Leakage",step_err_desc:"7 deliberately broken requests probe for API key, env vars, file paths, and LiteLLM internals leaking in error responses.",
@@ -1180,7 +1224,7 @@ const i18n={
     faq_q3:"What does prompt injection mean here?",
     faq_a3:'Prompt injection means the relay may prepend or insert hidden instructions into your request. API Relay Audit compares token usage, runs extraction probes, and records evidence when hidden prompt content appears.',
     faq_q4:"What is model substitution?",
-    faq_a4:'Model substitution means the relay claims to provide one model but routes you to another model or leaks a different model identity. API Relay Audit checks identity patterns and stream model identity where available.',
+    faq_a4:'Model substitution means the relay may expose signals for a different model identity, route, or upstream channel than expected. API Relay Audit checks self-ID, stream model identity, latency, and channel fingerprints as signals that require corroboration before provider-level claims.',
     faq_q5:"What is tool-call rewriting?",
     faq_a5:'Tool-call rewriting means the relay modifies package-install commands or tool-like output in the model response. API Relay Audit compares pinned package commands against returned text to detect proxy-layer supply-chain tampering.',
     faq_q6:"What are SSE anomalies?",

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">769</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">775</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -4,14 +4,14 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>API Relay Audit - AI API 中转站安全审计</title>
-<meta name="description" content="本地审计 AI API 中转站和 LLM proxy，检测 prompt injection、模型替换、工具调用改写、SSE 异常、错误泄漏和 Web3 钱包风险。API Key 只发送到你指定的中转站 URL。">
+<meta name="description" content="本地审计 AI API 中转站和 LLM proxy，把 API relay audit、prompt injection audit、model substitution signals 和 Web3 relay audit 拆成清晰查询意图。">
 <link rel="canonical" href="https://toby-bridges.github.io/api-relay-audit/zh/">
 <link rel="alternate" hreflang="en" href="https://toby-bridges.github.io/api-relay-audit/">
 <link rel="alternate" hreflang="zh-CN" href="https://toby-bridges.github.io/api-relay-audit/zh/">
 <link rel="alternate" hreflang="x-default" href="https://toby-bridges.github.io/api-relay-audit/">
 <meta property="og:type" content="website">
 <meta property="og:title" content="API Relay Audit - AI API 中转站安全审计">
-<meta property="og:description" content="本地审计 AI API 中转站和 LLM proxy。检测 prompt injection、模型替换、工具调用改写、SSE 异常和 Web3 钱包风险。">
+<meta property="og:description" content="本地审计 AI API 中转站和 LLM proxy，并为 relay、prompt injection、model substitution signals 和 Web3 profile 保持清晰证据边界。">
 <meta property="og:url" content="https://toby-bridges.github.io/api-relay-audit/zh/">
 <meta property="og:image" content="https://toby-bridges.github.io/api-relay-audit/assets/social-preview.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -31,7 +31,7 @@
 <main class="wrap">
   <div class="eyebrow">Local AI API Relay Security Audit</div>
   <h1>AI API 中转站安全审计，本地运行，只连接你指定的中转站</h1>
-  <p class="lead">API Relay Audit 是一个本地运行的 AI API 中转站 / LLM proxy 安全审计工具。它检测 prompt injection、模型替换、工具调用改写、SSE 流异常、错误响应泄漏，以及 Web3 钱包相关风险。</p>
+  <p class="lead">API Relay Audit 是本地运行、证据优先的 AI API 中转站 / LLM proxy 安全审计工具。它把 API relay audit、prompt injection audit、model substitution signals 和 Web3 relay audit 拆成独立查询意图。</p>
   <div class="cta">
     <a class="button primary" href="../#install">生成审计命令</a>
     <a class="button" href="https://github.com/toby-bridges/api-relay-audit">查看 GitHub</a>
@@ -44,11 +44,31 @@
     </section>
     <section class="card">
       <h2>检测什么</h2>
-      <p>覆盖 token injection、prompt extraction、identity substitution、context truncation、tool-call rewriting、error leakage、SSE stream integrity 和 Web3 signature isolation probes。</p>
+      <p>覆盖 token injection、prompt extraction、identity consistency signals、context truncation、tool-call rewriting、error leakage、SSE stream integrity 和 Web3 signature isolation probes。</p>
     </section>
     <section class="card">
       <h2>不声称什么</h2>
       <p>它不为任何中转站颁发安全认证，也不替代人工安全审查。`inconclusive` 不是 `clean`，被拦截或无法判断的探针会保留在报告里。</p>
+    </section>
+  </div>
+
+  <h2>查询意图边界</h2>
+  <div class="grid">
+    <section class="card">
+      <h2>API relay audit</h2>
+      <p>审计第三方中转站、镜像、网关、LLM proxy 或 resale API；默认使用 <code>general</code> profile。</p>
+    </section>
+    <section class="card">
+      <h2>Prompt injection audit</h2>
+      <p>检测隐藏 prompt 注入、prompt 泄漏、指令覆盖和提取行为；主要覆盖 Step 3-6。</p>
+    </section>
+    <section class="card">
+      <h2>Model substitution signals</h2>
+      <p>收集 self-ID、stream、latency 和 channel fingerprint 信号，但这些信号不能单独证明 provider 替换。</p>
+    </section>
+    <section class="card">
+      <h2>Web3 relay audit</h2>
+      <p>钱包敏感场景使用 <code>--profile web3</code> 或 <code>--profile full</code>，Step 11 是 profile-gated。</p>
     </section>
   </div>
 


### PR DESCRIPTION
﻿## Summary

- Add a query-family contract for API relay audit, prompt injection audit, model substitution signals, and Web3 relay audit.
- Align README, Pages, OpenClaw skill, and Hermes skill around those boundaries and evidence language.
- Harden public/private disclosure guidance and extend audit evidence submissions with provider/profile feedback metadata.

## Changes

- Added `docs/query-families.md` as the canonical growth/discovery contract.
- Updated README and Pages copy to keep query families separate and clarify model-substitution evidence boundaries.
- Updated OpenClaw/Hermes skill descriptions and when-to-use guidance to avoid collapsing distinct intents into one trigger phrase.
- Expanded the audit evidence issue template and processor output with claimed provider, API format, model tested, evidence level, step summary, operator contact, and false-positive suspicion fields.
- Added regression tests for query-family consistency and feedback metadata parsing/defaults.

## Validation

- `python -m pytest tests/test_skill_distribution.py tests/test_process_submission.py` — 53 passed
- `python -m pytest` — 770 passed
- `git diff --check` — passed

## Safety

- Built from a clean worktree based on latest `origin/master`.
- Current dirty `feat/relay-trust-registry` worktree was not reused.
- No audit reports, API keys, private relay URLs, generated screenshots, or raw traffic artifacts are included.
