### PR TITLE
[codex] add core research references

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ AGPL-3.0-only. See [LICENSE](./LICENSE).
 
 This keeps modified network-service deployments accountable to the same public source-availability standard as the relay ecosystem evidence we audit.
 
-## Citation
+## References and Citation
 
-If you use API Relay Audit in research, security reports, or public relay evaluations, please cite the software with [CITATION.cff](./CITATION.cff). The citation file also records the two academic papers that inform the audit model: Liu et al., *Your Agent Is Mine* (arXiv:2604.08407) and Zhang et al., *Real Money, Fake Models* (arXiv:2603.01919).
+The core research references are listed in [docs/references.md](./docs/references.md). If you use API Relay Audit in research, security reports, or public relay evaluations, please cite the software with [CITATION.cff](./CITATION.cff).
 
 ## How to Contribute
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,16 @@
+# References
+
+API Relay Audit keeps its core references intentionally small. These papers are
+the main research anchors for the current audit model.
+
+## Core Papers
+
+| Paper | Why it matters here |
+| --- | --- |
+| Liu et al., [*Your Agent Is Mine: Measuring Malicious Intermediary Attacks on the LLM Supply Chain*](https://arxiv.org/abs/2604.08407), arXiv:2604.08407, 2026. | Defines the malicious intermediary / LLM API router threat model behind prompt injection, dependency-targeted injection, conditional delivery, and secret exfiltration checks. |
+| Zhang et al., [*Real Money, Fake Models: Deceptive Model Claims in Shadow APIs*](https://arxiv.org/abs/2603.01919), arXiv:2603.01919, 2026. | Motivates model-identity and shadow-API audit questions for third-party API relays that claim to provide official frontier models. |
+
+## Citation
+
+Use [CITATION.cff](../CITATION.cff) to cite API Relay Audit itself. Cite the
+papers above directly when relying on their methods, findings, or threat models.


### PR DESCRIPTION
## Summary

- add a concise docs/references.md with the two core papers behind the audit model
- make the README citation section point to the references document
- keep the reference surface intentionally small instead of adding a broad lineage/link list

## Validation

- git diff --check
- python3 scripts/collect-metrics.py --check