### PR TITLE
[codex] Add report reproducibility metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Community evidence is shape-checked by GitHub Actions, but publication still req
 | Version | `v2.3` |
 | Audit steps | 14 |
 | Risk matrix | 6D |
-| pytest collected tests | 785 |
+| pytest collected tests | 789 |
 | CLI flags | 21 |
 | Runtime profiles | `general`, `web3`, `full` |
 
@@ -333,7 +333,7 @@ API Relay Audit 也可以作为 agent skill 使用。
 | 版本 | `v2.3` |
 | 审计步骤 | 14 |
 | 风险矩阵 | 6D |
-| pytest collected tests | 785 |
+| pytest collected tests | 789 |
 | CLI flags | 21 |
 | Runtime profiles | `general`, `web3`, `full` |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,10 +40,11 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
   detector, not a hosted preflight service, not a new API family, and not a
   change to LOW/MEDIUM/HIGH semantics. `inconclusive` remains
   `inconclusive`.
-- **Final test count**: 778/778 passing (733 baseline → 764 after current
+- **Final test count**: 789/789 passing (733 baseline → 764 after current
   master follow-ups → 769 after release-engineering version sync coverage →
   775 after query-family growth contracts → 778 after release-hardening
-  public verification regressions).
+  public verification regressions → 789 after report reproducibility metadata
+  and metadata source-boundary regressions).
 
 ### v1.9 — Dual-distribution full generation (2026-06-01)
 - **Standalone product promise preserved**: root `audit.py` stays committed,

--- a/api_relay_audit/reporter.py
+++ b/api_relay_audit/reporter.py
@@ -1,6 +1,6 @@
 """Markdown report generator for audit results."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class Reporter:
@@ -77,7 +77,8 @@ class Reporter:
         self.summary.append((level, msg))
         self.sections.append(f"{icon} **{msg}**\n")
 
-    def render(self, target_url="", model=""):
+    def render(self, target_url="", model="", tool_version="", profile="",
+               tool_commit=""):
         """Render the complete Markdown report.
 
         Produces a header block (title, metadata, risk summary) followed
@@ -88,6 +89,11 @@ class Reporter:
                 metadata when provided.
             model: The model identifier used for the audit. Shown in the
                 report metadata when provided.
+            tool_version: API Relay Audit version used for the run.
+            profile: Audit profile used for the run (``general``, ``web3``,
+                or ``full``).
+            tool_commit: Optional git commit for checkout-based runs. Omitted
+                when the standalone script is run outside a repository.
 
         Returns:
             A single Markdown string containing the full report.
@@ -100,12 +106,18 @@ class Reporter:
         """
         header = (
             f"# API Relay Security Audit Report\n\n"
-            f"**Generated**: {datetime.now().strftime('%Y-%m-%d %H:%M')}\n"
+            f"**Generated**: {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}\n"
         )
+        if tool_version:
+            header += f"**Tool Version**: `{tool_version}`\n"
+        if profile:
+            header += f"**Profile**: `{profile}`\n"
         if target_url:
             header += f"**Target**: `{target_url}`\n"
         if model:
             header += f"**Model**: `{model}`\n"
+        if tool_commit:
+            header += f"**Tool Commit**: `{tool_commit}`\n"
 
         header += "\n## Risk Summary\n\n"
         for level, msg in self.summary:

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 29098d59def1f325bc6c75efe2f96013c3c2056ca27277c01b1d6d5fb6d2ba28
-# standalone_body_sha256: c717d12b15a3d66b053ac5d600f35761504b1da5424ee6c4cffb444289e7ce24
+# source_sha256: e477b62621b1403b5788e19cda25ad3a0e9dc64acd85b8505ad34bf137ee7efc
+# standalone_body_sha256: 871029077edf2107f07d91223324a4d252a5d6bc8c795cc7d0c25ead85a27c00
 # END GENERATED STANDALONE HEADER
 
 """
