### PR TITLE
Harden curl JSON and header handling

### DIFF
--- a/api_relay_audit/_transport.py
+++ b/api_relay_audit/_transport.py
@@ -17,6 +17,35 @@ LOOPBACK_NO_PROXY = "localhost,127.0.0.1,::1"
 LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
 
+def _curl_config_escape(value) -> str:
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
+
+
+def _curl_header_config(headers: dict) -> str:
+    return "\n".join(
+        f'header = "{_curl_config_escape(k)}: {_curl_config_escape(v)}"'
+        for k, v in headers.items()
+    )
+
+
+def _json_object_or_none(text: str):
+    try:
+        data = json.loads(text or "")
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _json_error_preview(text: str) -> str:
+    return (text or "").replace("\r", "\\r").replace("\n", "\\n")[:200]
+
+
 def curl_loopback_no_proxy_args(url: str) -> list:
     """Return curl args that keep loopback URLs out of proxy env routing."""
     if urlparse(url).hostname in LOOPBACK_HOSTS:
@@ -43,7 +72,7 @@ def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
 
         cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), "-X", "POST", url,
                "--max-time", str(timeout), "--config", "-", "--data-binary", f"@{body_path}"]
-        config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
+        config = _curl_header_config(headers)
         r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
                                   timeout=timeout + 10)
     finally:
@@ -55,7 +84,15 @@ def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
 
     if r.returncode != 0:
         raise RuntimeError(f"curl failed: {r.stderr[:200]}")
-    return json.loads(r.stdout)
+    data = _json_object_or_none(r.stdout)
+    if data is None:
+        return {
+            "_http_error": (
+                "Invalid JSON response from curl: "
+                f"{_json_error_preview(r.stdout)}"
+            )
+        }
+    return data
 
 
 def httpx_post_json(url: str, headers: dict, body: dict, timeout: int,
@@ -72,12 +109,16 @@ def curl_get_json_data(url: str, headers: dict, timeout: int = 15,
     """GET JSON through curl and return the top-level ``data`` list."""
     cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), url,
            "--max-time", str(timeout), "--config", "-"]
-    config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
+    config = _curl_header_config(headers)
     r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
                               timeout=timeout + 10)
     if r.returncode != 0:
         return []
