### PR TITLE
[codex] Add local run feedback entrypoint

### DIFF
--- a/.github/ISSUE_TEMPLATE/local-run-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/local-run-feedback.yml
@@ -1,0 +1,92 @@
+name: Local Run Feedback / 本地运行反馈
+description: Share install or runtime feedback without submitting relay evidence / 提交安装或运行反馈，不提交中转站证据
+title: "[Local Run] "
+labels: ["documentation", "help wanted"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for local install, runtime, platform, dependency, or report-UX feedback.
+
+        This is not telemetry and not an audit-evidence submission. Do not include API keys, private relay domains, raw traffic, wallet material, or unredacted reports.
+
+  - type: input
+    id: tool_version
+    attributes:
+      label: Tool Version
+      description: "Version shown by the release, report, or downloaded script."
+      placeholder: "v2.3.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: Install / Run Method
+      options:
+        - standalone curl download
+        - git checkout
+        - OpenClaw skill
+        - Hermes Agent skill
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: profile
+    attributes:
+      label: Audit Profile
+      options:
+        - general
+        - web3
+        - full
+        - connectivity only
+        - not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: command_shape
+    attributes:
+      label: Command Shape
+      description: "Paste the command shape after replacing secrets and private domains."
+      placeholder: |
+        python audit.py --key <REDACTED> --url https://example.invalid/v1 --profile general --output report.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, shell, Python version, curl version, and anything relevant.
+      placeholder: "macOS 15, zsh, Python 3.11, curl 8.x"
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: What happened locally? Include sanitized error text when useful.
+      placeholder: |
+        Expected:
+        Actual:
+        Sanitized error text:
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Improvement
+      description: Optional. What would make this run path clearer or easier?
+      placeholder: "The report should explain..."
+
+  - type: checkboxes
+    id: safety_confirmation
+    attributes:
+      label: Safety Confirmation
+      options:
+        - label: I removed API keys, private relay domains, wallet material, raw traffic, and unredacted reports.
+          required: true

--- a/.github/ISSUE_TEMPLATE/local-run-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/local-run-feedback.yml
@@ -1,7 +1,7 @@
 name: Local Run Feedback / 本地运行反馈
 description: Share install or runtime feedback without submitting relay evidence / 提交安装或运行反馈，不提交中转站证据
 title: "[Local Run] "
-labels: ["documentation", "help wanted"]
+labels: ["documentation"]
 body:
   - type: markdown
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ specific, reproducible, and safe to publish.
 
 | Contribution type | Good input | Avoid |
 | --- | --- | --- |
+| Local run feedback | Tool version, install method, OS/shell/Python/curl versions, command shape, sanitized error text | API keys, private relay domains, raw traffic, or unredacted reports |
 | Detector gap | A sanitized prompt, profile, expected behavior, actual behavior, and affected step | Raw API keys, private relay traffic, or unverifiable claims |
 | Documentation example | A concrete command, flag combination, profile choice, or confusing report line | Broad rewrites that change project scope |
 | OpenClaw / Hermes feedback | Install command used, environment, error text, and what fixed it | Publishing secrets from shell history or logs |
@@ -30,9 +31,14 @@ specific, reproducible, and safe to publish.
 
 Use the issue templates when possible:
 
+- Local run feedback: `.github/ISSUE_TEMPLATE/local-run-feedback.yml`
 - Detector gap: `.github/ISSUE_TEMPLATE/detector-gap.yml`
 - Documentation example: `.github/ISSUE_TEMPLATE/documentation-example.yml`
 - Agent skill install feedback: `.github/ISSUE_TEMPLATE/agent-skill-feedback.yml`
+
+See [docs/community-evidence.md](./docs/community-evidence.md) for the
+difference between local run feedback, detector-gap reports, and formal audit
+evidence submissions.
 
 Do not submit a public example audit report with real relay domains, real API
 keys, wallet material, raw traffic captures, or private operational details.

--- a/README.md
+++ b/README.md
@@ -219,15 +219,18 @@ You do not need to write code to help. Good first contributions are small,
 reproducible, and evidence-focused:
 
 - Report a detector gap with a sanitized reproduction.
+- Share local run feedback for install, runtime, platform, or report-UX issues.
 - Add documentation examples for profiles, flags, or relay behavior.
 - Improve OpenClaw or Hermes install notes from a real local setup.
 - Translate Quick Start or clarify `clean`, `anomaly`, and `inconclusive`.
 
 Start with:
 
+- [Local Run Feedback](https://github.com/toby-bridges/api-relay-audit/issues/new?template=local-run-feedback.yml)
 - [Detector Gap](https://github.com/toby-bridges/api-relay-audit/issues/new?template=detector-gap.yml)
 - [Documentation Example](https://github.com/toby-bridges/api-relay-audit/issues/new?template=documentation-example.yml)
 - [Agent Skill Feedback](https://github.com/toby-bridges/api-relay-audit/issues/new?template=agent-skill-feedback.yml)
+- [Community Evidence Guide](./docs/community-evidence.md)
 - [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 Avoid publishing real API keys or private relay traffic, and keep changes scoped
@@ -336,11 +339,13 @@ API Relay Audit 也可以作为 agent skill 使用。
 
 ## 如何贡献
 
-你不需要写代码也能帮忙：可以提交检测缺口、文档示例、翻译改进，或 OpenClaw / Hermes 安装反馈。
+你不需要写代码也能帮忙：可以提交本地运行反馈、检测缺口、文档示例、翻译改进，或 OpenClaw / Hermes 安装反馈。
 
+- [Local Run Feedback](https://github.com/toby-bridges/api-relay-audit/issues/new?template=local-run-feedback.yml)
 - [Detector Gap](https://github.com/toby-bridges/api-relay-audit/issues/new?template=detector-gap.yml)
 - [Documentation Example](https://github.com/toby-bridges/api-relay-audit/issues/new?template=documentation-example.yml)
 - [Agent Skill Feedback](https://github.com/toby-bridges/api-relay-audit/issues/new?template=agent-skill-feedback.yml)
+- [Community Evidence Guide](./docs/community-evidence.md)
 
 请不要提交真实 API Key、私有中转站流量、钱包材料或未脱敏审计报告。
 

--- a/docs/community-evidence.md
+++ b/docs/community-evidence.md
@@ -1,0 +1,56 @@
+# Community Evidence And Feedback
+
+API Relay Audit accepts public input through separate lanes. Keep the lane
+boundary clear so users can share useful information without leaking private
+relay traffic or turning reports into relay recommendations.
+
+## Local Run Feedback
+
+Use this when the tool was hard to install, confusing to run, or produced an
+unclear local report.
+
+- Issue template: [Local Run Feedback](https://github.com/toby-bridges/api-relay-audit/issues/new?template=local-run-feedback.yml)
+- Good input: tool version, install method, profile, command shape with secrets
+  removed, OS/shell/Python/curl versions, sanitized error text, and a concrete
+  improvement suggestion.
+- Avoid: relay domains, API keys, raw request or response bodies, wallet
+  material, full unredacted reports, or claims that a relay is safe or unsafe.
+
+This lane is not telemetry. It is a user-authored issue for local runtime and
+documentation feedback.
+
+## Detector Gap
+
+Use this when a specific audit step appears to miss, overstate, or misclassify
+behavior.
+
+- Issue template: [Detector Gap](https://github.com/toby-bridges/api-relay-audit/issues/new?template=detector-gap.yml)
+- Good input: affected step, profile, sanitized reproduction, expected result,
+  actual result, and why the current classification seems wrong.
+- Avoid: private domains, secrets, raw traffic captures, or unredacted reports.
+
+Detector-gap issues can become tests or documentation clarifications, but they
+do not publish relay evidence by themselves.
+
+## Audit Evidence Submission
+
+Use this only when you want to submit a redacted, reviewable audit artifact for
+maintainer review.
+
+- Issue template: [Submit Audit Evidence](https://github.com/toby-bridges/api-relay-audit/issues/new?template=audit-report.yml)
+- Good input: redacted report artifact, report hash, profile, tool version,
+  tool commit, tested-at timestamp, step summary, and key findings.
+- Avoid: screenshots without artifacts, unhashable claims, secrets, raw headers,
+  full response bodies, private relay traffic, or wallet material.
+
+Submitted audit evidence is shape-checked by GitHub Actions. It still requires
+maintainer review before any public evidence record is published. A report is
+evidence from one run under one tool version and profile; it is not a relay
+recommendation, ranking, certification, or safety guarantee.
+
+## Operator Response
+
+Relay operators can use the
+[Operator Response](https://github.com/toby-bridges/api-relay-audit/issues/new?template=operator-response.yml)
+template to respond to submitted evidence. Operator responses are linked to a
+domain only after the requested domain-control proof is supplied.


### PR DESCRIPTION
## Summary

- add a lightweight Local Run Feedback issue template for install/runtime/report-UX feedback
- document the difference between local run feedback, detector gaps, formal audit evidence, and operator responses
- link the new entrypoint from README and CONTRIBUTING

## Boundary

This is user-authored feedback, not telemetry. It does not collect data automatically and it does not change audit evidence publication semantics.

## Validation

- `git diff --check`
- lightweight link/template assertions with `python3`