### PR TITLE
Add GitHub-installable DSH audit bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,71 @@ jobs:
 
       - name: Check standalone help works without site packages
         run: python3 -S audit.py --help
+
+  dsh-plugin-unit:
+    name: DSH plugin (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.19.0"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python test dependencies
+        run: python -m pip install -r requirements.txt pytest
+
+      - name: Run DSH adapter tests
+        run: npm run test:dsh
+
+      - name: Check key-env and version integration
+        run: >-
+          python -m pytest
+          tests/test_dual_distribution_parity.py
+          tests/test_version_sync.py
+          -q
+
+      - name: Inspect prebuilt bundle contents
+        run: npm pack --dry-run
+
+  dsh-plugin-composition:
+    name: DSH 0.1.0-rc.6 composition
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.19.0"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "11.7.0"
+
+      - name: Compose with official Web and dsh-cc-tui profiles
+        env:
+          DSH_HOME: ${{ runner.temp }}/dsh-home
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx --yes @deepseek-ai/dsh@0.1.0-rc.6 plugin --profile web add .
+          npx --yes @deepseek-ai/dsh@0.1.0-rc.6 --profile web --dump-config > web-config.txt
+          grep -q "api-relay-audit" web-config.txt
+
+          if ! npx --yes @deepseek-ai/dsh@0.1.0-rc.6 plugin --profile cc-tui add dsh-cc-tui@0.4.1; then
+            profile="$DSH_HOME/profiles/cc-tui"
+            grep -q "koffi: set this to true or false" "$profile/pnpm-workspace.yaml"
+            sed -i 's/koffi: set this to true or false/koffi: true/' "$profile/pnpm-workspace.yaml"
+            pnpm --dir "$profile" install
+          fi
+          npx --yes @deepseek-ai/dsh@0.1.0-rc.6 plugin --profile cc-tui add .
+          npx --yes @deepseek-ai/dsh@0.1.0-rc.6 --profile cc-tui --dump-config > cc-tui-config.txt
+          grep -q "api-relay-audit" cc-tui-config.txt

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Community evidence is shape-checked by GitHub Actions, but publication still req
 | Version | `v2.3` |
 | Audit steps | 14 |
 | Risk matrix | 6D |
-| pytest collected tests | 802 |
+| pytest collected tests | 808 |
 | CLI flags | 22 |
 | Runtime profiles | `general`, `web3`, `full` |
 
@@ -397,7 +397,7 @@ API Relay Audit 也可以作为 agent skill 使用。
 | 版本 | `v2.3` |
 | 审计步骤 | 14 |
 | 风险矩阵 | 6D |
-| pytest collected tests | 802 |
+| pytest collected tests | 808 |
 | CLI flags | 22 |
 | Runtime profiles | `general`, `web3`, `full` |
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 </p>
 
 <p align="center">
+  <a href="#deepseek-harness-dsh-plugin"><strong>DSH Plugin</strong></a>
+  ·
   <a href="./SKILL.md"><strong>OpenClaw Skill</strong></a>
   ·
   <a href="./skills/api-relay-audit/SKILL.md"><strong>Hermes Skill</strong></a>
@@ -96,6 +98,40 @@ Runtime profiles:
 - `web3`: wallet-safety probes for Web3 agent flows
 - `full`: general plus Web3 checks
 
+## DeepSeek Harness DSH Plugin
+
+The repository is also an installable `dsh-api-relay-audit` bundle for
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) Web and
+community TUI surfaces that use the official `@deepseek-ai/dsh-commands`
+registry. Pin an immutable commit or release tag:
+
+```bash
+DSH_PLUGIN_REF=<commit-sha-or-release-tag>
+dsh plugin --profile web add "github:toby-bridges/api-relay-audit#${DSH_PLUGIN_REF}"
+
+# dsh-cc-tui and other compatible profile-based clients
+dsh plugin --profile cc-tui add "github:toby-bridges/api-relay-audit#${DSH_PLUGIN_REF}"
+```
+
+The command reuses the current DSH provider's `baseURL`, model, and credential
+reference. The credential stays in DSH Credentials and is delivered to the
+local audit process through an environment variable, never through command
+arguments or the session log:
+
+```text
+/relay-audit
+/relay-audit --connectivity
+/relay-audit --profile web3 --fast-context
+/relay-audit --url <URL> --model <claude-model> --credential-ref <DSH_CREDENTIAL_REF>
+```
+
+No arguments preserves the existing full-audit default and may consume
+metered tokens. Use `--connectivity` for a lower-cost check. This distribution
+does not add a new model baseline: the selected route must identify as Claude,
+although the relay API itself may be Anthropic-compatible or OpenAI-compatible.
+Independent wrappers without DSH profiles and the DSH command registry are not
+compatible with this bundle. See [agent distribution notes](./docs/skill-distribution.md).
+
 ## Agent Skills: OpenClaw and Hermes
 
 API Relay Audit can also run as an agent skill when an agent workflow needs to
@@ -145,7 +181,7 @@ Community evidence is shape-checked by GitHub Actions, but publication still req
 | Audit steps | 14 |
 | Risk matrix | 6D |
 | pytest collected tests | 802 |
-| CLI flags | 21 |
+| CLI flags | 22 |
 | Runtime profiles | `general`, `web3`, `full` |
 
 ## Example Report And Live Page
@@ -221,7 +257,7 @@ reproducible, and evidence-focused:
 - Report a detector gap with a sanitized reproduction.
 - Share local run feedback for install, runtime, platform, or report-UX issues.
 - Add documentation examples for profiles, flags, or relay behavior.
-- Improve OpenClaw or Hermes install notes from a real local setup.
+- Improve DSH, OpenClaw, or Hermes install notes from a real local setup.
 - Translate Quick Start or clarify `clean`, `anomaly`, and `inconclusive`.
 
 Start with:
@@ -286,6 +322,34 @@ python audit.py --key <YOUR_KEY> --url <BASE_URL> --profile web3 --output report
 - 模型身份: 非 Claude 身份泄漏、模型替换信号、Claude / OpenAI 兼容中转行为
 - Web3 风险: 转账指引、签名拒绝、私钥泄漏拒绝
 
+## DeepSeek Harness DSH Plugin
+
+本仓库同时提供 GitHub 可直装的 `dsh-api-relay-audit` bundle，支持官方 DSH
+Web，以及使用 `@deepseek-ai/dsh-commands` registry 的社区 TUI。安装时必须固定
+commit 或 release tag：
+
+```bash
+DSH_PLUGIN_REF=<commit-sha-or-release-tag>
+dsh plugin --profile web add "github:toby-bridges/api-relay-audit#${DSH_PLUGIN_REF}"
+dsh plugin --profile cc-tui add "github:toby-bridges/api-relay-audit#${DSH_PLUGIN_REF}"
+```
+
+插件默认复用当前 DSH provider 的 `baseURL`、model 和 credential reference；
+真实 API Key 只从 DSH Credentials 解析，并通过子进程环境变量传递，不进入命令
+参数或会话日志。
+
+```text
+/relay-audit
+/relay-audit --connectivity
+/relay-audit --profile web3 --fast-context
+/relay-audit --url <URL> --model <claude-model> --credential-ref <DSH_CREDENTIAL_REF>
+```
+
+无参数仍运行 master 现有完整审计，可能产生较高 token 消耗；低成本检查使用
+`--connectivity`。插件不增加新的模型基线：中转接口可以兼容 Anthropic 或
+OpenAI，但被审计线路必须明确为 Claude。没有 DSH profile/plugin 机制的独立
+wrapper 不在兼容范围内。
+
 ## Agent Skill 支持
 
 API Relay Audit 也可以作为 agent skill 使用。
@@ -334,12 +398,12 @@ API Relay Audit 也可以作为 agent skill 使用。
 | 审计步骤 | 14 |
 | 风险矩阵 | 6D |
 | pytest collected tests | 802 |
-| CLI flags | 21 |
+| CLI flags | 22 |
 | Runtime profiles | `general`, `web3`, `full` |
 
 ## 如何贡献
 
