### PR TITLE
[codex] Verify release artifact provenance

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -111,3 +111,12 @@ jobs:
             --title "${TAG}" \
             --notes-file "${NOTES}" \
             --target "${GITHUB_SHA}"
+
+      - name: Verify published release artifact provenance
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          python3 scripts/verify-release-artifact.py --tag "${TAG}"

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -73,23 +73,61 @@ jobs:
       - name: Confirm workflow did not mutate source files
         run: git diff --exit-code
 
-      - name: Ensure tag and release do not already exist
+      - name: Inspect draft release state
+        id: release_state
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
+          EXPECTED_COMMIT: ${{ github.sha }}
         run: |
           set -euo pipefail
           git fetch --tags --force
 
-          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-            echo "tag already exists: ${TAG}" >&2
+          tag_commit=""
+          if git rev-parse -q --verify "refs/tags/${TAG}^{commit}" >/dev/null; then
+            tag_commit="$(git rev-list -n 1 "refs/tags/${TAG}")"
+          fi
+
+          release_error="$(mktemp)"
+          set +e
+          release_json="$(gh release view "${TAG}" --json isDraft,targetCommitish 2>"${release_error}")"
+          release_status=$?
+          set -e
+
+          release_exists=false
+          if [ "${release_status}" -eq 0 ]; then
+            release_exists=true
+          elif ! grep -qi "release not found" "${release_error}"; then
+            cat "${release_error}" >&2
+            exit "${release_status}"
+          fi
+
+          if [ -z "${tag_commit}" ] && [ "${release_exists}" = false ]; then
+            echo "mode=create" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${release_exists}" = false ]; then
+            echo "tag exists without a release: ${TAG}" >&2
             exit 1
           fi
 
-          if gh release view "${TAG}" >/dev/null 2>&1; then
-            echo "release already exists: ${TAG}" >&2
+          is_draft="$(jq -r '.isDraft' <<<"${release_json}")"
+          target_commit="$(jq -r '.targetCommitish' <<<"${release_json}")"
+          if [ "${is_draft}" != true ]; then
+            echo "release already published: ${TAG}" >&2
             exit 1
           fi
+          if [ "${target_commit}" != "${EXPECTED_COMMIT}" ]; then
+            echo "draft target mismatch: ${target_commit} != ${EXPECTED_COMMIT}" >&2
+            exit 1
+          fi
+          if [ -n "${tag_commit}" ] && [ "${tag_commit}" != "${EXPECTED_COMMIT}" ]; then
+            echo "tag target mismatch: ${tag_commit} != ${EXPECTED_COMMIT}" >&2
+            exit 1
+          fi
+
+          echo "mode=resume" >> "$GITHUB_OUTPUT"
 
       - name: Package standalone artifact
         run: |
@@ -99,6 +137,7 @@ jobs:
           (cd dist && sha256sum audit.py > audit.py.sha256)
 
       - name: Create draft GitHub Release
+        if: steps.release_state.outputs.mode == 'create'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
@@ -112,11 +151,28 @@ jobs:
             --notes-file "${NOTES}" \
             --target "${GITHUB_SHA}"
 
+      - name: Resume existing draft GitHub Release
+        if: steps.release_state.outputs.mode == 'resume'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          NOTES: ${{ steps.version.outputs.notes }}
+        run: |
+          set -euo pipefail
+          gh release upload "${TAG}" \
+            dist/audit.py \
+            dist/audit.py.sha256 \
+            --clobber
+          gh release edit "${TAG}" \
+            --title "${TAG}" \
+            --notes-file "${NOTES}"
+
       - name: Verify published release artifact provenance
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
-          python3 scripts/verify-release-artifact.py --tag "${TAG}"
+          python3 scripts/verify-release-artifact.py \
+            --tag "${TAG}" \
+            --source-ref "${GITHUB_SHA}"

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Community evidence is shape-checked by GitHub Actions, but publication still req
 | Version | `v2.3` |
 | Audit steps | 14 |
 | Risk matrix | 6D |
