### PR TITLE
[codex] Add GitHub Actions integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Community evidence is shape-checked by GitHub Actions, but publication still req
   [prompt injection in proxies](https://toby-bridges.github.io/api-relay-audit/guides/detect-prompt-injection-llm-api-proxies.html),
   [Web3 wallet prompt injection](https://toby-bridges.github.io/api-relay-audit/guides/web3-wallet-prompt-injection-ai-agents.html),
   [OpenClaw and Hermes skill](https://toby-bridges.github.io/api-relay-audit/guides/openclaw-hermes-skill-api-relay-audit.html)
+- Integrations: [GitHub Actions example](./docs/integrations/github-actions.md)
 - Contributors / Credits: [CONTRIBUTORS.md](./CONTRIBUTORS.md)
 - Security policy: [SECURITY.md](./SECURITY.md)
 - Contributing guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
@@ -349,6 +350,7 @@ API Relay Audit 也可以作为 agent skill 使用。
 - 贡献者 / Credits: [CONTRIBUTORS.md](./CONTRIBUTORS.md)
 - 安全政策: [SECURITY.md](./SECURITY.md)
 - 贡献指南: [CONTRIBUTING.md](./CONTRIBUTING.md)
+- 集成示例: [GitHub Actions example](./docs/integrations/github-actions.md)
 - 社交媒体: [X @li9292](https://x.com/li9292)
 
 </details>

--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -1,0 +1,51 @@
+# GitHub Actions Integration Example
+
+This example shows how another repository can run API Relay Audit in its own
+GitHub Actions runner. It is a downstream integration pattern, not evidence
+that any third-party repository has adopted the tool.
+
+Use this when you want a manual workflow that downloads the pinned standalone
+`audit.py`, runs a local audit against a relay URL stored in repository
+secrets, and uploads the resulting Markdown report as a workflow artifact.
+
+## Secrets
+
+Create these repository secrets in the downstream repository:
+
+| Secret | Purpose |
+| --- | --- |
+| `API_RELAY_AUDIT_KEY` | API key for the relay under test. |
+| `API_RELAY_AUDIT_URL` | Base URL for the relay, such as `https://relay.example.invalid/v1`. |
+
+Do not put API keys, private relay URLs, wallet material, or raw reports in
+workflow logs, issue comments, branch names, or commit messages.
+
+## Workflow
+
+Copy [`examples/github-actions/relay-audit.yml`](../../examples/github-actions/relay-audit.yml)
+into the downstream repository as `.github/workflows/relay-audit.yml`.
+
+The workflow is manual (`workflow_dispatch`) and asks for:
+
+- `model`: the model name sent to the relay.
+- `profile`: `general`, `web3`, or `full`.
+
+The workflow pins `AUDIT_SCRIPT_REF` to `v2.3.0`. Update that value only after
+reviewing the corresponding API Relay Audit release.
+
+## Report Handling
+
+The uploaded `report.md` artifact may contain private relay metadata depending
+on the target and findings. Treat it as private by default.
+
+Before sharing a report publicly:
+
+- replace real relay domains with `example.invalid`;
+- remove API keys, bearer tokens, key prefixes, raw headers, and private URLs;
+- remove wallet material, signed transactions, and private traffic;
+- keep tool version, profile, tested-at time, and step summaries when safe;
+- hash the redacted artifact if submitting public audit evidence.
+
+Public reports are evidence from one run under one tool version and profile.
+They are not relay recommendations, rankings, certifications, or safety
+guarantees.

--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -6,7 +6,7 @@ that any third-party repository has adopted the tool.
 
 Use this when you want a manual workflow that downloads the pinned standalone
 `audit.py`, runs a local audit against a relay URL stored in repository
-secrets, and uploads the resulting Markdown report as a workflow artifact.
+secrets, and records a checksum for the resulting Markdown report.
 
 ## Secrets
 
@@ -29,14 +29,23 @@ The workflow is manual (`workflow_dispatch`) and asks for:
 
 - `model`: the model name sent to the relay.
 - `profile`: `general`, `web3`, or `full`.
+- `upload_private_report`: optional, default `false`. Enabling it uploads the
+  raw `report.md` as a private workflow artifact for internal review.
 
 The workflow pins `AUDIT_SCRIPT_REF` to `v2.3.0`. Update that value only after
-reviewing the corresponding API Relay Audit release.
+reviewing the corresponding API Relay Audit release. The workflow downloads
+the release asset `audit.py` plus `audit.py.sha256` and verifies the script
+checksum before running.
 
 ## Report Handling
 
-The uploaded `report.md` artifact may contain private relay metadata depending
-on the target and findings. Treat it as private by default.
+The workflow does not upload `report.md` by default. It uploads only
+`report.md.sha256`, which lets an internal team later prove which private
+report was reviewed without exposing report contents.
+
+If `upload_private_report` is enabled, the uploaded `report.md` artifact may
+contain private relay metadata depending on the target and findings. Treat it
+as private by default.
 
 Before sharing a report publicly:
 

--- a/examples/github-actions/relay-audit.yml
+++ b/examples/github-actions/relay-audit.yml
@@ -1,0 +1,56 @@
+name: API Relay Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Relay model name to audit"
+        required: true
+        default: "claude-opus-4-6"
+      profile:
+        description: "Audit profile"
+        required: true
+        type: choice
+        options:
+          - general
+          - web3
+          - full
+        default: general
+
+permissions:
+  contents: read
+
+jobs:
+  audit-relay:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      AUDIT_SCRIPT_REF: v2.3.0
+      API_RELAY_AUDIT_KEY: ${{ secrets.API_RELAY_AUDIT_KEY }}
+      API_RELAY_AUDIT_URL: ${{ secrets.API_RELAY_AUDIT_URL }}
+    steps:
+      - name: Download pinned standalone audit script
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://raw.githubusercontent.com/toby-bridges/api-relay-audit/${AUDIT_SCRIPT_REF}/audit.py" -o audit.py
+          python3 -S audit.py --help >/dev/null
+
+      - name: Run local relay audit
+        run: |
+          set -euo pipefail
+          test -n "${API_RELAY_AUDIT_KEY}"
+          test -n "${API_RELAY_AUDIT_URL}"
+          python3 audit.py \
+            --key "${API_RELAY_AUDIT_KEY}" \
+            --url "${API_RELAY_AUDIT_URL}" \
+            --model "${{ inputs.model }}" \
+            --profile "${{ inputs.profile }}" \
+            --output report.md
+
+      - name: Upload redaction-required report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-relay-audit-report
+          path: report.md
+          if-no-files-found: error
+          retention-days: 7

--- a/examples/github-actions/relay-audit.yml
+++ b/examples/github-actions/relay-audit.yml
@@ -16,6 +16,11 @@ on:
           - web3
           - full
         default: general
+      upload_private_report:
+        description: "Upload raw report.md as a private artifact"
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -32,7 +37,10 @@ jobs:
       - name: Download pinned standalone audit script
         run: |
           set -euo pipefail
-          curl -fsSL "https://raw.githubusercontent.com/toby-bridges/api-relay-audit/${AUDIT_SCRIPT_REF}/audit.py" -o audit.py
+          base_url="https://github.com/toby-bridges/api-relay-audit/releases/download/${AUDIT_SCRIPT_REF}"
+          curl -fsSLO "${base_url}/audit.py"
+          curl -fsSLO "${base_url}/audit.py.sha256"
+          sha256sum -c audit.py.sha256
           python3 -S audit.py --help >/dev/null
 
       - name: Run local relay audit
@@ -46,11 +54,21 @@ jobs:
             --model "${{ inputs.model }}" \
             --profile "${{ inputs.profile }}" \
             --output report.md
+          sha256sum report.md > report.md.sha256
 
-      - name: Upload redaction-required report artifact
+      - name: Upload report checksum artifact
         uses: actions/upload-artifact@v4
         with:
-          name: api-relay-audit-report
+          name: api-relay-audit-report-sha256
+          path: report.md.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload private report artifact
+        if: ${{ inputs.upload_private_report }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-relay-audit-private-report
           path: report.md
           if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
## Summary

- add a manual GitHub Actions workflow example for downstream repositories
- document required secrets, report handling, and public redaction boundaries
- link the integration example from README

## Boundary

This is an integration pattern, not an adopter claim. It does not imply any third-party repository has adopted API Relay Audit.

## Validation

- `git diff --check`
- lightweight workflow/docs assertions with `python3`