### PR TITLE
[codex] Calibrate identity self-ID patterns with ZenMux data

### DIFF
--- a/api_relay_audit/identity_patterns.py
+++ b/api_relay_audit/identity_patterns.py
@@ -66,8 +66,10 @@ import re
 
 
 # Keyword literals that, if present in a response to "Who are you?
-# Who made you?", indicate that the relay is routing to a non-Claude
-# substitute model. See module docstring for matching strategy.
+# Who made you?", indicate that the response is self-identifying as
+# something other than Claude/Anthropic. See module docstring for the
+# evidence boundary: this is an identity-consistency signal, not
+# standalone attribution proof.
 #
 # Groups (not enforced by code, just for readability):
 #   1. Legacy (v2.1)        — Amazon / AWS brand leakage from earlier audits
@@ -76,7 +78,9 @@ import re
 #   3. Extended ASCII       — our additions (Zhipu / Tongyi brand aliases
 #                              for hvoy.ai's glm / qwen + Chinese-market
 #                              substitutes hvoy.ai did not cover)
-#   4. Chinese brand names  — CJK literals for catching Chinese-language
+#   4. ZenMux calibration   — current frontier-vendor aliases observed in
+#                              ZenMux Arena's 2026-06-01 "Who Are You?" run
+#   5. Chinese brand names  — CJK literals for catching Chinese-language
 #                              responses that use the Chinese brand instead
 #                              of the ASCII model name
 NON_CLAUDE_IDENTITY_KEYWORDS = (
@@ -112,13 +116,48 @@ NON_CLAUDE_IDENTITY_KEYWORDS = (
     "doubao",    # ByteDance Doubao
     "moonshot",  # Moonshot AI
     "kimi",      # Moonshot's Kimi product
-    # 6. Chinese brand names (catch Chinese-language responses)
+    # 6. Current frontier-vendor aliases from ZenMux Arena identity data
+    #    (2026-06-01 mix). These broaden Step 5 from a China-substitute
+    #    keyword set into a natural-language identity consistency signal.
+    "openai",
+    "chatgpt",
+    "chat gpt",
+    "google",
+    "gemini",
+    "x-ai",
+    "x.ai",
+    "xai",
+    "baidu",
+    "xiaomi",
+    "tencent",
+    "hunyuan",
+    "stepfun",
+    "step fun",
+    "kwai",
+    "kuaishou",
+    "kat-coder",
+    "kat coder",
+    "katcoder",
+    "inclusionai",
+    "inclusion ai",
+    "mistral",
+    "microsoft",
+    # 7. Chinese brand names (catch Chinese-language responses)
     "通义",
     "千问",
     "智谱",
     "豆包",
     "文心",
     "月之暗面",
+    "百度",
+    "小米",
+    "腾讯",
+    "混元",
+    "阶跃",
+    "阶跃星辰",
+    "快手",
+    "可灵",
+    "百灵",
 )
 
 
@@ -137,6 +176,31 @@ _STRICT_ASCII_KEYWORDS = frozenset({
     "gpt",    # "unlike GPT" / "not GPT" prose
     "ernie",  # common given name (Sesame Street)
     "kimi",   # common given name
+    # ZenMux-calibrated current vendor names that are high-signal only
+    # when used as an identity claim, not as ordinary product references.
+    "openai",
+    "chatgpt",
+    "chat gpt",
+    "google",
+    "gemini",
+    "x-ai",
+    "x.ai",
+    "xai",
+    "baidu",
+    "xiaomi",
+    "tencent",
+    "hunyuan",
+    "stepfun",
+    "step fun",
+    "kwai",
+    "kuaishou",
+    "kat-coder",
+    "kat coder",
+    "katcoder",
+    "inclusionai",
+    "inclusion ai",
+    "mistral",
+    "microsoft",
 })
 
 # v1.7.7: context-strict keywords require BOTH an identity anchor AND
@@ -283,6 +347,24 @@ _CJK_CONTEXT_STRICT_PATTERNS = tuple(
     if kw in _CONTEXT_STRICT_KEYWORDS
 )
 
+# v1.7.8: CJK-anchor supplementary patterns for lax ASCII keywords.
+# The normal lax regex starts with \b, but Python treats CJK letters as
+# word characters, so "我是DeepSeek" has no word boundary before D and
+# used to be missed. Keep this path anchor-gated so ordinary prose such
+# as "讨论DeepSeek发布节奏" does not become a match solely because a CJK
+# character precedes an ASCII model name.
+_CJK_LAX_ASCII_PATTERNS = tuple(
+    (kw, re.compile(
+        r"(?:" + _CJK_ANCHOR_ALTERNATION + r")"
+        r"\s*"
+        + re.escape(kw) + r"(?![a-zA-Z])",
+        re.IGNORECASE,
+    ))
+    for kw in NON_CLAUDE_IDENTITY_KEYWORDS
+    if kw.isascii() and kw not in _STRICT_ASCII_KEYWORDS
+    and kw not in _CONTEXT_STRICT_KEYWORDS
+)
+
 
 def find_non_claude_identities(text: str) -> list:
     """Return a sorted list of non-Claude identity keywords found in text.
@@ -339,6 +421,11 @@ def find_non_claude_identities(text: str) -> list:
             matched.append(keyword)
     # v1.7.7: CJK-anchor + identity suffix for context-strict keywords.
     for keyword, pattern in _CJK_CONTEXT_STRICT_PATTERNS:
+        if keyword not in matched and pattern.search(text):
+            matched.append(keyword)
+    # v1.7.8: CJK-anchor + no-whitespace path for distinctive lax
+    # ASCII model/vendor names such as "我是DeepSeek".
+    for keyword, pattern in _CJK_LAX_ASCII_PATTERNS:
         if keyword not in matched and pattern.search(text):
             matched.append(keyword)
     for keyword, pattern in _LAX_ASCII_PATTERNS:

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 57cc4ddc3ccb3ed54e76e82dfc447c6e21322c2c03ab804625924e7ec655f245
-# standalone_body_sha256: 3adf747824d6eeb9df837a1e6ae8fd6fe5aa861c57b6a422b9367e52ee0c630f
+# source_sha256: 7ba5f64496601cd86af13488f66aafa2fb6396adf4ea62f72f198032d0f2d1c4
+# standalone_body_sha256: b71fa88ef496bf1e52b118af00bf0b4d6a33b1545df5a4239ce2df36ba18b610
 # END GENERATED STANDALONE HEADER
 
 """
@@ -2597,8 +2597,10 @@ import re
 
 
 # Keyword literals that, if present in a response to "Who are you?
-# Who made you?", indicate that the relay is routing to a non-Claude
-# substitute model. See module docstring for matching strategy.
+# Who made you?", indicate that the response is self-identifying as
+# something other than Claude/Anthropic. See module docstring for the
+# evidence boundary: this is an identity-consistency signal, not
+# standalone attribution proof.
 #
 # Groups (not enforced by code, just for readability):
 #   1. Legacy (v2.1)        — Amazon / AWS brand leakage from earlier audits
@@ -2607,7 +2609,9 @@ import re
 #   3. Extended ASCII       — our additions (Zhipu / Tongyi brand aliases
 #                              for hvoy.ai's glm / qwen + Chinese-market
 #                              substitutes hvoy.ai did not cover)
-#   4. Chinese brand names  — CJK literals for catching Chinese-language
+#   4. ZenMux calibration   — current frontier-vendor aliases observed in
+#                              ZenMux Arena's 2026-06-01 "Who Are You?" run
+#   5. Chinese brand names  — CJK literals for catching Chinese-language
 #                              responses that use the Chinese brand instead
 #                              of the ASCII model name
 NON_CLAUDE_IDENTITY_KEYWORDS = (
@@ -2643,13 +2647,48 @@ NON_CLAUDE_IDENTITY_KEYWORDS = (
     "doubao",    # ByteDance Doubao
     "moonshot",  # Moonshot AI
     "kimi",      # Moonshot's Kimi product
-    # 6. Chinese brand names (catch Chinese-language responses)
+    # 6. Current frontier-vendor aliases from ZenMux Arena identity data
+    #    (2026-06-01 mix). These broaden Step 5 from a China-substitute
+    #    keyword set into a natural-language identity consistency signal.
+    "openai",
+    "chatgpt",
+    "chat gpt",
+    "google",
+    "gemini",
+    "x-ai",
+    "x.ai",
+    "xai",
+    "baidu",
+    "xiaomi",
+    "tencent",
+    "hunyuan",
+    "stepfun",
+    "step fun",
+    "kwai",
+    "kuaishou",
+    "kat-coder",
+    "kat coder",
+    "katcoder",
+    "inclusionai",
+    "inclusion ai",
+    "mistral",
+    "microsoft",
+    # 7. Chinese brand names (catch Chinese-language responses)
     "通义",
     "千问",
     "智谱",
     "豆包",
     "文心",
     "月之暗面",
+    "百度",
+    "小米",
+    "腾讯",
+    "混元",
+    "阶跃",
+    "阶跃星辰",
+    "快手",
+    "可灵",
+    "百灵",
 )
 
 
@@ -2668,6 +2707,31 @@ _STRICT_ASCII_KEYWORDS = frozenset({
     "gpt",    # "unlike GPT" / "not GPT" prose
     "ernie",  # common given name (Sesame Street)
     "kimi",   # common given name
+    # ZenMux-calibrated current vendor names that are high-signal only
+    # when used as an identity claim, not as ordinary product references.
+    "openai",
+    "chatgpt",
+    "chat gpt",
+    "google",
+    "gemini",
+    "x-ai",
+    "x.ai",
+    "xai",
+    "baidu",
+    "xiaomi",
+    "tencent",
+    "hunyuan",
+    "stepfun",
+    "step fun",
+    "kwai",
+    "kuaishou",
+    "kat-coder",
+    "kat coder",
+    "katcoder",
+    "inclusionai",
+    "inclusion ai",
+    "mistral",
+    "microsoft",
 })
 
 # v1.7.7: context-strict keywords require BOTH an identity anchor AND
@@ -2814,6 +2878,24 @@ _CJK_CONTEXT_STRICT_PATTERNS = tuple(
     if kw in _CONTEXT_STRICT_KEYWORDS
 )
 
+# v1.7.8: CJK-anchor supplementary patterns for lax ASCII keywords.
+# The normal lax regex starts with \b, but Python treats CJK letters as
+# word characters, so "我是DeepSeek" has no word boundary before D and
+# used to be missed. Keep this path anchor-gated so ordinary prose such
+# as "讨论DeepSeek发布节奏" does not become a match solely because a CJK
+# character precedes an ASCII model name.
+_CJK_LAX_ASCII_PATTERNS = tuple(
+    (kw, re.compile(
+        r"(?:" + _CJK_ANCHOR_ALTERNATION + r")"
+        r"\s*"
+        + re.escape(kw) + r"(?![a-zA-Z])",
+        re.IGNORECASE,
+    ))
+    for kw in NON_CLAUDE_IDENTITY_KEYWORDS
+    if kw.isascii() and kw not in _STRICT_ASCII_KEYWORDS
+    and kw not in _CONTEXT_STRICT_KEYWORDS
+)
+
 
 def find_non_claude_identities(text: str) -> list:
     """Return a sorted list of non-Claude identity keywords found in text.
@@ -2870,6 +2952,11 @@ def find_non_claude_identities(text: str) -> list:
             matched.append(keyword)
     # v1.7.7: CJK-anchor + identity suffix for context-strict keywords.
     for keyword, pattern in _CJK_CONTEXT_STRICT_PATTERNS:
+        if keyword not in matched and pattern.search(text):
+            matched.append(keyword)
+    # v1.7.8: CJK-anchor + no-whitespace path for distinctive lax
+    # ASCII model/vendor names such as "我是DeepSeek".
+    for keyword, pattern in _CJK_LAX_ASCII_PATTERNS:
         if keyword not in matched and pattern.search(text):
             matched.append(keyword)
     for keyword, pattern in _LAX_ASCII_PATTERNS:

--- a/docs/query-families.md
+++ b/docs/query-families.md
@@ -39,6 +39,10 @@ one headline, directory name, or skill description.
   that a provider or platform substituted the upstream model. Stronger claims
   require raw response JSON, request IDs, provider/model metadata, stream
   signatures, transparent logs, and reproducible runs.
+- Calibration note: ZenMux Arena's 2026-06-01 "Who Are You?" pooled run
+  measured cross-vendor self-identification confusion in first-party model
+  calls, which reinforces treating self-ID mismatches as consistency signals
+  rather than attribution proof.
 - Public surfaces: evidence model, FAQ, issue template provider/profile fields,
   operator response path.
 

--- a/tests/test_identity_patterns.py
+++ b/tests/test_identity_patterns.py
@@ -55,6 +55,32 @@ class TestNonClaudeIdentityKeywords:
         ):
             assert kw in NON_CLAUDE_IDENTITY_KEYWORDS
 
+    def test_zenmux_calibrated_vendor_aliases_present(self):
+        """ZenMux Arena's 2026-06-01 identity-confusion data showed
+        frontier models self-identifying as a wider set of non-Claude
+        vendors. These aliases keep Step 5 calibrated to natural-language
+        identity inconsistency, not only older China-substitute keywords."""
+        for kw in (
+            "openai",
+            "chatgpt",
+            "google",
+            "gemini",
+            "x-ai",
+            "x.ai",
+            "xai",
+            "baidu",
+            "xiaomi",
+            "tencent",
+            "hunyuan",
+            "stepfun",
+            "kwai",
+            "kuaishou",
+            "inclusionai",
+            "mistral",
+            "microsoft",
+        ):
+            assert kw in NON_CLAUDE_IDENTITY_KEYWORDS
+
     def test_chinese_brand_names_present(self):
         """Chinese brand names (for catching Chinese-language responses)
         must be present — this is our v1.6 extension beyond hvoy.ai."""
@@ -371,6 +397,43 @@ class TestFindNonClaudeIdentities:
         text = "Gravity is a fundamental force of nature."
         assert find_non_claude_identities(text) == []
 
+    def test_zenmux_current_vendor_aliases_with_identity_anchors(self):
+        """Current frontier-vendor aliases should match when the answer
+        self-identifies as that vendor or product."""
+        cases = [
+            ("I am Google Gemini, an AI model.", {"google", "gemini"}),
+            ("I am ChatGPT, built by OpenAI.", {"chatgpt", "openai"}),
+            ("I'm Mistral Large, created by Mistral AI.", {"mistral"}),
+            ("I am Microsoft Copilot.", {"microsoft"}),
+            ("I am Tencent Hunyuan, an AI assistant.", {"tencent", "hunyuan"}),
+            ("I'm KAT-Coder, created by Kuaishou.", {"kat-coder", "kuaishou"}),
+            ("I am inclusionAI, a model from Ant Group.", {"inclusionai"}),
+            ("I am ERNIE, developed by Baidu.", {"baidu", "ernie"}),
+            ("I am Grok, made by xAI.", {"xai", "grok"}),
+        ]
+        for text, expected in cases:
+            matches = set(find_non_claude_identities(text))
+            assert expected <= matches, f"Expected {expected} in {text!r}, got {matches}"
+
+    def test_zenmux_current_vendor_aliases_need_identity_context(self):
+        """Common product/vendor names must not fire from a bare comparison
+        mention without a self-identification anchor."""
+        text = (
+            "I can compare Claude with OpenAI, Google, Microsoft, "
+            "Gemini, Mistral, Tencent, and Baidu products."
+        )
+        matches = find_non_claude_identities(text)
+        for kw in (
+            "openai",
+            "google",
+            "microsoft",
+            "gemini",
+            "mistral",
+            "tencent",
+            "baidu",
+        ):
+            assert kw not in matches
+
 
 # ---------------------------------------------------------------------------
 # v1.7.6: Warp / Windsurf reverse-proxy dev-tool channels (cctest.ai FAQ)
@@ -474,6 +537,22 @@ class TestCJKNoWhitespace:
     def test_chinese_anchor_no_space_grok(self):
         """我是Grok must match grok."""
         assert "grok" in find_non_claude_identities("我是Grok，由xAI开发。")
+
+    def test_chinese_anchor_no_space_lax_ascii_keywords(self):
+        """ZenMux regression: distinctive lax ASCII names also need the
+        CJK no-whitespace path. `我是DeepSeek` used to be missed because
+        Python's Unicode word boundary does not split between 是 and D."""
+        for text, expected in (
+            ("我是DeepSeek，由深度求索公司创造的智能助手。", "deepseek"),
+            ("我是Qwen3.7，由阿里云开发。", "qwen"),
+            ("我叫MiniMax，一个AI助手。", "minimax"),
+        ):
+            assert expected in find_non_claude_identities(text)
+
+    def test_cjk_prose_before_lax_ascii_without_anchor_not_matched(self):
+        """The CJK no-whitespace repair is anchor-gated; ordinary CJK prose
+        directly preceding a distinctive ASCII model name should not match."""
+        assert find_non_claude_identities("讨论DeepSeek发布节奏。") == []
 
     def test_chinese_no_space_does_not_affect_english(self):
         """English 'I amGPT' (no space, typo) should NOT match because


### PR DESCRIPTION
﻿## Summary

- Calibrates Step 5 natural-language identity matching against ZenMux Arena's 2026-06-01 "Who Are You?" dataset.
- Adds current frontier-vendor aliases while keeping common names anchor-gated so product comparisons do not become identity findings.
- Fixes CJK no-whitespace matching for distinctive ASCII model names such as `我是DeepSeek`.
- Regenerates the standalone `audit.py` artifact and documents why self-ID mismatches remain consistency signals, not attribution proof.

## Validation

- `python -m pytest` (783 passed)
- Local ZenMux calibration rerun over 29,700 joined records: extractor non-Anthropic identity coverage improved from 49.2% to 62.1%; Anthropic-claim false flags stayed low at 0.2%.