-| pytest collected tests | 789 |
+| pytest collected tests | 796 |
 | CLI flags | 21 |
 | Runtime profiles | `general`, `web3`, `full` |
 
@@ -333,7 +333,7 @@ API Relay Audit 也可以作为 agent skill 使用。
 | 版本 | `v2.3` |
 | 审计步骤 | 14 |
 | 风险矩阵 | 6D |
-| pytest collected tests | 789 |
+| pytest collected tests | 796 |
 | CLI flags | 21 |
 | Runtime profiles | `general`, `web3`, `full` |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,11 +40,12 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
   detector, not a hosted preflight service, not a new API family, and not a
   change to LOW/MEDIUM/HIGH semantics. `inconclusive` remains
   `inconclusive`.
-- **Final test count**: 789/789 passing (733 baseline → 764 after current
+- **Final test count**: 796/796 passing (733 baseline → 764 after current
   master follow-ups → 769 after release-engineering version sync coverage →
   775 after query-family growth contracts → 778 after release-hardening
   public verification regressions → 789 after report reproducibility metadata
-  and metadata source-boundary regressions).
+  and metadata source-boundary regressions → 796 after resumable release
+  provenance verification).
 
 ### v1.9 — Dual-distribution full generation (2026-06-01)
 - **Standalone product promise preserved**: root `audit.py` stays committed,

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,23 +16,23 @@
 | 单文件版版本 | `v2.3.1` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **789** | `pytest --collect-only` |
-| 测试数 (static) | 761 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **796** | `pytest --collect-only` |
+| 测试数 (static) | 768 | grep `def test_*` in tests/ |
 | CLI flag 数 | 21 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-07 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
-| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 789] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `6d17ea0` | recent reachable commit; `--check` allows follow-up metrics commits |
+| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 796] | grep `Final test count: N/N passing` |
+| Recorded commit SHA | `b95adff` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-08-16 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3.1`。
 - ✅ 步骤数一致：14。
-- ℹ️ pytest (789) vs 静态 (761) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
+- ℹ️ pytest (796) vs 静态 (768) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -46,3 +46,27 @@ Run the draft-release workflow only from `master` after the release-prep PR is
 merged. If versioned skill or release docs now point at a new tag such as
 `v2.3.0`, create the draft release immediately after merge so the immutable tag
 exists before users follow those download commands.
+
+## Standalone Artifact Provenance
+
+Each release has one authoritative standalone artifact: `audit.py` at the
+release tag. The GitHub Release asset `audit.py` must be byte-identical to that
+tagged file, and `audit.py.sha256` must be the SHA-256 digest of the uploaded
+asset.
+
+The draft-release workflow enforces this after creating the draft release:
+
+```bash
+python3 scripts/verify-release-artifact.py --tag vX.Y.Z
+```
+
+The verifier checks all three links in the chain:
+
+1. `git show vX.Y.Z:audit.py`
+2. the generated standalone artifact for the checked-out source
+3. the downloaded GitHub Release `audit.py` and `audit.py.sha256` assets
+
+If any byte differs, the release is not reproducible and must not be published.
+Do not manually replace release assets to paper over drift. Fix the source,
+regenerate `audit.py`, rerun the draft-release workflow, and preserve the failed
+draft as audit trail if it was already visible to collaborators.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -54,19 +54,23 @@ release tag. The GitHub Release asset `audit.py` must be byte-identical to that
 tagged file, and `audit.py.sha256` must be the SHA-256 digest of the uploaded
 asset.
 
-The draft-release workflow enforces this after creating the draft release:
+The draft-release workflow enforces this after creating or resuming the draft
+release:
 
 ```bash
