### PR TITLE
Move transparent log helpers to module scope

### DIFF
--- a/api_relay_audit/client.py
+++ b/api_relay_audit/client.py
@@ -15,6 +15,7 @@ import httpx
 from api_relay_audit import _transport
 from api_relay_audit.error_diagnosis import diagnose_error
 from api_relay_audit.stream_integrity import StreamSignals
+from api_relay_audit.transparent_log import redact_error, sha256hex
 
 
 def _extract_anthropic_text(content) -> str:
@@ -570,7 +571,6 @@ class APIClient:
         """
         if self._transparent_logger is None:
             return
-        from api_relay_audit.transparent_log import sha256hex, redact_error
         # Pre-computed digest from stream hashing is a 64-char hex string.
         if isinstance(response_body_bytes, str) and len(response_body_bytes) == 64:
             try:

--- a/audit.py
+++ b/audit.py
@@ -4,7 +4,7 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: ae0e88978fd7e4e0a3c48bfbf23006b2c2efa8854fd98d81a7d118ef4c233453
+# source_sha256: 6fb11df52ddf05eeab8989ad23f0039c9038f369a0db942427cad02e883e980b
 # standalone_body_sha256: badbe213d9e8f5ee25a551fec8cb7a6e82b6253b38c5bcb2e9b62ca58ce57aae
 # END GENERATED STANDALONE HEADER
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,13 @@
 """Tests for api_relay_audit.client.APIClient."""
 
+import inspect
 import json
 import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import api_relay_audit.client as client_module
 from api_relay_audit.client import APIClient
 
 
@@ -665,3 +667,9 @@ class TestLog:
     def test_quiet_no_output(self, client, capsys):
         client._log("hello")
         assert capsys.readouterr().out == ""
+
+    def test_transparent_log_helpers_imported_at_module_scope(self):
+        assert callable(client_module.sha256hex)
+        assert callable(client_module.redact_error)
+        source = inspect.getsource(APIClient._log_transparent)
+        assert "from api_relay_audit.transparent_log import" not in source


### PR DESCRIPTION
﻿## Summary
- Import `sha256hex` and `redact_error` once at `api_relay_audit.client` module scope.
- Remove the per-call import inside `_log_transparent()`.
- Regenerate the standalone artifact so generated hashes stay current.

## Stack
- Based on #74 (`codex/error-leakage-all-hits`).

## Tests
- `python -m pytest tests/test_client.py tests/test_dual_distribution_parity.py -q`
- `python scripts/build-standalone.py --check`
