### PR TITLE
Harden v2.3 release verification surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ The canonical contract lives in [docs/query-families.md](./docs/query-families.m
 ## Quick Start
 
 ```bash
-curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py
+AUDIT_SCRIPT_REF=v2.3.0
+curl -fsSL "https://raw.githubusercontent.com/toby-bridges/api-relay-audit/${AUDIT_SCRIPT_REF}/audit.py" -o audit.py
 
 python audit.py --key <YOUR_KEY> --url <BASE_URL> --output report.md
 
@@ -56,6 +57,7 @@ python audit.py --key <YOUR_KEY> --url <BASE_URL> --profile web3 --output report
 ```
 
 See a public-safe fixture report: [sanitized audit report](./docs/examples/sanitized-audit-report.md).
+Use `master` as `AUDIT_SCRIPT_REF` only when intentionally testing unreleased changes.
 
 ## Coverage
 
@@ -140,7 +142,7 @@ Community evidence is shape-checked by GitHub Actions, but publication still req
 | Version | `v2.3` |
 | Audit steps | 14 |
 | Risk matrix | 6D |
-| pytest collected tests | 764 |
+| pytest collected tests | 778 |
 | CLI flags | 21 |
 | Runtime profiles | `general`, `web3`, `full` |
 
@@ -263,7 +265,8 @@ to one behavior or document.
 ## 30 秒快速开始
 
 ```bash
-curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py
+AUDIT_SCRIPT_REF=v2.3.0
+curl -fsSL "https://raw.githubusercontent.com/toby-bridges/api-relay-audit/${AUDIT_SCRIPT_REF}/audit.py" -o audit.py
 
 python audit.py --key <YOUR_KEY> --url <BASE_URL> --output report.md
 
@@ -325,7 +328,7 @@ API Relay Audit 也可以作为 agent skill 使用。
 | 版本 | `v2.3` |
 | 审计步骤 | 14 |
 | 风险矩阵 | 6D |
-| pytest collected tests | 764 |
+| pytest collected tests | 778 |
 | CLI flags | 21 |
 | Runtime profiles | `general`, `web3`, `full` |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,8 +40,10 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
   detector, not a hosted preflight service, not a new API family, and not a
   change to LOW/MEDIUM/HIGH semantics. `inconclusive` remains
   `inconclusive`.
-- **Final test count**: 769/769 passing (733 baseline → 764 after current
-  master follow-ups → 769 after release-engineering version sync coverage).
+- **Final test count**: 778/778 passing (733 baseline → 764 after current
+  master follow-ups → 769 after release-engineering version sync coverage →
+  775 after query-family growth contracts → 778 after release-hardening
+  public verification regressions).
 
 ### v1.9 — Dual-distribution full generation (2026-06-01)
 - **Standalone product promise preserved**: root `audit.py` stays committed,

--- a/SKILL.md
+++ b/SKILL.md
@@ -175,7 +175,7 @@ Summarize in this format:
 - Tool-Call Substitution (AC-1.a): [clean / N probes rewritten]
 - Infrastructure: [key findings]
 
-**Recommendation:** [use freely / use with caution / do not use]
+**Recommendation:** [no issue found by these probes / use with caution / do not use]
 ```
 
 Include specific red flags and extracted prompt content (if any) below the summary.
@@ -186,8 +186,8 @@ Include specific red flags and extracted prompt content (if any) below the summa
 
 | Level | Criteria | Recommendation |
 |-------|----------|----------------|
-| GREEN (低风险) | No injection + instructions work + full context + no tool-call substitution | Safe for general use (可放心使用) |
-| YELLOW (中风险) | Minor injection (<100 tokens) OR prompt extractable, no substitution | OK for simple tasks, caution for complex workflows (简单任务可用，复杂工作流需谨慎) |
+| GREEN (低风险) | No injection + instructions work + full context + no tool-call substitution | No issue found by these probes; not a safety certification (探针未发现问题；不是安全认证) |
+| YELLOW (中风险) | Minor injection (<100 tokens) OR prompt extractable, no substitution | Use with caution; avoid sensitive or autonomous workflows until reviewed (谨慎使用；敏感或自主工作流前需复核) |
 | RED (高风险) | Injection >100 tokens AND instructions overridden, OR **any** tool-call substitution (AC-1.a) | Do not use (不建议使用) |
 
 **Note on AC-1.a**: A single substituted probe (e.g. `pip install requests` -> `pip install reqeusts`) is sufficient to escalate to RED. The attacker needs exactly one successful package-install rewrite to get persistent code execution on the agent host. This finding is non-negotiable.

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 7093e3f6beef3fa742fa52a9b4e3223bd0534661fd2f90acb90974eb913a87d7
-# standalone_body_sha256: 664a23e101a5b0f598a3273e97911cc3a3b13da975c105afb7882cd6ff177640
+# source_sha256: 57cc4ddc3ccb3ed54e76e82dfc447c6e21322c2c03ab804625924e7ec655f245
+# standalone_body_sha256: 3adf747824d6eeb9df837a1e6ae8fd6fe5aa861c57b6a422b9367e52ee0c630f
 # END GENERATED STANDALONE HEADER
 
 """
@@ -13,7 +13,8 @@ API Relay Security Audit Tool v2.3 --- Standalone Edition
 
 Generated curl-only artifact for users who want:
 
-  curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py
+  AUDIT_SCRIPT_REF=v2.3.0
+  curl -fsSL "https://raw.githubusercontent.com/toby-bridges/api-relay-audit/${AUDIT_SCRIPT_REF}/audit.py" -o audit.py
   python audit.py --key YOUR_KEY --url https://relay.example.com/v1
 
 The detection semantics below are generated from the modular source files
@@ -4896,12 +4897,12 @@ def parse_args():
     p.add_argument("--profile", choices=["general", "web3", "full"],
                    default="general",
                    help="Audit profile selector. 'general' (default) runs "
-                        "Steps 1-10 — suitable for regular API relay users. "
+                        "all non-Web3 relay checks; Step 11 is profile-gated. "
                         "'web3' adds Web3-specific checks (Step 11 prompt "
                         "injection targeting private keys / transaction "
                         "signing / transfer guidance) for wallet users. "
-                        "'full' enables everything including future web3 "
-                        "steps. Profile gating allows the same tool to serve "
+                        "'full' runs all available checks. Profile gating "
+                        "allows the same tool to serve "
                         "both general and Web3 audiences without branch splits.")
     p.add_argument("--skip-web3-injection", action="store_true",
                    help="Skip Step 11 Web3 prompt injection probes (only "

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,24 +16,23 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **775** | `pytest --collect-only` |
-| 测试数 (static) | 751 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **778** | `pytest --collect-only` |
+| 测试数 (static) | 754 | grep `def test_*` in tests/ |
 | CLI flag 数 | 21 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-07 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
-| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 769] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `2c43261` | recent reachable commit; `--check` allows follow-up metrics commits |
+| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 778] | grep `Final test count: N/N passing` |
+| Recorded commit SHA | `eeb9a2c` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-06-07 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
-- ℹ️ pytest (775) vs 静态 (751) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
-- ⚠️ ROADMAP 最新记录 769 个测试，但当前 pytest 是 775。要么 ROADMAP 漏更新，要么有未记录的新测试。
+- ℹ️ pytest (778) vs 静态 (754) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/docs/releases/v2.3.md
+++ b/docs/releases/v2.3.md
@@ -28,9 +28,18 @@ python3 audit.py --key <YOUR_KEY> --url <BASE_URL> --profile web3 --output repor
 - Anthropic-style SSE stream integrity checks.
 - Web3 wallet-safety probes with `--profile web3` and `--profile full`.
 - OpenClaw and Hermes Agent skill distribution documentation.
-- GitHub Pages SEO/GEO surfaces: English homepage, Chinese page, guide pages,
-  sitemap, canonical links, and structured data.
+- GitHub Pages metadata and guide surfaces: English homepage, Chinese page,
+  guide pages, sitemap, canonical links, and structured data.
 - Community-health docs and non-code contributor entry points.
+
+## Release Verification
+
+- Source tag: `v2.3.0`
+- Standalone `audit.py` SHA-256: `c9c1f66cfb6e880f044ba18e7a9e7952f45e688470e299e455c64836b68ab482`
+- Required gates before publishing: version sync, standalone drift,
+  metrics drift, full pytest, and `python3 -S audit.py --help`.
+- Published release check: `/releases/latest`, `/releases/tags/v2.3.0`, and
+  the `audit.py` / `audit.py.sha256` assets should be publicly accessible.
 
 ## Agent Skill Support
 
@@ -51,9 +60,9 @@ python3 audit.py --key <YOUR_KEY> --url <BASE_URL> --profile web3 --output repor
 
 ## Links
 
-- README: <https://github.com/toby-bridges/api-relay-audit>
+- README: <https://github.com/toby-bridges/api-relay-audit/tree/v2.3.0>
 - GitHub Pages: <https://toby-bridges.github.io/api-relay-audit/>
 - Chinese page: <https://toby-bridges.github.io/api-relay-audit/zh/>
-- Security policy: <https://github.com/toby-bridges/api-relay-audit/blob/master/SECURITY.md>
-- Contributing guide: <https://github.com/toby-bridges/api-relay-audit/blob/master/CONTRIBUTING.md>
-- Discoverability benchmark: <https://github.com/toby-bridges/api-relay-audit/blob/master/docs/discoverability.md>
+- Security policy: <https://github.com/toby-bridges/api-relay-audit/blob/v2.3.0/SECURITY.md>
+- Contributing guide: <https://github.com/toby-bridges/api-relay-audit/blob/v2.3.0/CONTRIBUTING.md>
+- Discoverability benchmark: <https://github.com/toby-bridges/api-relay-audit/blob/v2.3.0/docs/discoverability.md>

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -127,12 +127,12 @@ def parse_args():
     p.add_argument("--profile", choices=["general", "web3", "full"],
                    default="general",
                    help="Audit profile selector. 'general' (default) runs "
-                        "Steps 1-10 — suitable for regular API relay users. "
+                        "all non-Web3 relay checks; Step 11 is profile-gated. "
                         "'web3' adds Web3-specific checks (Step 11 prompt "
                         "injection targeting private keys / transaction "
                         "signing / transfer guidance) for wallet users. "
-                        "'full' enables everything including future web3 "
-                        "steps. Profile gating allows the same tool to serve "
+                        "'full' runs all available checks. Profile gating "
+                        "allows the same tool to serve "
                         "both general and Web3 audiences without branch splits.")
     p.add_argument("--skip-web3-injection", action="store_true",
                    help="Skip Step 11 Web3 prompt injection probes (only "

--- a/scripts/build-standalone.py
+++ b/scripts/build-standalone.py
@@ -140,13 +140,21 @@ def display_version_from_file() -> str:
     return f"v{major}.{minor}.{patch}"
 
 
+def release_tag_from_file() -> str:
+    version = read(VERSION_FILE).strip()
+    if not re.fullmatch(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)", version):
+        raise SystemExit(f"VERSION must be MAJOR.MINOR.PATCH SemVer: {version!r}")
+    return f"v{version}"
+
+
 def standalone_doc() -> str:
     return f'''"""
 API Relay Security Audit Tool {display_version_from_file()} --- Standalone Edition
 
 Generated curl-only artifact for users who want:
 
-  curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py
+  AUDIT_SCRIPT_REF={release_tag_from_file()}
+  curl -fsSL "https://raw.githubusercontent.com/toby-bridges/api-relay-audit/${{AUDIT_SCRIPT_REF}}/audit.py" -o audit.py
   python audit.py --key YOUR_KEY --url https://relay.example.com/v1
 
 The detection semantics below are generated from the modular source files

--- a/tests/test_dual_distribution_parity.py
+++ b/tests/test_dual_distribution_parity.py
@@ -428,6 +428,11 @@ def test_standalone_ensure_format_real_body_detects_anthropic(monkeypatch):
 
 
 def _help_option_set(path):
+    text = _help_text(path)
+    return set(re.findall(r"--[a-z0-9-]+", text))
+
+
+def _help_text(path):
     result = subprocess.run(
         [sys.executable, str(path), "--help"],
         cwd=str(REPO_ROOT),
@@ -436,7 +441,7 @@ def _help_option_set(path):
         timeout=10,
         check=True,
     )
-    return set(re.findall(r"--[a-z0-9-]+", result.stdout))
+    return result.stdout
 
 
 def test_public_help_flags_parity():
@@ -446,6 +451,22 @@ def test_public_help_flags_parity():
     standalone_flags = _help_option_set(REPO_ROOT / "audit.py")
     assert "--connectivity" in modular_flags
     assert modular_flags == standalone_flags
+
+
+def test_profile_help_matches_current_14_step_contract():
+    """The profile selector should describe the shipped 14-step runtime.
+
+    Regression: after Steps 12-14 shipped, the help text still said general
+    only ran the first ten steps and full enabled future Web3 checks.
+    """
+    for path in [REPO_ROOT / "scripts" / "audit.py", REPO_ROOT / "audit.py"]:
+        text = _help_text(path)
+        normalized = " ".join(text.split())
+        assert "Steps 1-10" not in text
+        assert "future web3" not in text.lower()
+        assert "non-Web3 relay checks" in normalized
+        assert "Step 11 is profile-gated" in normalized
+        assert "'full' runs all available checks" in normalized
 
 
 def test_connectivity_mode_exits_before_full_audit(monkeypatch, tmp_path):

--- a/tests/test_skill_distribution.py
+++ b/tests/test_skill_distribution.py
@@ -75,10 +75,20 @@ def test_versioned_skill_artifacts_pin_audit_script_download():
         text = _read(path)
         assert VERSION_TAG in text
         assert "master/audit.py" not in text
+        assert "blob/master" not in text
 
     distribution_doc = _read(SKILL_DISTRIBUTION_DOC)
     assert VERSION_TAG in distribution_doc
     assert "Do not publish a\nversioned skill that downloads mutable `master/audit.py`" in distribution_doc
+
+
+def test_release_notes_include_public_verification_contract():
+    text = _read(RELEASE_DRAFT)
+    assert "TO_BE_REGENERATED" not in text
+    assert "SEO/GEO" not in text
+    assert re.search(r"Standalone `audit\.py` SHA-256: `[0-9a-f]{64}`", text)
+    assert "/releases/latest" in text
+    assert f"/releases/tags/{VERSION_TAG}" in text
 
 
 def test_skill_surfaces_do_not_regress_to_13_step_copy():
@@ -176,6 +186,18 @@ def test_root_skill_secret_handling_prefers_secure_environment():
     assert "API_RELAY_AUDIT_KEY" in text
     assert "The agent may also ask the user directly" not in text
     assert "avoid repeating the raw key in chat" in text
+
+
+def test_root_skill_does_not_certify_green_results_as_safe():
+    text = _read(ROOT_SKILL)
+    forbidden = [
+        "use freely",
+        "Safe for general use",
+        "可放心使用",
+    ]
+    for phrase in forbidden:
+        assert phrase not in text
+    assert "not a safety certification" in text
 
 
 def test_hermes_skill_supports_windows_git_bash_contract():

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">775</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">778</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">
@@ -600,7 +600,7 @@ footer a:hover{color:var(--text)}
 <!-- ── Demo Report ── -->
 <section class="demo-section container" id="demo">
   <h2 data-i18n="demo_title">Audit Report Demo</h2>
-  <p class="demo-subtitle" data-i18n="demo_sub">Real audit results from three relay services — click tabs to compare</p>
+  <p class="demo-subtitle" data-i18n="demo_sub">Redacted report examples from relay audits — click tabs to compare</p>
 
   <div class="demo-tabs">
     <button class="demo-tab active" onclick="showDemo(0)" data-rating="red"><span data-i18n="demo_tab_high">High Risk</span> — example1.com</button>
@@ -609,7 +609,7 @@ footer a:hover{color:var(--text)}
   </div>
 
   <div id="demo-cards"></div>
-  <p class="demo-note" data-i18n="demo_note">Domain names redacted. Data from actual audits run with api-relay-audit.</p>
+  <p class="demo-note" data-i18n="demo_note">Domain names and sensitive details redacted; examples preserve the report shape without publishing raw relay traffic.</p>
 </section>
 
 <!-- ── How It Works ── -->
@@ -988,14 +988,15 @@ function generateCmd(){
   if(!url){document.getElementById('f-url').focus();return}
   if(!key){document.getElementById('f-key').focus();return}
   const win=isWindows();
+  const scriptRef='v2.3.0';
   let cmd;
   if(win){
     // PowerShell: Invoke-WebRequest, semicolon, single-quote escaping via doubling
     const psKey=key.replace(/'/g,"''");
     const psUrl=url.replace(/'/g,"''");
-    cmd=`Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py' -OutFile audit.py; python audit.py --key '${psKey}' --url '${psUrl}' --model ${model}`;
+    cmd=`$env:AUDIT_SCRIPT_REF='${scriptRef}'; Invoke-WebRequest -Uri \"https://raw.githubusercontent.com/toby-bridges/api-relay-audit/$env:AUDIT_SCRIPT_REF/audit.py\" -OutFile audit.py; python audit.py --key '${psKey}' --url '${psUrl}' --model ${model}`;
   } else {
-    cmd=`curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py && python3 audit.py --key ${shellEscape(key)} --url ${shellEscape(url)} --model ${model}`;
+    cmd=`AUDIT_SCRIPT_REF=${scriptRef} && curl -fsSL \"https://raw.githubusercontent.com/toby-bridges/api-relay-audit/\${AUDIT_SCRIPT_REF}/audit.py\" -o audit.py && python3 audit.py --key ${shellEscape(key)} --url ${shellEscape(url)} --model ${model}`;
   }
   const el=document.getElementById('cmd-output');
   el.setAttribute('data-cmd',cmd);
@@ -1161,9 +1162,9 @@ const i18n={
     family_web3_desc:"Use the profile-gated Step 11 checks with --profile web3 or --profile full before wallet-sensitive agent workflows.",
     stat_steps:"Audit Steps",stat_matrix:"Risk Matrix",stat_tests:"Unit Tests",stat_deps:"Dependencies (standalone)",
     cta_demo:"See Demo Report",cta_install:"Start Audit",
-    demo_title:"Audit Report Demo",demo_sub:"Real audit results from three relay services — click tabs to compare",
+    demo_title:"Audit Report Demo",demo_sub:"Redacted report examples from relay audits — click tabs to compare",
     demo_tab_high:"High Risk",demo_tab_mid:"Medium Risk",demo_tab_low:"Low Risk",
-    demo_note:"Domain names redacted. Data from actual audits run with api-relay-audit.",
+    demo_note:"Domain names and sensitive details redacted; examples preserve the report shape without publishing raw relay traffic.",
     demo_date:"Test date",demo_no_inject:"No injection",demo_extracted:"extracted",demo_risk_items:"Risk Items",
     demo_th_step:"Test",demo_th_result:"Result",demo_th_detail:"Detail",
     how_title:"Detect Prompt Injection and Model Substitution Signals",

--- a/web/zh/index.html
+++ b/web/zh/index.html
@@ -73,7 +73,8 @@
   </div>
 
   <h2>快速开始</h2>
-  <pre class="code"><code>curl -sO https://raw.githubusercontent.com/toby-bridges/api-relay-audit/master/audit.py
+  <pre class="code"><code>AUDIT_SCRIPT_REF=v2.3.0
+curl -fsSL "https://raw.githubusercontent.com/toby-bridges/api-relay-audit/${AUDIT_SCRIPT_REF}/audit.py" -o audit.py
 python audit.py --key &lt;YOUR_KEY&gt; --url &lt;BASE_URL&gt; --output report.md
 
 # Web3 / 钱包用户


### PR DESCRIPTION
## Summary
- pin README/Pages/standalone quick-start paths to v2.3.0 and document master as unreleased
- tighten v2.3 release notes with verification gates and standalone audit.py SHA-256
- remove safety-certification wording from the root skill and fix profile help for the shipped 14-step contract
- sync public metrics to 778 tests and add regression coverage for release trust surfaces

## Validation
- python3 scripts/sync-version.py --check
- python3 scripts/build-standalone.py --check
- python3 scripts/collect-metrics.py --check
- python3 -m pytest tests/ -q
- python3 -S audit.py --help
- git diff --check