-你不需要写代码也能帮忙：可以提交本地运行反馈、检测缺口、文档示例、翻译改进，或 OpenClaw / Hermes 安装反馈。
+你不需要写代码也能帮忙：可以提交本地运行反馈、检测缺口、文档示例、翻译改进，或 DSH / OpenClaw / Hermes 安装反馈。
 
 - [Local Run Feedback](https://github.com/toby-bridges/api-relay-audit/issues/new?template=local-run-feedback.yml)
 - [Detector Gap](https://github.com/toby-bridges/api-relay-audit/issues/new?template=detector-gap.yml)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,8 @@ item has a short rationale so future contributors (including future
 iterations of the author) can quickly reconstruct why a thing is or is not
 on the list.
 
-**Last updated**: 2026-08-16 (Step 10 terminal completeness added without
-changing the 6D risk matrix or TLS behavior)
+**Last updated**: 2026-08-16 (DSH bundle added with strict adapter/runtime
+boundaries; Step 10 completeness remains in the existing 6D risk matrix)
 
 **Threat model anchor**: Liu et al., *Your Agent Is Mine: Measuring
 Malicious Intermediary Attacks on the LLM Supply Chain*, arXiv:2604.08407.
@@ -22,6 +22,17 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
 ---
 
 ## ✅ Shipped
+
+### 2026-08-16 distribution — DeepSeek Harness bundle
+- **Two-profile bundle**: the repository package installs into DSH web and
+  cc-tui profiles while continuing to execute the generated standalone audit.
+- **Credential boundary**: the adapter resolves the configured key on every
+  invocation and passes it through a child-only environment variable, never
+  argv or command output.
+- **Runtime boundary**: non-Claude routes are rejected before credential or
+  subprocess use. Adapter-controlled long-option abbreviations, including
+  `--flag=value` forms, are rejected in JavaScript and both Python
+  distributions disable argparse abbreviation.
 
 ### 2026-08-16 hardening — SSE terminal completeness
 - **Terminal protocol gate**: Step 10 requires exactly one `message_stop`
@@ -49,12 +60,13 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
   detector, not a hosted preflight service, not a new API family, and not a
   change to LOW/MEDIUM/HIGH semantics. `inconclusive` remains
   `inconclusive`.
-- **Final test count**: 802/802 passing (733 baseline → 764 after current
+- **Final test count**: 808/808 passing (733 baseline → 764 after current
   master follow-ups → 769 after release-engineering version sync coverage →
   775 after query-family growth contracts → 778 after release-hardening
   public verification regressions → 789 after report reproducibility metadata
   and metadata source-boundary regressions → 796 after resumable release
-  provenance verification → 802 after SSE terminal-completeness regressions).
+  provenance verification → 802 after SSE terminal-completeness regressions →
+  808 after DSH/version and dual-distribution abbreviation regressions).
 
 ### v1.9 — Dual-distribution full generation (2026-06-01)
 - **Standalone product promise preserved**: root `audit.py` stays committed,

--- a/audit.py
+++ b/audit.py
@@ -4895,6 +4895,7 @@ Usage:
 """
 
 import argparse
+import os
 import re
 import shutil
 import socket
@@ -5007,7 +5008,10 @@ def _tool_commit_from_checkout():
 
 def parse_args():
     p = argparse.ArgumentParser(description="API Relay Security Audit Tool")
-    p.add_argument("--key", required=True, help="API Key")
+    key_source = p.add_mutually_exclusive_group(required=True)
+    key_source.add_argument("--key", help="API Key")
+    key_source.add_argument("--key-env", metavar="NAME",
+                            help="Read the API Key from environment variable NAME")
     p.add_argument("--url", required=True, help="Base URL (e.g. https://xxx.com/v1)")
     p.add_argument("--model", default="claude-opus-4-6", help="Model name")
     p.add_argument("--connectivity", action="store_true",
@@ -5069,7 +5073,15 @@ def parse_args():
                    help="Path to an append-only JSONL forensic log (arXiv §7.3). "
                         "Every API request is recorded with timestamp, URL, "
                         "SHA-256 of request/response, and status code.")
-    return p.parse_args()
+    args = p.parse_args()
+    if args.key_env is not None:
+        value = os.environ.get(args.key_env)
+        if not value:
+            p.error(
+                f"environment variable {args.key_env!r} is missing or empty"
+            )
+        args.key = value
+    return args
 
 
 def run_warmup(client, n):

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 722d1c65bf44ee9c8dff2a62a826800db09f2d3419396c739d6d19fcec63190a
-# standalone_body_sha256: 8040f23082bd40681bfdefc52a52af0d3657de5567df51fef3b05d1fab7cd54a
+# source_sha256: 158e497652fa21d37033481f65ba1585ce821f47c058886d7399d1a3baa6645f
+# standalone_body_sha256: b42f856efce9cc66821ef5511022f3fcc43965dc4caca479d058107f77beaefc
 # END GENERATED STANDALONE HEADER
 
 """
@@ -5007,7 +5007,10 @@ def _tool_commit_from_checkout():
 # ============================================================
 
 def parse_args():
-    p = argparse.ArgumentParser(description="API Relay Security Audit Tool")
+    p = argparse.ArgumentParser(
+        description="API Relay Security Audit Tool",
+        allow_abbrev=False,
+    )
     key_source = p.add_mutually_exclusive_group(required=True)
     key_source.add_argument("--key", help="API Key")
     key_source.add_argument("--key-env", metavar="NAME",

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,23 +16,23 @@
 | 单文件版版本 | `v2.3.1` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **802** | `pytest --collect-only` |
-| 测试数 (static) | 774 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **808** | `pytest --collect-only` |
+| 测试数 (static) | 778 | grep `def test_*` in tests/ |
 | CLI flag 数 | 22 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-08-16 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
-| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 802] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `0eeadb1` | recent reachable commit; `--check` allows follow-up metrics commits |
+| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 808] | grep `Final test count: N/N passing` |
+| Recorded commit SHA | `211e537` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-08-16 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3.1`。
 - ✅ 步骤数一致：14。
-- ℹ️ pytest (802) vs 静态 (774) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
+- ℹ️ pytest (808) vs 静态 (778) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -18,7 +18,7 @@
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
 | 测试数 (pytest) | **802** | `pytest --collect-only` |
 | 测试数 (static) | 774 | grep `def test_*` in tests/ |
-| CLI flag 数 | 21 | grep `add_argument("--*")` |
+| CLI flag 数 | 22 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-08-16 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |

--- a/docs/skill-distribution.md
+++ b/docs/skill-distribution.md
@@ -110,37 +110,20 @@ openclaw skills check
 
 ## Hermes Agent
 
-Hermes supports direct install, GitHub taps, Skills Hub publishing, and
-well-known discovery endpoints. The repo currently supports GitHub tap install
-from `skills/api-relay-audit/SKILL.md`.
-
-Direct install:
-
-```bash
-hermes skills install toby-bridges/api-relay-audit/skills/api-relay-audit
-```
-
-Tap install:
+The supported Hermes distribution entrypoint is this repository's GitHub tap.
+It installs `skills/api-relay-audit/SKILL.md` without opening a pull request
+against the source repository:
 
 ```bash
 hermes skills tap add toby-bridges/api-relay-audit
 hermes skills install toby-bridges/api-relay-audit/api-relay-audit
 ```
 
-Skills Hub publish after merge:
-
-```bash
-hermes --version
-hermes auth status
-hermes skills publish skills/api-relay-audit \
-  --to github \
-  --repo toby-bridges/api-relay-audit
-```
-
-Post-publish verification:
+Post-install verification:
 
 ```bash
 hermes skills list | grep api-relay-audit