@@ -4854,7 +4854,7 @@ from urllib.request import Request, urlopen
 
 
 
-TOOL_VERSION_FALLBACK = "2.3.0"
+TOOL_VERSION_FALLBACK = "2.3.1"
 
 
 def _api_relay_audit_checkout_root(script_path):

--- a/audit.py
+++ b/audit.py
@@ -4857,6 +4857,24 @@ from urllib.request import Request, urlopen
 TOOL_VERSION_FALLBACK = "2.3.0"
 
 
+def _api_relay_audit_checkout_root(script_path):
+    """Return this project's checkout root, or ``None`` for copied scripts."""
+    script_path = script_path.resolve()
+    candidates = []
+    if script_path.parent.name == "scripts":
+        candidates.append(script_path.parent.parent)
+    candidates.append(script_path.parent)
+
+    for root in candidates:
+        if all((
+            (root / "VERSION").is_file(),
+            (root / "scripts" / "build-standalone.py").is_file(),
+            (root / "api_relay_audit" / "reporter.py").is_file(),
+        )):
+            return root
+    return None
+
+
 def _format_identity_inconsistency(non_claude_matches):
     """Render Step 5's non-Claude self-ID finding without over-attribution."""
     matches = ", ".join(non_claude_matches)
@@ -4885,15 +4903,13 @@ def _report_error(report, error, status=None):
 
 def _tool_version():
     """Return the packaged tool version for report metadata."""
-    script_path = Path(__file__).resolve()
-    for candidate in (
-        script_path.parent / "VERSION",
-        script_path.parent.parent / "VERSION",
-    ):
+    repo_root = _api_relay_audit_checkout_root(Path(__file__).resolve())
+    if repo_root is not None:
+        candidate = repo_root / "VERSION"
         try:
             value = candidate.read_text(encoding="utf-8").strip()
         except OSError:
-            continue
+            value = ""
         if re.fullmatch(r"\d+\.\d+\.\d+", value):
             return value
     return TOOL_VERSION_FALLBACK
@@ -4901,11 +4917,22 @@ def _tool_version():
 
 def _tool_commit_from_checkout():
     """Return a short git commit only when this script is in this repo checkout."""
-    script_path = Path(__file__).resolve()
-    repo_root = script_path.parent.parent if script_path.parent.name == "scripts" else script_path.parent
+    repo_root = _api_relay_audit_checkout_root(Path(__file__).resolve())
+    if repo_root is None:
+        return ""
     if not (repo_root / ".git").exists():
         return ""
     try:
+        root_result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True,
+        )
+        git_root = Path(root_result.stdout.strip()).resolve()
+        if git_root != repo_root.resolve():
+            return ""
         result = subprocess.run(
             ["git", "-C", str(repo_root), "rev-parse", "--short=12", "HEAD"],
             capture_output=True,

--- a/audit.py
+++ b/audit.py
@@ -1624,7 +1624,7 @@ class APIClient:
 
 """Markdown report generator for audit results."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class Reporter:
@@ -1701,7 +1701,8 @@ class Reporter:
         self.summary.append((level, msg))
         self.sections.append(f"{icon} **{msg}**\n")
 
-    def render(self, target_url="", model=""):
+    def render(self, target_url="", model="", tool_version="", profile="",
+               tool_commit=""):
         """Render the complete Markdown report.
 
         Produces a header block (title, metadata, risk summary) followed
@@ -1712,6 +1713,11 @@ class Reporter:
                 metadata when provided.
             model: The model identifier used for the audit. Shown in the
                 report metadata when provided.
+            tool_version: API Relay Audit version used for the run.
+            profile: Audit profile used for the run (``general``, ``web3``,
+                or ``full``).
+            tool_commit: Optional git commit for checkout-based runs. Omitted
+                when the standalone script is run outside a repository.
 
         Returns:
             A single Markdown string containing the full report.
@@ -1724,12 +1730,18 @@ class Reporter:
         """
         header = (
             f"# API Relay Security Audit Report\n\n"
-            f"**Generated**: {datetime.now().strftime('%Y-%m-%d %H:%M')}\n"
+            f"**Generated**: {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}\n"
         )
+        if tool_version:
+            header += f"**Tool Version**: `{tool_version}`\n"
+        if profile:
+            header += f"**Profile**: `{profile}`\n"
         if target_url:
             header += f"**Target**: `{target_url}`\n"
         if model:
             header += f"**Model**: `{model}`\n"
+        if tool_commit:
+            header += f"**Tool Commit**: `{tool_commit}`\n"
 
         header += "\n## Risk Summary\n\n"
         for level, msg in self.summary:
@@ -4842,6 +4854,8 @@ from urllib.request import Request, urlopen
 
 
 
+TOOL_VERSION_FALLBACK = "2.3.0"
+
 
 def _format_identity_inconsistency(non_claude_matches):
     """Render Step 5's non-Claude self-ID finding without over-attribution."""
@@ -4867,6 +4881,42 @@ def _report_error(report, error, status=None):
     """
     report.p(f"Error: {error}")
     report.p(format_diagnosis(_diagnosis_for_error(error, status=status)))
+
+
+def _tool_version():
+    """Return the packaged tool version for report metadata."""
+    script_path = Path(__file__).resolve()
+    for candidate in (
+        script_path.parent / "VERSION",
+        script_path.parent.parent / "VERSION",
+    ):
+        try:
+            value = candidate.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if re.fullmatch(r"\d+\.\d+\.\d+", value):
+            return value
+    return TOOL_VERSION_FALLBACK
+
+
+def _tool_commit_from_checkout():
+    """Return a short git commit only when this script is in this repo checkout."""
+    script_path = Path(__file__).resolve()
+    repo_root = script_path.parent.parent if script_path.parent.name == "scripts" else script_path.parent
+    if not (repo_root / ".git").exists():
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--short=12", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True,
+        )
+    except Exception:
+        return ""
+    commit = result.stdout.strip()
+    return commit if re.fullmatch(r"[0-9a-f]{7,12}", commit) else ""
 
 
 # ============================================================
@@ -6683,7 +6733,13 @@ def main():
                  "anomaly, or Web3 injection detected.")
 
     # Output
-    md = report.render(target_url=client.base_url, model=args.model)
+    md = report.render(
+        target_url=client.base_url,
+        model=args.model,
+        tool_version=f"v{_tool_version()}",
+        profile=args.profile,
+        tool_commit=_tool_commit_from_checkout(),
+    )
 
     if args.output:
         Path(args.output).parent.mkdir(parents=True, exist_ok=True)

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,24 +16,23 @@
 | 单文件版版本 | `v2.3.1` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **785** | `pytest --collect-only` |
-| 测试数 (static) | 757 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **789** | `pytest --collect-only` |
+| 测试数 (static) | 761 | grep `def test_*` in tests/ |
 | CLI flag 数 | 21 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-07 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
-| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 778] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `dc617ba` | recent reachable commit; `--check` allows follow-up metrics commits |
+| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 789] | grep `Final test count: N/N passing` |
+| Recorded commit SHA | `6d17ea0` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-08-16 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3.1`。
 - ✅ 步骤数一致：14。
-- ℹ️ pytest (785) vs 静态 (757) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
-- ⚠️ ROADMAP 最新记录 778 个测试，但当前 pytest 是 785。要么 ROADMAP 漏更新，要么有未记录的新测试。
+- ℹ️ pytest (789) vs 静态 (761) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -72,6 +72,24 @@ from api_relay_audit.web3.injection_probes import run_web3_injection_probes
 TOOL_VERSION_FALLBACK = "2.3.0"
 
 
+def _api_relay_audit_checkout_root(script_path):
+    """Return this project's checkout root, or ``None`` for copied scripts."""
+    script_path = script_path.resolve()
+    candidates = []
+    if script_path.parent.name == "scripts":
+        candidates.append(script_path.parent.parent)
+    candidates.append(script_path.parent)
+
+    for root in candidates:
+        if all((
+            (root / "VERSION").is_file(),
+            (root / "scripts" / "build-standalone.py").is_file(),
+            (root / "api_relay_audit" / "reporter.py").is_file(),
+        )):
+            return root
+    return None
+
+
 def _format_identity_inconsistency(non_claude_matches):
     """Render Step 5's non-Claude self-ID finding without over-attribution."""
     matches = ", ".join(non_claude_matches)
@@ -100,15 +118,13 @@ def _report_error(report, error, status=None):
 
 def _tool_version():
     """Return the packaged tool version for report metadata."""
-    script_path = Path(__file__).resolve()
-    for candidate in (
-        script_path.parent / "VERSION",
-        script_path.parent.parent / "VERSION",
-    ):
+    repo_root = _api_relay_audit_checkout_root(Path(__file__).resolve())
+    if repo_root is not None:
+        candidate = repo_root / "VERSION"
         try:
             value = candidate.read_text(encoding="utf-8").strip()
         except OSError:
-            continue
+            value = ""
         if re.fullmatch(r"\d+\.\d+\.\d+", value):
             return value
     return TOOL_VERSION_FALLBACK
@@ -116,11 +132,22 @@ def _tool_version():
 
 def _tool_commit_from_checkout():
     """Return a short git commit only when this script is in this repo checkout."""
-    script_path = Path(__file__).resolve()
-    repo_root = script_path.parent.parent if script_path.parent.name == "scripts" else script_path.parent
+    repo_root = _api_relay_audit_checkout_root(Path(__file__).resolve())
+    if repo_root is None:
+        return ""
     if not (repo_root / ".git").exists():
         return ""
     try:
+        root_result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True,
+        )
+        git_root = Path(root_result.stdout.strip()).resolve()
+        if git_root != repo_root.resolve():
+            return ""
         result = subprocess.run(
             ["git", "-C", str(repo_root), "rev-parse", "--short=12", "HEAD"],
             capture_output=True,

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -69,7 +69,7 @@ from api_relay_audit.stream_integrity import analyze_stream
 from api_relay_audit.tool_substitution import run_tool_substitution_test
 from api_relay_audit.web3.injection_probes import run_web3_injection_probes
 
-TOOL_VERSION_FALLBACK = "2.3.0"
+TOOL_VERSION_FALLBACK = "2.3.1"
 
 
 def _api_relay_audit_checkout_root(script_path):

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -69,6 +69,8 @@ from api_relay_audit.stream_integrity import analyze_stream
 from api_relay_audit.tool_substitution import run_tool_substitution_test
 from api_relay_audit.web3.injection_probes import run_web3_injection_probes
 
+TOOL_VERSION_FALLBACK = "2.3.0"
+
 
 def _format_identity_inconsistency(non_claude_matches):
     """Render Step 5's non-Claude self-ID finding without over-attribution."""
@@ -94,6 +96,42 @@ def _report_error(report, error, status=None):
     """
     report.p(f"Error: {error}")
     report.p(format_diagnosis(_diagnosis_for_error(error, status=status)))
+
+
+def _tool_version():
+    """Return the packaged tool version for report metadata."""
+    script_path = Path(__file__).resolve()
+    for candidate in (
+        script_path.parent / "VERSION",
+        script_path.parent.parent / "VERSION",
+    ):
+        try:
+            value = candidate.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if re.fullmatch(r"\d+\.\d+\.\d+", value):
+            return value
+    return TOOL_VERSION_FALLBACK
+
+
+def _tool_commit_from_checkout():
+    """Return a short git commit only when this script is in this repo checkout."""
+    script_path = Path(__file__).resolve()
+    repo_root = script_path.parent.parent if script_path.parent.name == "scripts" else script_path.parent
+    if not (repo_root / ".git").exists():
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--short=12", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True,
+        )
+    except Exception:
+        return ""
+    commit = result.stdout.strip()
+    return commit if re.fullmatch(r"[0-9a-f]{7,12}", commit) else ""
 
 
 # ============================================================
@@ -1911,7 +1949,13 @@ def main():
                  "anomaly, or Web3 injection detected.")
 
     # Output
-    md = report.render(target_url=client.base_url, model=args.model)
+    md = report.render(
+        target_url=client.base_url,
+        model=args.model,
+        tool_version=f"v{_tool_version()}",
+        profile=args.profile,
+        tool_commit=_tool_commit_from_checkout(),
+    )
 
     if args.output:
         Path(args.output).parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/sync-version.py
+++ b/scripts/sync-version.py
@@ -103,10 +103,16 @@ def replace_regex(
 
 def sync_audit_script(version: Version, path: Path) -> str:
     text = read_text(path)
-    return replace_regex(
+    text = replace_regex(
         text,
         rf"API Relay Security Audit Tool {DISPLAY_VERSION_RE}",
         f"API Relay Security Audit Tool {version.display}",
+        path,
+    )
+    return replace_regex(
+        text,
+        rf'^TOOL_VERSION_FALLBACK = "{FULL_VERSION_RE}"$',
+        f'TOOL_VERSION_FALLBACK = "{version.full}"',
         path,
     )
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -119,17 +119,35 @@ class TestRender:
 
     @patch("api_relay_audit.reporter.datetime")
     def test_render_with_target_and_model(self, mock_dt, rpt):
-        mock_dt.now.return_value.strftime.return_value = "2026-03-30 12:00"
+        mock_dt.now.return_value.strftime.return_value = "2026-03-30T12:00:00Z"
         output = rpt.render(target_url="https://relay.test", model="claude-3")
         assert "`https://relay.test`" in output
         assert "`claude-3`" in output
 
     @patch("api_relay_audit.reporter.datetime")
+    def test_render_with_reproducibility_metadata(self, mock_dt, rpt):
+        mock_dt.now.return_value.strftime.return_value = "2026-03-30T12:00:00Z"
+        output = rpt.render(
+            target_url="https://relay.test",
+            model="claude-3",
+            tool_version="v2.3.0",
+            profile="full",
+            tool_commit="abc1234",
+        )
+        assert "**Generated**: 2026-03-30T12:00:00Z" in output
+        assert "**Tool Version**: `v2.3.0`" in output
+        assert "**Profile**: `full`" in output
+        assert "**Tool Commit**: `abc1234`" in output
+
+    @patch("api_relay_audit.reporter.datetime")
     def test_render_without_target_and_model(self, mock_dt, rpt):
-        mock_dt.now.return_value.strftime.return_value = "2026-03-30 12:00"
+        mock_dt.now.return_value.strftime.return_value = "2026-03-30T12:00:00Z"
         output = rpt.render()
         assert "**Target**" not in output
         assert "**Model**" not in output
+        assert "**Tool Version**" not in output
+        assert "**Profile**" not in output
+        assert "**Tool Commit**" not in output
 
     @patch("api_relay_audit.reporter.datetime")
     def test_render_includes_risk_summary(self, mock_dt, rpt):

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -77,3 +77,5 @@ def test_generated_standalone_uses_display_version():
     modular = (REPO_ROOT / "scripts" / "audit.py").read_text(encoding="utf-8")
     assert f"API Relay Security Audit Tool {display}" in modular
     assert f"API Relay Security Audit Tool {display} --- Standalone Edition" in standalone
+    assert f'TOOL_VERSION_FALLBACK = "{version}"' in modular
+    assert f'TOOL_VERSION_FALLBACK = "{version}"' in standalone

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -4,14 +4,26 @@ import importlib.util
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SYNC_VERSION = REPO_ROOT / "scripts" / "sync-version.py"
+AUDIT_SCRIPT = REPO_ROOT / "scripts" / "audit.py"
+STANDALONE_AUDIT = REPO_ROOT / "audit.py"
 
 
 def _load_sync_version_module():
     spec = importlib.util.spec_from_file_location("sync_version", SYNC_VERSION)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_module(path: Path, name: str):
+    sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(name, path)
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
@@ -73,9 +85,48 @@ def test_generated_standalone_uses_display_version():
     major, minor, patch = (int(part) for part in version.split("."))
     display = f"v{major}.{minor}" if patch == 0 else f"v{version}"
 
-    standalone = (REPO_ROOT / "audit.py").read_text(encoding="utf-8")
-    modular = (REPO_ROOT / "scripts" / "audit.py").read_text(encoding="utf-8")
+    standalone = STANDALONE_AUDIT.read_text(encoding="utf-8")
+    modular = AUDIT_SCRIPT.read_text(encoding="utf-8")
     assert f"API Relay Security Audit Tool {display}" in modular
     assert f"API Relay Security Audit Tool {display} --- Standalone Edition" in standalone
     assert f'TOOL_VERSION_FALLBACK = "{version}"' in modular
     assert f'TOOL_VERSION_FALLBACK = "{version}"' in standalone
+
+
+def test_standalone_metadata_ignores_arbitrary_neighbor_version(tmp_path):
+    module = _load_module(STANDALONE_AUDIT, "standalone_audit_metadata_boundary")
+    downstream = tmp_path / "downstream"
+    downstream.mkdir()
+    (downstream / "VERSION").write_text("9.9.9\n", encoding="utf-8")
+
+    module.__file__ = str(downstream / "audit.py")
+
+    assert module._tool_version() == module.TOOL_VERSION_FALLBACK
+
+
+def test_standalone_metadata_does_not_probe_downstream_git_repo(tmp_path):
+    module = _load_module(STANDALONE_AUDIT, "standalone_audit_commit_boundary")
+    downstream = tmp_path / "downstream"
+    downstream.mkdir()
+    (downstream / ".git").mkdir()
+    (downstream / "VERSION").write_text("9.9.9\n", encoding="utf-8")
+
+    module.__file__ = str(downstream / "audit.py")
+
+    with patch.object(module.subprocess, "run") as run:
+        assert module._tool_commit_from_checkout() == ""
+    run.assert_not_called()
+
+
+def test_modular_metadata_reads_version_only_for_project_checkout_shape(tmp_path):
+    module = _load_module(AUDIT_SCRIPT, "modular_audit_metadata_boundary")
+    checkout = tmp_path / "api-relay-audit"
+    (checkout / "scripts").mkdir(parents=True)
+    (checkout / "api_relay_audit").mkdir()
+    (checkout / "VERSION").write_text("3.4.5\n", encoding="utf-8")
+    (checkout / "scripts" / "build-standalone.py").write_text("", encoding="utf-8")
+    (checkout / "api_relay_audit" / "reporter.py").write_text("", encoding="utf-8")
+
+    module.__file__ = str(checkout / "scripts" / "audit.py")
+
+    assert module._tool_version() == "3.4.5"

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">785</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">789</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## Summary

- add UTC generation time, tool version, profile, and checkout commit metadata to audit report headers
- keep tool commit optional so standalone downloads outside a git checkout do not report a misleading commit
- keep the standalone artifact, version-sync fallback, and public metrics aligned

## Validation

- `git diff --check`
- `python3 scripts/build-standalone.py --check`
- `python3 scripts/sync-version.py --check`
- `python3 scripts/collect-metrics.py --check`
- `python3 -m pytest tests/test_reporter.py tests/test_version_sync.py -q`
- `python3 -m pytest tests/test_dual_distribution_parity.py -q`
- `python3 -m pytest tests/test_reporter.py tests/test_version_sync.py tests/test_dual_distribution_parity.py -q`
- `python3 -S audit.py --help`
- `python3 scripts/audit.py --help`