-python3 scripts/verify-release-artifact.py --tag vX.Y.Z
+python3 scripts/verify-release-artifact.py --tag vX.Y.Z --source-ref <release-commit>
 ```
 
 The verifier checks all three links in the chain:
 
-1. `git show vX.Y.Z:audit.py`
+1. `git show <release-commit>:audit.py` while the release is draft, and
+   `git show vX.Y.Z:audit.py` after publication
 2. the generated standalone artifact for the checked-out source
 3. the downloaded GitHub Release `audit.py` and `audit.py.sha256` assets
 
 If any byte differs, the release is not reproducible and must not be published.
-Do not manually replace release assets to paper over drift. Fix the source,
-regenerate `audit.py`, rerun the draft-release workflow, and preserve the failed
-draft as audit trail if it was already visible to collaborators.
+Do not manually replace release assets to paper over drift. Fix the source and
+regenerate `audit.py`. A rerun may replace assets only when the existing release
+is still a draft targeting the exact same commit. Published releases, draft
+target mismatches, and orphaned tag-only states fail closed and require explicit
+maintainer recovery.

--- a/scripts/verify-release-artifact.py
+++ b/scripts/verify-release-artifact.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Verify standalone release artifact provenance.
+
+The release contract is intentionally strict: the committed ``audit.py`` at a
+release tag, the generated standalone artifact for the checked-out source, and
+the GitHub Release asset must be the same bytes. This script is designed for
+the draft-release workflow, but it is also useful as a maintainer post-release
+check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BUILD_STANDALONE = REPO_ROOT / "scripts" / "build-standalone.py"
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def parse_sha256_file(text: str) -> str:
+    """Return the first SHA-256 digest from a sha256sum-style file."""
+    match = re.search(r"\b([0-9a-fA-F]{64})\b", text)
+    if not match:
+        raise ValueError("sha256 file does not contain a 64-character digest")
+    return match.group(1).lower()
+
+
+def run(args: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess:
+    return subprocess.run(args, cwd=cwd, check=True, capture_output=True)
+
+
+def git_show_bytes(tag: str, path: str) -> bytes:
+    return run(["git", "show", f"{tag}:{path}"]).stdout
+
+
+def generated_standalone_bytes() -> bytes:
+    spec = importlib.util.spec_from_file_location("build_standalone", BUILD_STANDALONE)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {BUILD_STANDALONE}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.build_text().encode("utf-8")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def require_equal(left_label: str, left: bytes, right_label: str, right: bytes) -> None:
+    if left == right:
+        print(f"OK: {left_label} == {right_label} ({sha256_bytes(left)})")
+        return
+    fail(
+        f"release artifact mismatch: {left_label} ({sha256_bytes(left)}) "
+        f"!= {right_label} ({sha256_bytes(right)})"
+    )
+
+
+def verify_local(tag: str) -> bytes:
+    tag_bytes = git_show_bytes(tag, "audit.py")
+    head_bytes = git_show_bytes("HEAD", "audit.py")
+    generated_bytes = generated_standalone_bytes()
+
+    require_equal(f"{tag}:audit.py", tag_bytes, "HEAD:audit.py", head_bytes)
+    require_equal("HEAD:audit.py", head_bytes, "generated standalone", generated_bytes)
+    return tag_bytes
+
+
+def download_release_assets(tag: str, repo: str | None, dest: Path) -> tuple[Path, Path]:
+    cmd = ["gh", "release", "download", tag, "--pattern", "audit.py*", "--dir", str(dest)]
+    if repo:
+        cmd.extend(["--repo", repo])
+    run(cmd)
+
+    audit_asset = dest / "audit.py"
+    sha_asset = dest / "audit.py.sha256"
+    if not audit_asset.is_file():
+        fail(f"release asset missing: {audit_asset.name}")
+    if not sha_asset.is_file():
+        fail(f"release asset missing: {sha_asset.name}")
+    return audit_asset, sha_asset
+
+
+def verify_release_assets(tag: str, expected_bytes: bytes, repo: str | None) -> None:
+    with tempfile.TemporaryDirectory(prefix="api-relay-audit-release-") as tmp:
+        audit_asset, sha_asset = download_release_assets(tag, repo, Path(tmp))
+        asset_bytes = audit_asset.read_bytes()
+        published_digest = parse_sha256_file(sha_asset.read_text(encoding="utf-8"))
+        actual_digest = sha256_bytes(asset_bytes)
+
+        if published_digest != actual_digest:
+            fail(
+                "release checksum mismatch: audit.py.sha256 "
+                f"({published_digest}) != audit.py asset ({actual_digest})"
+            )
+        print(f"OK: audit.py.sha256 matches release asset ({actual_digest})")
+        require_equal("release asset audit.py", asset_bytes, f"{tag}:audit.py", expected_bytes)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify that a release audit.py asset matches the tagged generated artifact."
+    )
+    parser.add_argument("--tag", required=True, help="Release tag, e.g. v2.3.1")
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY"),
+        help="GitHub repository for gh release download, e.g. owner/repo.",
+    )
+    parser.add_argument(
+        "--skip-release-download",
+        action="store_true",
+        help="Only verify tag, working tree, and generated standalone bytes.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    expected_bytes = verify_local(args.tag)
+    if not args.skip_release_download:
+        verify_release_assets(args.tag, expected_bytes, args.repo)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-release-artifact.py
+++ b/scripts/verify-release-artifact.py
@@ -41,8 +41,8 @@ def run(args: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProces
     return subprocess.run(args, cwd=cwd, check=True, capture_output=True)
 
 
-def git_show_bytes(tag: str, path: str) -> bytes:
-    return run(["git", "show", f"{tag}:{path}"]).stdout
+def git_show_bytes(ref: str, path: str) -> bytes:
+    return run(["git", "show", f"{ref}:{path}"]).stdout
 
 
 def generated_standalone_bytes() -> bytes:
@@ -69,14 +69,14 @@ def require_equal(left_label: str, left: bytes, right_label: str, right: bytes) 
     )
 
 
-def verify_local(tag: str) -> bytes:
-    tag_bytes = git_show_bytes(tag, "audit.py")
+def verify_local(source_ref: str) -> bytes:
+    source_bytes = git_show_bytes(source_ref, "audit.py")
     head_bytes = git_show_bytes("HEAD", "audit.py")
     generated_bytes = generated_standalone_bytes()
 
-    require_equal(f"{tag}:audit.py", tag_bytes, "HEAD:audit.py", head_bytes)
+    require_equal(f"{source_ref}:audit.py", source_bytes, "HEAD:audit.py", head_bytes)
     require_equal("HEAD:audit.py", head_bytes, "generated standalone", generated_bytes)
-    return tag_bytes
+    return source_bytes
 
 
 def download_release_assets(tag: str, repo: str | None, dest: Path) -> tuple[Path, Path]:
@@ -94,7 +94,12 @@ def download_release_assets(tag: str, repo: str | None, dest: Path) -> tuple[Pat
     return audit_asset, sha_asset
 
 
-def verify_release_assets(tag: str, expected_bytes: bytes, repo: str | None) -> None:
+def verify_release_assets(
+    tag: str,
+    expected_bytes: bytes,
+    repo: str | None,
+    source_ref: str,
+) -> None:
     with tempfile.TemporaryDirectory(prefix="api-relay-audit-release-") as tmp:
         audit_asset, sha_asset = download_release_assets(tag, repo, Path(tmp))
         asset_bytes = audit_asset.read_bytes()
@@ -107,7 +112,12 @@ def verify_release_assets(tag: str, expected_bytes: bytes, repo: str | None) -> 
                 f"({published_digest}) != audit.py asset ({actual_digest})"
             )
         print(f"OK: audit.py.sha256 matches release asset ({actual_digest})")
-        require_equal("release asset audit.py", asset_bytes, f"{tag}:audit.py", expected_bytes)
+        require_equal(
+            "release asset audit.py",
+            asset_bytes,
+            f"{source_ref}:audit.py",
+            expected_bytes,
+        )
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -115,6 +125,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Verify that a release audit.py asset matches the tagged generated artifact."
     )
     parser.add_argument("--tag", required=True, help="Release tag, e.g. v2.3.1")
+    parser.add_argument(
+        "--source-ref",
+        default=None,
+        help=(
+            "Git ref that owns the expected audit.py bytes. Defaults to --tag. "
+            "Draft-release workflows should pass the exact release commit SHA."
+        ),
+    )
     parser.add_argument(
         "--repo",
         default=os.environ.get("GITHUB_REPOSITORY"),
@@ -130,9 +148,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    expected_bytes = verify_local(args.tag)
+    source_ref = args.source_ref or args.tag
+    expected_bytes = verify_local(source_ref)
     if not args.skip_release_download:
-        verify_release_assets(args.tag, expected_bytes, args.repo)
+        verify_release_assets(args.tag, expected_bytes, args.repo, source_ref)
     return 0
 
 

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -49,3 +49,38 @@ def test_generated_standalone_bytes_imports_builder():
 
     assert data.startswith(b"#!/usr/bin/env python")
     assert b"GENERATED STANDALONE ARTIFACT" in data
+
+
+def test_verify_local_uses_explicit_source_ref(monkeypatch):
+    mod = load_module()
+    calls = []
+
+    def fake_show(ref, path):
+        calls.append((ref, path))
+        return b"same"
+
+    monkeypatch.setattr(mod, "git_show_bytes", fake_show)
+    monkeypatch.setattr(mod, "generated_standalone_bytes", lambda: b"same")
+
+    assert mod.verify_local("deadbeef") == b"same"
+    assert calls == [("deadbeef", "audit.py"), ("HEAD", "audit.py")]
+
+
+def test_source_ref_defaults_to_tag():
+    mod = load_module()
+
+    args = mod.parse_args(["--tag", "v2.3.1", "--skip-release-download"])
+    assert args.source_ref is None
+
+
+def test_workflow_has_bounded_draft_recovery():
+    workflow = (ROOT / ".github" / "workflows" / "release-draft.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "release already published" in workflow
+    assert "draft target mismatch" in workflow
+    assert "tag exists without a release" in workflow
+    assert 'gh release upload "${TAG}"' in workflow
+    assert "--clobber" in workflow
+    assert '--source-ref "${GITHUB_SHA}"' in workflow

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -1,0 +1,51 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "verify-release-artifact.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("verify_release_artifact", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_sha256_file_accepts_sha256sum_format():
+    mod = load_module()
+    digest = "a" * 64
+
+    assert mod.parse_sha256_file(f"{digest}  audit.py\n") == digest
+
+
+def test_parse_sha256_file_rejects_missing_digest():
+    mod = load_module()
+
+    with pytest.raises(ValueError):
+        mod.parse_sha256_file("not-a-digest  audit.py\n")
+
+
+def test_require_equal_reports_hashes_on_mismatch():
+    mod = load_module()
+
+    with pytest.raises(SystemExit) as exc:
+        mod.require_equal("left", b"one", "right", b"two")
+
+    message = str(exc.value)
+    assert "release artifact mismatch" in message
+    assert mod.sha256_bytes(b"one") in message
+    assert mod.sha256_bytes(b"two") in message
+
+
+def test_generated_standalone_bytes_imports_builder():
+    mod = load_module()
+
+    data = mod.generated_standalone_bytes()
+
+    assert data.startswith(b"#!/usr/bin/env python")
+    assert b"GENERATED STANDALONE ARTIFACT" in data

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">789</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">796</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## Summary
- add a release artifact verifier that compares the tagged audit.py blob, generated standalone output, release asset, and audit.py.sha256
- run the verifier after the draft release workflow creates and uploads assets
- document the standalone artifact provenance policy

## Validation
- python -m pytest tests/test_release_artifact.py -q
- python scripts/build-standalone.py --check
- python scripts/verify-release-artifact.py --tag v2.3.0 --skip-release-download
- python scripts/verify-release-artifact.py --tag v2.3.0
- git diff --check