+hermes skills audit api-relay-audit
 hermes chat --toolsets skills -q "Use the api-relay-audit skill to explain how to audit a relay without exposing my API key."
 ```
 

--- a/docs/skill-distribution.md
+++ b/docs/skill-distribution.md
@@ -1,12 +1,13 @@
-# OpenClaw and Hermes Skill Distribution
+# DSH, OpenClaw, and Hermes Distribution
 
-This document tracks the publish path for API Relay Audit as an agent skill.
+This document tracks the distribution paths for API Relay Audit integrations.
 It is operational release documentation, not a user-facing safety claim.
 
-## Current Skill Files
+## Current Distribution Files
 
 | Target | File | Role |
 | --- | --- | --- |
+| DeepSeek Harness | `package.json`, `dsh/` | GitHub-installable bundle that registers `/relay-audit` on DSH command-compatible clients and carries the generated standalone `audit.py`. |
 | OpenClaw / ClawHub | `SKILL.md` | Root skill file used for ClawHub publish. `.clawhubignore` keeps the published bundle to this file. |
 | Hermes Agent | `skills/api-relay-audit/SKILL.md` | Hermes skill folder for GitHub tap, direct install, and Skills Hub publish. |
 
@@ -23,9 +24,46 @@ Both files must stay aligned with the current audit surface:
   the one-shot recipe; direct local `python audit.py ...` commands can also run
   from PowerShell.
 
-The skill files are versioned distribution artifacts, so their `audit.py`
+The skill files and DSH package are versioned distribution artifacts, so their `audit.py`
 download commands must use an immutable tag or commit SHA. Do not publish a
 versioned skill that downloads mutable `master/audit.py`.
+
+## DeepSeek Harness
+
+The DSH bundle is deliberately prebuilt JavaScript with no `prepare` or build
+hook. A Git install therefore does not require pnpm's install-time build
+allowlist. Install an immutable repository revision into each intended
+profile:
+
+```bash
+DSH_PLUGIN_REF=<commit-sha-or-release-tag>
+dsh plugin --profile web add "github:toby-bridges/api-relay-audit#${DSH_PLUGIN_REF}"
+dsh plugin --profile cc-tui add "github:toby-bridges/api-relay-audit#${DSH_PLUGIN_REF}"
+```
+
+Compatibility contract:
+
+- tested with DSH `0.1.0-rc.6` and `dsh-cc-tui` `0.4.1`;
+- requires the DSH profile/bundle loader and `@deepseek-ai/dsh-commands`;
+- resolves `baseURL`, model, and `apiKeyEnv` from the current configurable
+  provider, with explicit command overrides for missing facts;
+- resolves the credential per invocation and never puts the value in argv or
+  the recorded command input;
+- accepts Claude routes over either Anthropic-compatible or OpenAI-compatible
+  APIs, but refuses non-Claude model families because the current identity and
+  stream-integrity baselines are Claude-specific;
+- writes reports under the current session workspace by default.
+
+Post-install verification:
+
+```bash
+dsh --profile web --dump-config
+dsh --profile cc-tui --dump-config
+```
+
+Both dumps must contain the `api-relay-audit` row. In a configured session,
+`/relay-audit --connectivity` should create a local Markdown report without
+placing the API key in the command input, result, process argv, or logs.
 
 ## OpenClaw / ClawHub
 
@@ -127,10 +165,12 @@ Do not merge these project-level query families into one marketplace slogan:
 
 Skill-specific long-tail phrases:
 
+- DSH plugin for AI API relay audit
+- DeepSeek Harness Claude relay security audit
 - OpenClaw skill for AI API relay audit
 - OpenClaw prompt injection relay audit
 - Hermes skill for LLM proxy security
 - Hermes Agent API key relay audit
 
 Use these phrases naturally in README and Pages. Do not rename the project or
-make OpenClaw / Hermes the primary concept.
+make DSH / OpenClaw / Hermes the primary concept.

--- a/dsh/cordis.patch.yml
+++ b/dsh/cordis.patch.yml
@@ -1,0 +1,3 @@
+- insert:
+    - id: api-relay-audit
+      name: dsh-api-relay-audit

--- a/dsh/index.js
+++ b/dsh/index.js
@@ -1,0 +1,467 @@
+/**
+ * DeepSeek Harness adapter for the generated standalone API Relay Audit.
+ *
+ * This module deliberately owns only distribution concerns: resolve one DSH
+ * provider target, resolve one credential, launch the existing audit.py, and
+ * return its report path. Detection semantics remain entirely in Python.
+ */
+
+import { access, realpath } from 'node:fs/promises'
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const name = 'api-relay-audit'
+export const inject = ['commands', 'credentials', 'subprocess', 'llm', 'settings']
+
+export const CHILD_KEY_ENV = 'API_RELAY_AUDIT_KEY'
+export const OUTPUT_LIMIT_BYTES = 64 * 1024
+export const PROCESS_GRACE_MS = 5_000
+
+const CREDENTIAL_REF = /^[A-Za-z_][A-Za-z0-9_]*$/u
+const OWNED_OPTIONS = new Set([
+  '--url',
+  '--model',
+  '--credential-ref',
+  '--output',
+  '--transparent-log',
+])
+const FORBIDDEN_OPTIONS = new Set(['--key', '--key-env'])
+const AUDIT_SCRIPT = fileURLToPath(new URL('../audit.py', import.meta.url))
+
+const USAGE = `Usage: /relay-audit [audit options]
+
+Defaults to the current DSH provider/model and runs the full existing audit.
+Use --connectivity for the lower-cost connectivity check.
+
+Target overrides:
+  --url <URL>
+  --model <claude-model>
+  --credential-ref <DSH_CREDENTIAL_REF>
+
+Output paths:
+  --output <workspace path>
+  --transparent-log <workspace path>
+
+Raw --key and caller-supplied --key-env are not accepted.`
+
+function optionName(token) {
+  const equals = token.indexOf('=')
+  return equals === -1 ? token : token.slice(0, equals)
+}
+
+function optionInlineValue(token) {
+  const equals = token.indexOf('=')
+  return equals === -1 ? undefined : token.slice(equals + 1)
+}
+
+/** Split human-command input without invoking a shell. */
+export function tokenizeCommandInput(rawInput) {
+  const tokens = []
+  let token = ''
+  let quote
+  let started = false
+
+  for (let index = 0; index < rawInput.length; index += 1) {
+    const character = rawInput[index]
+    if (quote !== undefined) {
+      if (character === quote) {
+        quote = undefined
+        started = true
+        continue
+      }
+      if (character === '\\' && quote === '"') {
+        const next = rawInput[index + 1]
+        if (next === '"' || next === '\\' || /\s/u.test(next ?? '')) {
+          token += next
+          index += 1
+          started = true
+          continue
+        }
+      }
+      token += character
+      started = true
+      continue
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character
+      started = true
+      continue
+    }
+    if (/\s/u.test(character)) {
+      if (started) {
+        tokens.push(token)
+        token = ''
+        started = false
+      }
+      continue
+    }
+    if (character === '\\') {
+      const next = rawInput[index + 1]
+      if (next === '"' || next === "'" || next === '\\' || /\s/u.test(next ?? '')) {
+        token += next
+        index += 1
+        started = true
+        continue
+      }
+    }
+    token += character
+    started = true
+  }
+
+  if (quote !== undefined) throw new Error('unterminated quoted command argument')
+  if (started) tokens.push(token)
+  return tokens
+}
+
+/** Parse DSH-owned options and leave existing audit.py options untouched. */
+export function parseCommandInput(rawInput) {
+  const tokens = tokenizeCommandInput(rawInput)
+  const values = new Map()
+  const passthrough = []
+  let help = false
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]
+    const name = optionName(token)
+    if (FORBIDDEN_OPTIONS.has(name)) {
+      throw new Error(`${name} is not accepted; store the key in DSH Credentials`)
+    }
+    if (token === '--help' || token === '-h') {
+      help = true
+      continue
+    }
+    if (!OWNED_OPTIONS.has(name)) {
+      passthrough.push(token)
+      continue
+    }
+    if (values.has(name)) throw new Error(`${name} may be specified only once`)
+
+    let value = optionInlineValue(token)
+    if (value === undefined) {
+      index += 1
+      value = tokens[index]
+    }
+    if (value === undefined || value.length === 0 || value.startsWith('--')) {
+      throw new Error(`${name} requires a value`)
+    }
+    values.set(name, value)
+  }
+
+  return Object.freeze({
+    help,
+    url: values.get('--url'),
+    model: values.get('--model'),
+    credentialRef: values.get('--credential-ref'),
+    output: values.get('--output'),
+    transparentLog: values.get('--transparent-log'),
+    passthrough: Object.freeze(passthrough),
+  })
+}
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function atPath(value, path) {
+  let current = value
+  for (const segment of path) {
+    if (!isRecord(current)) return undefined
+    current = current[segment]
+  }
+  return current
+}
+
+function configuredProviderProfile(ctx, provider) {
+  if (provider === undefined) return undefined
+  const directory = ctx.llm.listConfigurableProviders()
+  const entry = directory.find(candidate => candidate.provider === provider)
+  if (entry === undefined) return undefined
+  const section = ctx.settings.get(entry.settingsNs)
+  const profile = atPath(section, entry.settingsPath)
+  return isRecord(profile) ? profile : undefined
+}
+
+function validateUrl(value) {
+  let url
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error('relay URL must be an absolute http(s) URL')
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('relay URL must use http or https')
+  }
+  if (url.username.length > 0 || url.password.length > 0) {
+    throw new Error('relay URL must not contain embedded credentials')
+  }
+  return value
+}
+
+function assertCredentialRef(value) {
+  if (!CREDENTIAL_REF.test(value)) {
+    throw new Error('credential reference must be a POSIX environment-variable name')
+  }
+  return value
+}
+
+async function modelLooksLikeClaude(ctx, provider, model, signal) {
+  const labels = [model]
+  if (provider !== undefined) {
+    try {
+      const info = await ctx.llm.resolveModelInfo(provider, model, signal)
+      labels.push(info.name, info.description ?? '')
+    } catch (error) {
+      if (signal.aborted) throw error
+      // A custom relay alias may be absent from an advisory catalog. The id
+      // remains sufficient when it explicitly declares the Claude family.
+    }
+  }
+  return labels.some(label => /claude/iu.test(label))
+}
+
+/** Resolve the current DSH route, with explicit command values taking priority. */
+export async function resolveTarget(ctx, agent, parsed, signal) {
+  const provider = agent.options?.provider
+  const profile = parsed.url === undefined || parsed.credentialRef === undefined
+    ? configuredProviderProfile(ctx, provider)
+    : undefined
+  const url = parsed.url ?? (typeof profile?.baseURL === 'string' ? profile.baseURL : undefined)
+  const model = parsed.model ?? agent.options?.model
+  const credentialRef = parsed.credentialRef
+    ?? (typeof profile?.apiKeyEnv === 'string' ? profile.apiKeyEnv : undefined)
+
+  const missing = []
+  if (url === undefined) missing.push('--url')
+  if (model === undefined) missing.push('--model')
+  if (credentialRef === undefined) missing.push('--credential-ref')
+  if (missing.length > 0) {
+    throw new Error(
+      `could not resolve ${missing.join(', ')} from the current DSH provider; provide the missing override(s)`,
+    )
+  }
+
+  const resolvedUrl = validateUrl(url)
+  const resolvedCredentialRef = assertCredentialRef(credentialRef)
+  if (!await modelLooksLikeClaude(ctx, provider, model, signal)) {
+    throw new Error(
+      'the current audit baseline applies only to routes that declare a Claude model; no report was generated',
+    )
+  }
+  return Object.freeze({
+    provider,
+    url: resolvedUrl,
+    model,
+    credentialRef: resolvedCredentialRef,
+  })
+}
+
+function isOutsideWorkspace(workspace, candidate) {
+  const pathFromWorkspace = relative(workspace, candidate)
+  return pathFromWorkspace === '..'
+    || pathFromWorkspace.startsWith(`..${sep}`)
+    || isAbsolute(pathFromWorkspace)
+}
+
+/** Resolve an optional user path and require that it remains in the workspace. */
+export function resolveWorkspacePath(workspace, input, fallback) {
+  const candidate = input === undefined ? fallback : resolve(workspace, input)
+  if (candidate === workspace || isOutsideWorkspace(workspace, candidate)) {
+    throw new Error('output paths must resolve to a file inside the current workspace')
+  }
+  return candidate
+}
+
+async function nearestExistingRealPath(candidate) {
+  let current = candidate
+  for (;;) {
+    try {
+      return await realpath(current)
+    } catch (error) {
+      if (error?.code !== 'ENOENT' && error?.code !== 'ENOTDIR') throw error
+      const parent = dirname(current)
+      if (parent === current) throw error
+      current = parent
+    }
+  }
+}
+
+/** Reject existing symlinks that would make an output escape the workspace. */
+export async function assertWorkspacePathContained(workspace, candidate) {
+  const canonicalWorkspace = await realpath(workspace)
+  const canonicalAncestor = await nearestExistingRealPath(candidate)
+  if (canonicalAncestor !== canonicalWorkspace
+    && isOutsideWorkspace(canonicalWorkspace, canonicalAncestor)) {
+    throw new Error('output paths must not escape the current workspace through a symlink')
+  }
+  return candidate
+}
+
+function safeCommandId(commandId) {
+  const sanitized = String(commandId).replace(/[^A-Za-z0-9_-]/gu, '_').slice(0, 64)
+  return sanitized.length > 0 ? sanitized : 'command'
+}
+
+function defaultReportPath(workspace, commandId, now) {
+  const timestamp = now.toISOString().replace(/[-:.]/gu, '')
+  return resolve(
+    workspace,
+    '.api-relay-audit',
+    'reports',
+    `api-relay-audit-${timestamp}-${safeCommandId(commandId)}.md`,
+  )
+}
+
+async function resolvePython(ctx, signal, platform = process.platform) {
+  const candidates = [
+    { command: 'python3', prefix: [] },
+    { command: 'python', prefix: [] },
+    ...(platform === 'win32' ? [{ command: 'py', prefix: ['-3'] }] : []),
+  ]
+  for (const candidate of candidates) {
+    try {
+      const executable = await ctx.subprocess.resolveExecutable(
+        candidate.command,
+        undefined,
+        signal,
+      )
+      return { executable, prefix: candidate.prefix }
+    } catch (error) {
+      if (signal.aborted) throw error
+    }
+  }
+  throw new Error('Python 3 was not found (tried python3, python, and Windows py -3)')
+}
+
+function collectedText(handle, stream) {
+  const reader = handle.collected[stream]
+  return reader === undefined ? '' : reader.readFrom(0).text
+}
+
+export function redactSecret(text, secret) {
+  if (secret.length === 0) return text
+  return text.split(secret).join('[REDACTED]')
+}
+
+function diagnosticTail(handle, secret) {
+  const combined = [collectedText(handle, 'stdout'), collectedText(handle, 'stderr')]
+    .filter(Boolean)
+    .join('\n')
+  return redactSecret(combined, secret).slice(-4_096).trim()
+}
+
+async function fileExists(path) {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Execute one human-command invocation against the existing audit.py CLI. */
+export async function executeAuditCommand(invocation, ctx, options = {}) {
+  let secret = ''
+  try {
+    const parsed = parseCommandInput(invocation.rawInput)
+    if (parsed.help) return { kind: 'success', text: USAGE }
+
+    const workspace = invocation.agent.session?.header?.cwd
+    if (typeof workspace !== 'string' || workspace.length === 0 || !isAbsolute(workspace)) {
+      throw new Error('the receiving DSH session has no absolute workspace')
+    }
+
+    const target = await resolveTarget(ctx, invocation.agent, parsed, invocation.signal)
+    const now = options.now ?? new Date()
+    const fallbackReport = defaultReportPath(workspace, invocation.commandId, now)
+    const reportPath = resolveWorkspacePath(workspace, parsed.output, fallbackReport)
+    const transparentLogPath = parsed.transparentLog === undefined
+      ? undefined
+      : resolveWorkspacePath(workspace, parsed.transparentLog, parsed.transparentLog)
+    await assertWorkspacePathContained(workspace, reportPath)
+    if (transparentLogPath !== undefined) {
+      await assertWorkspacePathContained(workspace, transparentLogPath)
+    }
+
+    const credential = await ctx.credentials.resolve(target.credentialRef)
+    if (credential === undefined || typeof credential.value !== 'string' || credential.value.length === 0) {
+      throw new Error(`DSH Credential ${target.credentialRef} is missing or empty`)
+    }
+    secret = credential.value
+
+    const python = await resolvePython(
+      ctx,
+      invocation.signal,
+      options.platform ?? process.platform,
+    )
+
+    const argv = [
+      python.executable,
+      ...python.prefix,
+      options.auditScript ?? AUDIT_SCRIPT,
+      '--key-env',
+      CHILD_KEY_ENV,
+      '--url',
+      target.url,
+      '--model',
+      target.model,
+      '--output',
+      reportPath,
+      ...parsed.transparentLog === undefined
+        ? []
+        : ['--transparent-log', transparentLogPath],
+      ...parsed.passthrough,
+    ]
+
+    const handle = ctx.subprocess.spawn({
+      argv,
+      cwd: workspace,
+      stdio: {
+        stdin: 'ignore',
+        stdout: { maxBytes: OUTPUT_LIMIT_BYTES },
+        stderr: { maxBytes: OUTPUT_LIMIT_BYTES },
+      },
+      graceMs: PROCESS_GRACE_MS,
+      signal: invocation.signal,
+      env: { [CHILD_KEY_ENV]: secret },
+    })
+    const outcome = await handle.done
+    const reportExists = await fileExists(reportPath)
+
+    if (invocation.signal.aborted) {
+      return {
+        kind: 'error',
+        text: reportExists
+          ? `Audit canceled. Partial report: ${reportPath}`
+          : 'Audit canceled; no report was generated.',
+      }
+    }
+    if (outcome.exitCode !== 0) {
+      const diagnostic = diagnosticTail(handle, secret)
+      const report = reportExists ? `\nReport: ${reportPath}` : ''
+      const detail = diagnostic.length > 0 ? `\n${diagnostic}` : ''
+      return {
+        kind: 'error',
+        text: `Audit process exited with code ${String(outcome.exitCode)}.${report}${detail}`,
+      }
+    }
+    if (!reportExists) {
+      throw new Error('audit.py exited successfully but did not create its report')
+    }
+    return { kind: 'success', text: `Report: ${reportPath}` }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { kind: 'error', text: redactSecret(message, secret) }
+  }
+}
+
+/** Register the command globally for every DSH command-compatible surface. */
+export function apply(ctx) {
+  ctx.commands.register({
+    name: 'relay-audit',
+    description: 'run the local API relay security audit',
+    input: { hint: '[audit.py options]' },
+    recordInput: false,
+    handler: invocation => executeAuditCommand(invocation, ctx),
+  })
+}

--- a/dsh/index.js
+++ b/dsh/index.js
@@ -26,6 +26,7 @@ const OWNED_OPTIONS = new Set([
   '--transparent-log',
 ])
 const FORBIDDEN_OPTIONS = new Set(['--key', '--key-env'])
+const CONTROLLED_OPTIONS = new Set([...OWNED_OPTIONS, ...FORBIDDEN_OPTIONS])
 const AUDIT_SCRIPT = fileURLToPath(new URL('../audit.py', import.meta.url))
 
 const USAGE = `Usage: /relay-audit [audit options]
