### PR TITLE
Report all error leakage markers per category

### DIFF
--- a/api_relay_audit/error_leakage.py
+++ b/api_relay_audit/error_leakage.py
@@ -387,7 +387,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text_lower.index(host)
                 raw = text[max(0, idx - 30):idx + len(host) + 30]
                 hits.append(_mk_hit("high", "upstream_host", raw, where, api_key))
-                break
 
         # HIGH: environment variable name
         for env in ENV_VAR_MARKERS:
@@ -395,7 +394,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text.index(env)
                 raw = text[max(0, idx - 20):idx + len(env) + 40]
                 hits.append(_mk_hit("high", "env_var", raw, where, api_key))
-                break
 
         # MEDIUM: filesystem path
         for prefix in PATH_PREFIXES:
@@ -403,7 +401,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text.index(prefix)
                 raw = text[max(0, idx):idx + 80]
                 hits.append(_mk_hit("medium", "fs_path", raw, where, api_key))
-                break
 
         # MEDIUM: stack trace marker
         for marker in STACK_TRACE_MARKERS:
@@ -411,7 +408,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text.index(marker)
                 raw = text[max(0, idx):idx + 120]
                 hits.append(_mk_hit("medium", "stack_trace", raw, where, api_key))
-                break
 
         # MEDIUM: LiteLLM internal field leak (v1.5.1, sourced from
         # LiteLLM issues #5762 / #13705 / #20419)
@@ -420,7 +416,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text.index(marker)
                 raw = text[max(0, idx - 20):idx + len(marker) + 60]
                 hits.append(_mk_hit("medium", "litellm_internal_leak", raw, where, api_key))
-                break
 
         # MEDIUM: provider-side guardrail PII echo (v1.5.1, sourced from
         # LiteLLM issue #12152)
@@ -429,7 +424,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text.index(marker)
                 raw = text[max(0, idx):idx + 120]
                 hits.append(_mk_hit("medium", "pii_echo", raw, where, api_key))
-                break
 
     return hits
 

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 08bf533ec15f7cd3a1b3a6cd40949865fa64ed2e9cca2b72c4c8ccd58ac4bc4e
-# standalone_body_sha256: d271d96014bf1edb3732606071fe2913e348a2ff7582ac6babfc81c53721c926
+# source_sha256: ae0e88978fd7e4e0a3c48bfbf23006b2c2efa8854fd98d81a7d118ef4c233453
+# standalone_body_sha256: badbe213d9e8f5ee25a551fec8cb7a6e82b6253b38c5bcb2e9b62ca58ce57aae
 # END GENERATED STANDALONE HEADER
 
 """
@@ -3468,7 +3468,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text_lower.index(host)
                 raw = text[max(0, idx - 30):idx + len(host) + 30]
                 hits.append(_mk_hit("high", "upstream_host", raw, where, api_key))
-                break
 
         # HIGH: environment variable name
         for env in ENV_VAR_MARKERS:
@@ -3476,7 +3475,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text.index(env)
                 raw = text[max(0, idx - 20):idx + len(env) + 40]
                 hits.append(_mk_hit("high", "env_var", raw, where, api_key))
-                break
 
         # MEDIUM: filesystem path
         for prefix in PATH_PREFIXES:
@@ -3484,7 +3482,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text.index(prefix)
                 raw = text[max(0, idx):idx + 80]
                 hits.append(_mk_hit("medium", "fs_path", raw, where, api_key))
-                break
 
         # MEDIUM: stack trace marker
         for marker in STACK_TRACE_MARKERS:
@@ -3492,7 +3489,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text.index(marker)
                 raw = text[max(0, idx):idx + 120]
                 hits.append(_mk_hit("medium", "stack_trace", raw, where, api_key))
-                break
 
         # MEDIUM: LiteLLM internal field leak (v1.5.1, sourced from
         # LiteLLM issues #5762 / #13705 / #20419)
@@ -3501,7 +3497,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text.index(marker)
                 raw = text[max(0, idx - 20):idx + len(marker) + 60]
                 hits.append(_mk_hit("medium", "litellm_internal_leak", raw, where, api_key))
-                break
 
         # MEDIUM: provider-side guardrail PII echo (v1.5.1, sourced from
         # LiteLLM issue #12152)
@@ -3510,7 +3505,6 @@ def scan_for_leaks(body: str, response_headers: dict, api_key: str, base_url: st
                 idx = text.index(marker)
                 raw = text[max(0, idx):idx + 120]
                 hits.append(_mk_hit("medium", "pii_echo", raw, where, api_key))
-                break
 
     return hits
 

--- a/tests/test_error_leakage.py
+++ b/tests/test_error_leakage.py
@@ -114,6 +114,27 @@ class TestScanForLeaks:
         assert "high" in severities
         assert "medium" in severities
 
+    def test_multiple_markers_per_category_are_all_reported(self):
+        """A single error response can leak several signals in the same
+        category; each distinct marker should be surfaced."""
+        body = (
+            "proxy failed api.openai.com then api.anthropic.com; "
+            "env OPENAI_API_KEY and ANTHROPIC_API_KEY; "
+            'paths /home/relay/app.py and /var/www/relay/app.py; '
+            'Traceback (most recent call last): File "server.py"; '
+            '"user_api_key" appeared in previous_models; '
+            '"piiEntities" under sensitiveInformationPolicy'
+        )
+
+        hits = scan_for_leaks(body, {}, API_KEY, "https://relay.example.com")
+
+        assert len([h for h in hits if h["kind"] == "upstream_host"]) == 2
+        assert len([h for h in hits if h["kind"] == "env_var"]) == 2
+        assert len([h for h in hits if h["kind"] == "fs_path"]) == 2
+        assert len([h for h in hits if h["kind"] == "stack_trace"]) == 2
+        assert len([h for h in hits if h["kind"] == "litellm_internal_leak"]) == 2
+        assert len([h for h in hits if h["kind"] == "pii_echo"]) == 2
+
     def test_snippet_always_redacted_for_path_hit(self):
         """Even a non-credential hit must scrub the api_key if it happens
         to fall inside the 80-char context window."""


### PR DESCRIPTION
﻿## Summary
- Continue scanning marker lists after the first hit in each error-leakage category.
- Surface multiple upstream hosts, env vars, filesystem paths, stack markers, LiteLLM internals, and PII markers from the same response.
- Regenerate the standalone artifact from the modular source.

## Stack
- Based on #73 (`codex/transport-json-hardening`).

## Tests
- `python -m pytest tests/test_error_leakage.py tests/test_dual_distribution_parity.py -q`
- `python scripts/build-standalone.py --check`