-    return json.loads(r.stdout).get("data", [])
+    payload = _json_object_or_none(r.stdout)
+    if payload is None:
+        return []
+    data = payload.get("data", [])
+    return data if isinstance(data, list) else []
 
 
 def httpx_get_json_data(url: str, headers: dict, timeout: int = 15,

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 57cc4ddc3ccb3ed54e76e82dfc447c6e21322c2c03ab804625924e7ec655f245
-# standalone_body_sha256: 3adf747824d6eeb9df837a1e6ae8fd6fe5aa861c57b6a422b9367e52ee0c630f
+# source_sha256: 08bf533ec15f7cd3a1b3a6cd40949865fa64ed2e9cca2b72c4c8ccd58ac4bc4e
+# standalone_body_sha256: d271d96014bf1edb3732606071fe2913e348a2ff7582ac6babfc81c53721c926
 # END GENERATED STANDALONE HEADER
 
 """
@@ -558,6 +558,35 @@ LOOPBACK_NO_PROXY = "localhost,127.0.0.1,::1"
 LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
 
+def _curl_config_escape(value) -> str:
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
+
+
+def _curl_header_config(headers: dict) -> str:
+    return "\n".join(
+        f'header = "{_curl_config_escape(k)}: {_curl_config_escape(v)}"'
+        for k, v in headers.items()
+    )
+
+
+def _json_object_or_none(text: str):
+    try:
+        data = json.loads(text or "")
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _json_error_preview(text: str) -> str:
+    return (text or "").replace("\r", "\\r").replace("\n", "\\n")[:200]
+
+
 def curl_loopback_no_proxy_args(url: str) -> list:
     """Return curl args that keep loopback URLs out of proxy env routing."""
     if urlparse(url).hostname in LOOPBACK_HOSTS:
@@ -584,7 +613,7 @@ def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
 
         cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), "-X", "POST", url,
                "--max-time", str(timeout), "--config", "-", "--data-binary", f"@{body_path}"]
-        config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
+        config = _curl_header_config(headers)
         r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
                                   timeout=timeout + 10)
     finally:
@@ -596,7 +625,15 @@ def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
 
     if r.returncode != 0:
         raise RuntimeError(f"curl failed: {r.stderr[:200]}")
-    return json.loads(r.stdout)
+    data = _json_object_or_none(r.stdout)
+    if data is None:
+        return {
+            "_http_error": (
+                "Invalid JSON response from curl: "
+                f"{_json_error_preview(r.stdout)}"
+            )
+        }
+    return data
 
 
 
@@ -606,12 +643,16 @@ def curl_get_json_data(url: str, headers: dict, timeout: int = 15,
     """GET JSON through curl and return the top-level ``data`` list."""
     cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), url,
            "--max-time", str(timeout), "--config", "-"]
-    config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
+    config = _curl_header_config(headers)
     r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
                               timeout=timeout + 10)
     if r.returncode != 0:
         return []
-    return json.loads(r.stdout).get("data", [])
+    payload = _json_object_or_none(r.stdout)
+    if payload is None:
+        return []
+    data = payload.get("data", [])
+    return data if isinstance(data, list) else []
 
 
 
@@ -650,7 +691,7 @@ def httpx_get_json_data(url: str, headers: dict, timeout: int = 15):
         "curl", "-sk", *curl_loopback_no_proxy_args(url),
         "-i", url, "--max-time", str(timeout), "--config", "-"
     ]
-    config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
+    config = _curl_header_config(headers)
     r = subprocess.run(
         cmd,
         capture_output=True,
@@ -665,10 +706,10 @@ def httpx_get_json_data(url: str, headers: dict, timeout: int = 15):
     text = parsed.get("body", "")
     data = []
     if status == 200:
-        try:
-            data = json.loads(text).get("data", [])
-        except Exception:
-            data = []
+        payload = _json_object_or_none(text)
+        if payload is not None:
+            maybe_data = payload.get("data", [])
+            data = maybe_data if isinstance(maybe_data, list) else []
     return status, data, text, parsed.get("headers", {})
 
 

--- a/scripts/build-standalone.py
+++ b/scripts/build-standalone.py
@@ -75,7 +75,7 @@ def httpx_get_json_data(url: str, headers: dict, timeout: int = 15):
         "curl", "-sk", *curl_loopback_no_proxy_args(url),
         "-i", url, "--max-time", str(timeout), "--config", "-"
     ]
-    config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
+    config = _curl_header_config(headers)
     r = subprocess.run(
         cmd,
         capture_output=True,
@@ -90,10 +90,10 @@ def httpx_get_json_data(url: str, headers: dict, timeout: int = 15):
     text = parsed.get("body", "")
     data = []
     if status == 200:
-        try:
-            data = json.loads(text).get("data", [])
-        except Exception:
-            data = []
+        payload = _json_object_or_none(text)
+        if payload is not None:
+            maybe_data = payload.get("data", [])
+            data = maybe_data if isinstance(maybe_data, list) else []
     return status, data, text, parsed.get("headers", {})
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -331,6 +331,43 @@ class TestCurlFallback:
         assert "x-api-key: sk-test" in config_input
 
     @patch("api_relay_audit.client.subprocess.run")
+    def test_curl_post_invalid_json_returns_http_error(self, mock_run, client):
+        client._use_curl = True
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="<html>Bad Gateway</html>",
+            stderr="",
+        )
+
+        result = client._curl_post(
+            "https://relay.example.com/v1/messages",
+            {"x-api-key": "sk-test"},
+            {"model": "test"},
+        )
+
+        assert "_http_error" in result
+        assert "Invalid JSON response from curl" in result["_http_error"]
+        assert "Bad Gateway" in result["_http_error"]
+
+    @patch("api_relay_audit.client.subprocess.run")
+    def test_curl_post_escapes_header_config_values(self, mock_run, client):
+        client._use_curl = True
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"ok": true}', stderr="")
+
+        client._curl_post(
+            "https://relay.example.com/v1/messages",
+            {"Authorization": 'Bearer sk-test"\nheader = "Injected: yes'},
+            {"model": "test"},
+        )
+
+        config_input = mock_run.call_args[1].get("input", "")
+        assert config_input.startswith('header = "Authorization: ')
+        assert len(config_input.splitlines()) == 1
+        assert "\n" not in config_input
+        assert "\\n" in config_input
+        assert '\\"Injected: yes' in config_input
+
+    @patch("api_relay_audit.client.subprocess.run")
     def test_curl_post_bypasses_proxy_for_loopback(self, mock_run, client):
         client._use_curl = True
         mock_run.return_value = MagicMock(
@@ -368,6 +405,18 @@ class TestCurlFallback:
         cmd = mock_run.call_args[0][0]
         assert "--noproxy" in cmd
         assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
+
+    @patch("api_relay_audit.client.subprocess.run")
+    def test_curl_get_models_invalid_json_returns_empty(self, mock_run, client):
+        client._use_curl = True
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="<html>Bad Gateway</html>",
+            stderr="",
+        )
+
+        assert client.get_models() == []
+        assert mock_run.call_count == 2
 
     @patch("api_relay_audit.client.subprocess.run")
     def test_curl_raw_request_bypasses_proxy_for_loopback(self, mock_run):


### PR DESCRIPTION
﻿## Summary
- Return a structured curl `_http_error` when POST responses are not JSON instead of raising `JSONDecodeError`.
- Make curl model-list fallback degrade to `[]` on invalid JSON.
- Escape curl config header keys/values and keep standalone generation aligned.

## Tests
- `python -m pytest tests/test_client.py tests/test_dual_distribution_parity.py -q`
- `python scripts/build-standalone.py --check`