@@ -52,6 +53,11 @@ function optionName(token) {
 function optionInlineValue(token) {
   const equals = token.indexOf('=')
   return equals === -1 ? undefined : token.slice(equals + 1)
+}
+
+function abbreviatedControlledOptions(name) {
+  if (!name.startsWith('--')) return []
+  return [...CONTROLLED_OPTIONS].filter(option => option !== name && option.startsWith(name))
 }
 
 /** Split human-command input without invoking a shell. */
@@ -126,6 +132,12 @@ export function parseCommandInput(rawInput) {
     const name = optionName(token)
     if (FORBIDDEN_OPTIONS.has(name)) {
       throw new Error(`${name} is not accepted; store the key in DSH Credentials`)
+    }
+    const abbreviations = abbreviatedControlledOptions(name)
+    if (abbreviations.length > 0) {
+      throw new Error(
+        `${name} is an abbreviation of adapter-controlled option ${abbreviations.join(' or ')}`,
+      )
     }
     if (token === '--help' || token === '-h') {
       help = true

--- a/dsh/test/plugin.test.js
+++ b/dsh/test/plugin.test.js
@@ -1,0 +1,413 @@
+import assert from 'node:assert/strict'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+
+import {
+  CHILD_KEY_ENV,
+  PROCESS_GRACE_MS,
+  apply,
+  assertWorkspacePathContained,
+  executeAuditCommand,
+  inject,
+  parseCommandInput,
+  redactSecret,
+  resolveTarget,
+  resolveWorkspacePath,
+  tokenizeCommandInput,
+} from '../index.js'
+
+const SECRET = 'sk-dsh-secret-never-log'
+
+function collected(text = '') {
+  return {
+    readFrom: () => ({ text, nextOffset: Buffer.byteLength(text), lossy: false }),
+  }
+}
+
+function harness(overrides = {}) {
+  const workspace = mkdtempSync(join(tmpdir(), 'dsh-api-relay-audit-'))
+  const calls = { credentials: [], executable: [], spawns: [] }
+  const ctx = {
+    llm: {
+      listConfigurableProviders: () => [{
+        provider: 'relay',
+        displayName: 'Relay',
+        settingsNs: 'llm-pi-ai',
+        settingsPath: ['providers', 'relay'],
+      }],
+      resolveModelInfo: async (provider, model) => ({
+        provider,
+        id: model,
+        name: 'Claude Opus',
+      }),
+    },
+    settings: {
+      get: () => ({
+        providers: {
+          relay: {
+            baseURL: 'https://relay.example.com/v1',
+            apiKeyEnv: 'RELAY_API_KEY',
+          },
+        },
+      }),
+    },
+    credentials: {
+      resolve: async ref => {
+        calls.credentials.push(ref)
+        return { value: SECRET, source: 'test' }
+      },
+    },
+    subprocess: {
+      resolveExecutable: async (command, env, signal) => {
+        calls.executable.push({ command, env, signal })
+        return `/usr/bin/${command}`
+      },
+      spawn: spec => {
+        calls.spawns.push(spec)
+        const outputIndex = spec.argv.indexOf('--output')
+        const report = spec.argv[outputIndex + 1]
+        mkdirSync(dirname(report), { recursive: true })
+        writeFileSync(report, '# fixture report\n', 'utf8')
+        return {
+          done: Promise.resolve({ exitCode: 0, signal: null }),
+          collected: { stdout: collected(), stderr: collected() },
+        }
+      },
+    },
+  }
+  Object.assign(ctx, overrides.ctx)
+  const agent = overrides.agent ?? {
+    options: { provider: 'relay', model: 'claude-opus-4-6' },
+    session: { header: { cwd: workspace } },
+  }
+  const controller = new AbortController()
+  const invocation = {
+    commandId: 'command/1',
+    agent,
+    rawInput: overrides.rawInput ?? '',
+    signal: controller.signal,
+  }
+  return {
+    workspace,
+    calls,
+    ctx,
+    agent,
+    controller,
+    invocation,
+    cleanup: () => rmSync(workspace, { recursive: true, force: true }),
+  }
+}
+
+test('tokenizes quoted values without a shell', () => {
+  assert.deepEqual(
+    tokenizeCommandInput(' --url "https://relay.example/v1" --model \'claude opus\' a\\ b '),
+    ['--url', 'https://relay.example/v1', '--model', 'claude opus', 'a b'],
+  )
+  assert.throws(() => tokenizeCommandInput("--model 'claude"), /unterminated quoted/u)
+})
+
+test('extracts adapter options and preserves audit options', () => {
+  assert.deepEqual(parseCommandInput([
+    '--url=https://relay.example/v1',
+    '--model', 'claude-opus',
+    '--credential-ref', 'RELAY_KEY',
+    '--profile', 'web3',
+    '--fast-context',
+  ].join(' ')), {
+    help: false,
+    url: 'https://relay.example/v1',
+    model: 'claude-opus',
+    credentialRef: 'RELAY_KEY',
+    output: undefined,
+    transparentLog: undefined,
+    passthrough: ['--profile', 'web3', '--fast-context'],
+  })
+  for (const rawInput of ['--key secret', '--key=secret', '--key-env OTHER']) {
+    assert.throws(() => parseCommandInput(rawInput), /not accepted/u)
+  }
+})
+
+test('resolves nested DSH provider settings and partial overrides', async () => {
+  const testHarness = harness()
+  try {
+    const parsed = parseCommandInput('--url https://override.example/v1')
+    const target = await resolveTarget(
+      testHarness.ctx,
+      testHarness.agent,
+      parsed,
+      testHarness.invocation.signal,
+    )
+    assert.deepEqual(target, {
+      provider: 'relay',
+      url: 'https://override.example/v1',
+      model: 'claude-opus-4-6',
+      credentialRef: 'RELAY_API_KEY',
+    })
+  } finally {
+    testHarness.cleanup()
+  }
+})
+
+test('fully explicit target overrides do not require provider settings', async () => {
+  const testHarness = harness()
+  testHarness.ctx.llm.listConfigurableProviders = () => {
+    throw new Error('provider settings must not be read')
+  }
+  try {
+    const target = await resolveTarget(
+      testHarness.ctx,
+      testHarness.agent,
+      parseCommandInput([
+        '--url https://explicit.example/v1',
+        '--model claude-explicit',
+        '--credential-ref EXPLICIT_KEY',
+      ].join(' ')),
+      testHarness.invocation.signal,
+    )
+    assert.deepEqual(target, {
+      provider: 'relay',
+      url: 'https://explicit.example/v1',
+      model: 'claude-explicit',
+      credentialRef: 'EXPLICIT_KEY',
+    })
+  } finally {
+    testHarness.cleanup()
+  }
+})
+
+test('accepts a Claude metadata name for an opaque model alias', async () => {
+  const testHarness = harness({
+    agent: {
+      options: { provider: 'relay', model: 'production-alias' },
+      session: { header: { cwd: '/workspace' } },
+    },
+  })
+  try {
+    const target = await resolveTarget(
+      testHarness.ctx,
+      testHarness.agent,
+      parseCommandInput(''),
+      testHarness.invocation.signal,
+    )
+    assert.equal(target.model, 'production-alias')
+  } finally {
+    testHarness.cleanup()
+  }
+})
+
+test('rejects non-Claude routes before credential or subprocess use', async () => {
+  const testHarness = harness()
+  testHarness.ctx.llm.resolveModelInfo = async (provider, model) => ({
+    provider,
+    id: model,
+    name: 'GPT-5',
+  })
+  testHarness.invocation.agent.options.model = 'gpt-5'
+  try {
+    const result = await executeAuditCommand(testHarness.invocation, testHarness.ctx)
+    assert.equal(result.kind, 'error')
+    assert.match(result.text, /only to routes that declare a Claude model/u)
+    assert.deepEqual(testHarness.calls.credentials, [])
+    assert.deepEqual(testHarness.calls.spawns, [])
+  } finally {
+    testHarness.cleanup()
+  }
+})
+
+test('requires all unresolved target fields', async () => {
+  const testHarness = harness({
+    agent: { options: {}, session: { header: { cwd: '/workspace' } } },
+    ctx: {
+      llm: {
+        listConfigurableProviders: () => [],
+        resolveModelInfo: async () => { throw new Error('not called') },
+      },
+    },
+  })
+  try {
+    const result = await executeAuditCommand(testHarness.invocation, testHarness.ctx)
+    assert.equal(result.kind, 'error')
+    assert.match(result.text, /--url, --model, --credential-ref/u)
+  } finally {
+    testHarness.cleanup()
+  }
+})
+
+test('constrains output files to the current workspace', () => {
+  const workspace = join(tmpdir(), 'workspace')
+  assert.equal(
+    resolveWorkspacePath(workspace, 'reports/report.md', '/unused'),
+    join(workspace, 'reports', 'report.md'),
+  )
+  assert.throws(
+    () => resolveWorkspacePath(workspace, '../outside.md', '/unused'),
+    /inside the current workspace/u,
+  )
+  assert.throws(
+    () => resolveWorkspacePath(workspace, workspace, '/unused'),
+    /inside the current workspace/u,
+  )
+})
+
+test('rejects workspace paths that escape through a symlink', async () => {
+  const workspace = mkdtempSync(join(tmpdir(), 'dsh-path-workspace-'))
+  const outside = mkdtempSync(join(tmpdir(), 'dsh-path-outside-'))
+  try {
+    symlinkSync(outside, join(workspace, 'escape'), process.platform === 'win32' ? 'junction' : 'dir')
+    const candidate = resolveWorkspacePath(workspace, 'escape/report.md', '/unused')
+    await assert.rejects(
+      assertWorkspacePathContained(workspace, candidate),
+      /escape the current workspace through a symlink/u,
+    )
+  } finally {
+    rmSync(workspace, { recursive: true, force: true })
+    rmSync(outside, { recursive: true, force: true })
+  }
+})
+
+test('spawns audit.py without putting the secret in argv or command result', async () => {
+  const testHarness = harness({ rawInput: '--connectivity --fast-context' })
+  try {
+    const result = await executeAuditCommand(
+      testHarness.invocation,
+      testHarness.ctx,
+      { now: new Date('2026-08-14T10:00:00.123Z'), auditScript: '/package/audit.py' },
+    )
+    assert.equal(result.kind, 'success')
+    assert.match(result.text, /^Report: /u)
+    assert.equal(result.text.includes(SECRET), false)
+    assert.equal(testHarness.calls.spawns.length, 1)
+    const [spawn] = testHarness.calls.spawns
+    assert.equal(spawn.argv.includes(SECRET), false)
+    assert.deepEqual(spawn.argv.slice(0, 3), ['/usr/bin/python3', '/package/audit.py', '--key-env'])
+    assert.equal(spawn.argv.includes('--connectivity'), true)
+    assert.equal(spawn.argv.includes('--fast-context'), true)
+    assert.equal(spawn.env[CHILD_KEY_ENV], SECRET)
+    assert.equal(spawn.signal, testHarness.invocation.signal)
+    assert.equal(spawn.graceMs, PROCESS_GRACE_MS)
+    assert.equal(readFileSync(spawn.argv[spawn.argv.indexOf('--output') + 1], 'utf8'), '# fixture report\n')
+  } finally {
+    testHarness.cleanup()
+  }
+})
+
+test('uses Windows py -3 only after python3 and python fail', async () => {
+  const testHarness = harness()
+  testHarness.ctx.subprocess.resolveExecutable = async command => {
+    testHarness.calls.executable.push({ command })
+    if (command === 'py') return 'C:\\Windows\\py.exe'
+    throw new Error('missing')
+  }
+  try {
+    const result = await executeAuditCommand(
+      testHarness.invocation,
+      testHarness.ctx,
+      { platform: 'win32', auditScript: 'C:\\package\\audit.py' },
+    )
+    assert.equal(result.kind, 'success')
+    assert.deepEqual(
+      testHarness.calls.executable.map(call => call.command),
+      ['python3', 'python', 'py'],
+    )
+    assert.deepEqual(testHarness.calls.spawns[0].argv.slice(0, 3), [
+      'C:\\Windows\\py.exe', '-3', 'C:\\package\\audit.py',
+    ])
+  } finally {
+    testHarness.cleanup()
+  }
+})
+
+test('redacts credential values from subprocess diagnostics', async () => {
+  const testHarness = harness()
+  testHarness.ctx.subprocess.spawn = spec => {
+    testHarness.calls.spawns.push(spec)
+    return {
+      done: Promise.resolve({ exitCode: 2, signal: null }),
+      collected: {
+        stdout: collected(`stdout ${SECRET}`),
+        stderr: collected(`stderr ${SECRET}`),
+      },
+    }
+  }
+  try {
+    const result = await executeAuditCommand(testHarness.invocation, testHarness.ctx)
+    assert.equal(result.kind, 'error')
+    assert.equal(result.text.includes(SECRET), false)
+    assert.match(result.text, /\[REDACTED\]/u)
+    assert.equal(redactSecret(`x ${SECRET}`, SECRET), 'x [REDACTED]')
+  } finally {
+    testHarness.cleanup()
+  }
+})
+
+test('reports cancellation and passes the invocation signal to the process', async () => {
+  const testHarness = harness()
+  testHarness.ctx.subprocess.spawn = spec => {
+    testHarness.calls.spawns.push(spec)
+    testHarness.controller.abort(new Error('user canceled'))
+    return {
+      done: Promise.resolve({ exitCode: null, signal: 'SIGTERM' }),
+      collected: { stdout: collected(), stderr: collected() },
+    }
+  }
+  try {
+    const result = await executeAuditCommand(testHarness.invocation, testHarness.ctx)
+    assert.deepEqual(result, { kind: 'error', text: 'Audit canceled; no report was generated.' })
+    assert.equal(testHarness.calls.spawns[0].signal, testHarness.controller.signal)
+  } finally {
+    testHarness.cleanup()
+  }
+})
+
+test('requires an absolute DSH workspace and a stored credential', async () => {
+  const noWorkspace = harness()
+  noWorkspace.invocation.agent.session.header.cwd = undefined
+  try {
+    const result = await executeAuditCommand(noWorkspace.invocation, noWorkspace.ctx)
+    assert.match(result.text, /no absolute workspace/u)
+    assert.deepEqual(noWorkspace.calls.credentials, [])
+  } finally {
+    noWorkspace.cleanup()
+  }
+
+  const noCredential = harness()
+  noCredential.ctx.credentials.resolve = async () => undefined
+  try {
+    const result = await executeAuditCommand(noCredential.invocation, noCredential.ctx)
+    assert.match(result.text, /missing or empty/u)
+    assert.deepEqual(noCredential.calls.spawns, [])
+  } finally {
+    noCredential.cleanup()
+  }
+})
+
+test('registers a non-recording human command with only the planned services', () => {
+  let registered
+  apply({ commands: { register: definition => { registered = definition } } })
+  assert.deepEqual(inject, ['commands', 'credentials', 'subprocess', 'llm', 'settings'])
+  assert.equal(registered.name, 'relay-audit')
+  assert.equal(registered.recordInput, false)
+  assert.equal(typeof registered.handler, 'function')
+})
+
+test('package metadata declares a prebuilt GitHub bundle without install hooks', () => {
+  const manifest = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8'))
+  assert.equal(manifest.name, 'dsh-api-relay-audit')
+  assert.equal(manifest.private, true)
+  assert.deepEqual(manifest.dsh, { bundle: { patch: './dsh/cordis.patch.yml' } })
+  assert.equal(manifest.scripts.prepare, undefined)
+  assert.equal(manifest.scripts.build, undefined)
+  assert.equal(manifest.files.includes('audit.py'), true)
+  for (const [peer, range] of Object.entries(manifest.peerDependencies)) {
+    if (peer.startsWith('@deepseek-ai/dsh-')) assert.equal(range, '0.1.0-rc.6')
+  }
+})

--- a/dsh/test/plugin.test.js
+++ b/dsh/test/plugin.test.js
@@ -136,6 +136,32 @@ test('extracts adapter options and preserves audit options', () => {
   }
 })
 
+test('rejects every abbreviation of adapter-controlled long options', () => {
+  const controlledOptions = [
+    '--url',
+    '--model',
+    '--credential-ref',
+    '--output',
+    '--transparent-log',
+    '--key',
+    '--key-env',
+  ]
+  const exactOptions = new Set(controlledOptions)
+  const abbreviations = new Set()
+
+  for (const option of controlledOptions) {
+    for (let length = 3; length < option.length; length += 1) {
+      const prefix = option.slice(0, length)
+      if (!exactOptions.has(prefix)) abbreviations.add(prefix)
+    }
+  }
+
+  for (const abbreviation of abbreviations) {
+    assert.throws(() => parseCommandInput(abbreviation), /abbreviation/u)
+    assert.throws(() => parseCommandInput(`${abbreviation}=value`), /abbreviation/u)
+  }
+})
+
 test('resolves nested DSH provider settings and partial overrides', async () => {
   const testHarness = harness()
   try {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "dsh-api-relay-audit",
+  "version": "2.3.0",
+  "private": true,
+  "description": "DeepSeek Harness bundle for running API Relay Audit locally",
+  "type": "module",
+  "main": "./dsh/index.js",
+  "exports": {
+    ".": "./dsh/index.js",
+    "./audit.py": "./audit.py",
+    "./cordis.patch.yml": "./dsh/cordis.patch.yml"
+  },
+  "files": [
+    "audit.py",
+    "dsh/index.js",
+    "dsh/cordis.patch.yml",
+    "README.md",
+    "LICENSE",
+    "NOTICE",
+    "VERSION"
+  ],
+  "scripts": {
+    "test:dsh": "node --test dsh/test/*.test.js"
+  },
+  "engines": {
+    "node": "^22.19.0 || >=24.0.0"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-commands": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-credentials": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-llm": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-settings": "0.1.0-rc.6",
+    "@deepseek-ai/dsh-subprocess": "0.1.0-rc.6"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/toby-bridges/api-relay-audit.git"
+  },
+  "license": "AGPL-3.0-only",
+  "dsh": {
+    "bundle": {
+      "patch": "./dsh/cordis.patch.yml"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-api-relay-audit",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "description": "DeepSeek Harness bundle for running API Relay Audit locally",
   "type": "module",

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -18,6 +18,7 @@ Usage:
 """
 
 import argparse
+import os
 import re
 import shutil
 import socket
@@ -167,7 +168,10 @@ def _tool_commit_from_checkout():
 
 def parse_args():
     p = argparse.ArgumentParser(description="API Relay Security Audit Tool")
-    p.add_argument("--key", required=True, help="API Key")
+    key_source = p.add_mutually_exclusive_group(required=True)
+    key_source.add_argument("--key", help="API Key")
+    key_source.add_argument("--key-env", metavar="NAME",
+                            help="Read the API Key from environment variable NAME")
     p.add_argument("--url", required=True, help="Base URL (e.g. https://xxx.com/v1)")
     p.add_argument("--model", default="claude-opus-4-6", help="Model name")
     p.add_argument("--connectivity", action="store_true",
@@ -229,7 +233,15 @@ def parse_args():
                    help="Path to an append-only JSONL forensic log (arXiv §7.3). "
                         "Every API request is recorded with timestamp, URL, "
                         "SHA-256 of request/response, and status code.")
-    return p.parse_args()
+    args = p.parse_args()
+    if args.key_env is not None:
+        value = os.environ.get(args.key_env)
+        if not value:
+            p.error(
+                f"environment variable {args.key_env!r} is missing or empty"
+            )
+        args.key = value
+    return args
 
 
 def run_warmup(client, n):

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -167,7 +167,10 @@ def _tool_commit_from_checkout():
 # ============================================================
 
 def parse_args():
-    p = argparse.ArgumentParser(description="API Relay Security Audit Tool")
+    p = argparse.ArgumentParser(
+        description="API Relay Security Audit Tool",
+        allow_abbrev=False,
+    )
     key_source = p.add_mutually_exclusive_group(required=True)
     key_source.add_argument("--key", help="API Key")
     key_source.add_argument("--key-env", metavar="NAME",

--- a/scripts/sync-version.py
+++ b/scripts/sync-version.py
@@ -139,6 +139,16 @@ def sync_package_init(version: Version, path: Path) -> str:
     )
 
 
+def sync_dsh_package(version: Version, path: Path) -> str:
+    text = read_text(path)
+    return replace_regex(
+        text,
+        rf'^  "version": "{FULL_VERSION_RE}",$',
+        f'  "version": "{version.full}",',
+        path,
+    )
+
+
 def sync_skill(version: Version, path: Path) -> str:
     text = read_text(path)
     text = replace_regex(
@@ -238,6 +248,7 @@ def planned_files(version: Version) -> list[PlannedFile]:
     audit_script = REPO_ROOT / "scripts" / "audit.py"
     build_standalone = REPO_ROOT / "scripts" / "build-standalone.py"
     package_init = REPO_ROOT / "api_relay_audit" / "__init__.py"
+    dsh_package = REPO_ROOT / "package.json"
     root_skill = REPO_ROOT / "SKILL.md"
     hermes_skill = REPO_ROOT / "skills" / "api-relay-audit" / "SKILL.md"
     skill_distribution = REPO_ROOT / "docs" / "skill-distribution.md"
@@ -248,6 +259,7 @@ def planned_files(version: Version) -> list[PlannedFile]:
         PlannedFile(audit_script, sync_audit_script(version, audit_script)),
         PlannedFile(build_standalone, sync_build_standalone(version, build_standalone)),
         PlannedFile(package_init, sync_package_init(version, package_init)),
+        PlannedFile(dsh_package, sync_dsh_package(version, dsh_package)),
         PlannedFile(root_skill, sync_skill(version, root_skill)),
         PlannedFile(hermes_skill, sync_skill(version, hermes_skill)),
         PlannedFile(

--- a/tests/test_dual_distribution_parity.py
+++ b/tests/test_dual_distribution_parity.py
@@ -450,7 +450,97 @@ def test_public_help_flags_parity():
     modular_flags = _help_option_set(REPO_ROOT / "scripts" / "audit.py")
     standalone_flags = _help_option_set(REPO_ROOT / "audit.py")
     assert "--connectivity" in modular_flags
+    assert "--key-env" in modular_flags
     assert modular_flags == standalone_flags
+
+
+def test_api_key_cli_sources_are_safe_and_dual_distributed(monkeypatch, capsys):
+    """Both entrypoints accept exactly one API-key source without echoing it."""
+    import scripts.audit as modular
+
+    standalone = _load_standalone_audit()
+    secret = "sk-dsh-secret-must-not-appear"
+
+    for module in (modular, standalone):
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "audit.py",
+                "--key",
+                secret,
+                "--url",
+                "https://relay.example.com/v1",
+            ],
+        )
+        assert module.parse_args().key == secret
+
+        monkeypatch.setenv("API_RELAY_AUDIT_TEST_KEY", secret)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "audit.py",
+                "--key-env",
+                "API_RELAY_AUDIT_TEST_KEY",
+                "--url",
+                "https://relay.example.com/v1",
+            ],
+        )
+        parsed = module.parse_args()
+        assert parsed.key == secret
+        assert parsed.key_env == "API_RELAY_AUDIT_TEST_KEY"
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "audit.py",
+                "--key",
+                secret,
+                "--key-env",
+                "API_RELAY_AUDIT_TEST_KEY",
+                "--url",
+                "https://relay.example.com/v1",
+            ],
+        )
+        with pytest.raises(SystemExit) as conflict:
+            module.parse_args()
+        assert conflict.value.code == 2
+        assert secret not in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_key_env_rejects_missing_or_empty_values_without_leaking(
+    monkeypatch, capsys, value
+):
+    import scripts.audit as modular
+
+    standalone = _load_standalone_audit()
+    name = "API_RELAY_AUDIT_EMPTY_TEST_KEY"
+    if value is None:
+        monkeypatch.delenv(name, raising=False)
+    else:
+        monkeypatch.setenv(name, value)
+
+    for module in (modular, standalone):
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "audit.py",
+                "--key-env",
+                name,
+                "--url",
+                "https://relay.example.com/v1",
+            ],
+        )
+        with pytest.raises(SystemExit) as exc:
+            module.parse_args()
+        assert exc.value.code == 2
+        error = capsys.readouterr().err
+        assert name in error
+        assert "missing or empty" in error
 
 
 def test_profile_help_matches_current_14_step_contract():

--- a/tests/test_dual_distribution_parity.py
+++ b/tests/test_dual_distribution_parity.py
@@ -12,6 +12,7 @@ focused behavior/constant regression tests for public standalone semantics.
 """
 
 import ast
+import importlib.util
 import sys
 import re
 import subprocess
@@ -22,6 +23,58 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_audit_module(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _long_options(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return {
+        node.args[0].value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "add_argument"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+        and node.args[0].value.startswith("--")
+    }
+
+
+@pytest.mark.parametrize(
+    ("path", "module_name"),
+    [
+        (REPO_ROOT / "scripts" / "audit.py", "modular_audit_no_abbrev"),
+        (REPO_ROOT / "audit.py", "standalone_audit_no_abbrev"),
+    ],
+)
+def test_all_long_option_abbreviations_are_rejected(path, module_name, monkeypatch, capsys):
+    module = _load_audit_module(path, module_name)
+    options = _long_options(path)
+    abbreviations = {
+        option[:length]
+        for option in options
+        for length in range(3, len(option))
+        if option[:length] not in options
+    }
+
+    for abbreviation in sorted(abbreviations):
+        for token in (abbreviation, f"{abbreviation}=value"):
+            monkeypatch.setattr(
+                sys,
+                "argv",
+                ["audit.py", "--key", "test-key", "--url", "https://example.invalid", token],
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                module.parse_args()
+            assert exc_info.value.code == 2
+            assert "unrecognized arguments" in capsys.readouterr().err
 
 
 def test_standalone_artifact_generated_from_sources():

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,6 +1,7 @@
 """Regression checks for VERSION-derived release surfaces."""
 
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -130,3 +131,10 @@ def test_modular_metadata_reads_version_only_for_project_checkout_shape(tmp_path
     module.__file__ = str(checkout / "scripts" / "audit.py")
 
     assert module._tool_version() == "3.4.5"
+
+
+def test_dsh_package_version_comes_from_root_version():
+    version = (REPO_ROOT / "VERSION").read_text(encoding="utf-8").strip()
+    package = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))
+
+    assert package["version"] == version

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">802</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">808</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## Summary

- add a prebuilt, dependency-free `dsh-api-relay-audit` ESM bundle for DSH Web and `@deepseek-ai/dsh-commands` compatible TUI profiles
- add dual-distributed `--key-env` support so DSH credentials reach `audit.py` only through the explicit child environment
- enforce the Claude applicability gate, workspace-contained report/log paths, bounded subprocess output, cancellation, and exact secret redaction
- document immutable GitHub installs and add Node/Python/package/composition CI coverage

This is a distribution adapter only: it does not change probes, the 14-step audit, the 6D risk matrix, or audit baselines.

## Verification

- `python3 -m pytest tests/ -q`: **782 passed**
- Node **22.19.0**, `node --test dsh/test/*.test.js`: **16 passed**
- `npm pack --dry-run`: **8 expected files**, no build/prepare install hooks
- version sync, generated standalone, metrics drift, `python3 -S audit.py --help`, and diff checks passed
- fresh DSH **0.1.0-rc.6** Web and `dsh-cc-tui@0.4.1` profiles composed with pnpm **11.7.0**
- official Web and TUI dogfood against a local fake relay both produced `Connectivity Verdict: OK`; exact test-secret scans over reports and DSH state had no matches

## Compatibility boundary

Verified against DSH `0.1.0-rc.6` and `dsh-cc-tui@0.4.1`. Independent wrappers without the DSH profile/plugin loader and command registry are outside this contract.