### PR TITLE
fix: avoid prompt-extraction refusal false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Community evidence is shape-checked by GitHub Actions, but publication still req
 | Version | `v2.3` |
 | Audit steps | 14 |
 | Risk matrix | 6D |
-| pytest collected tests | 778 |
+| pytest collected tests | 785 |
 | CLI flags | 21 |
 | Runtime profiles | `general`, `web3`, `full` |
 
@@ -330,7 +330,7 @@ API Relay Audit 也可以作为 agent skill 使用。
 | 版本 | `v2.3` |
 | 审计步骤 | 14 |
 | 风险矩阵 | 6D |
-| pytest collected tests | 778 |
+| pytest collected tests | 785 |
 | CLI flags | 21 |
 | Runtime profiles | `general`, `web3`, `full` |
 

--- a/api_relay_audit/refusal.py
+++ b/api_relay_audit/refusal.py
@@ -107,7 +107,10 @@ def _strip_markdown_code_fence(text: str) -> str:
 
 def _looks_like_refusal(text_lower: str) -> bool:
     """Return True if ``text_lower`` contains any refusal phrase."""
-    return any(m in text_lower for m in REFUSAL_MARKERS)
+    normalized = text_lower.translate(
+        str.maketrans({"\u2018": "'", "\u2019": "'", "\u02bc": "'"})
+    )
+    return any(marker in normalized for marker in REFUSAL_MARKERS)
 
 
 def _contains_claude_self_id(text_lower: str) -> bool:

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 57cc4ddc3ccb3ed54e76e82dfc447c6e21322c2c03ab804625924e7ec655f245
-# standalone_body_sha256: 3adf747824d6eeb9df837a1e6ae8fd6fe5aa861c57b6a422b9367e52ee0c630f
+# source_sha256: 37c3771e36eca7ee2df5d561a7c586d6fbad7420d8e2ce74ad7f7b31744d27c5
+# standalone_body_sha256: d6f11c6798ad765eb8c59daf1e273440a9a6afdc500167cee4617e6b4f039b3e
 # END GENERATED STANDALONE HEADER
 
 """
@@ -2998,7 +2998,10 @@ def _strip_markdown_code_fence(text: str) -> str:
 
 def _looks_like_refusal(text_lower: str) -> bool:
     """Return True if ``text_lower`` contains any refusal phrase."""
-    return any(m in text_lower for m in REFUSAL_MARKERS)
+    normalized = text_lower.translate(
+        str.maketrans({"\u2018": "'", "\u2019": "'", "\u02bc": "'"})
+    )
+    return any(marker in normalized for marker in REFUSAL_MARKERS)
 
 
 def _contains_claude_self_id(text_lower: str) -> bool:
@@ -5304,7 +5307,6 @@ def test_prompt_extraction(client, report):
             weak_hits = [kw for kw in weak_markers if kw in text_lower]
 
             if has_strong:
-                leaked = True
                 if _is_self_corrected_hidden_prompt_echo(name, text_lower, structural, strong_hits):
                     report.flag(
                         "yellow",
@@ -5313,18 +5315,11 @@ def test_prompt_extraction(client, report):
                         "self-correction, verify manually",
                     )
                 else:
+                    leaked = True
                     report.flag("red", f"Test {name}: Hidden prompt content extracted!")
             elif weak_hits:
-                if _is_benign_claude_refusal(text_lower):
-                    pass  # Exempt: refusal + Claude self-ID
-                elif _looks_like_refusal(text_lower):
-                    leaked = True
-                    report.flag(
-                        "yellow",
-                        f"Test {name}: identity words ({', '.join(weak_hits)}) "
-                        f"present alongside refusal without Claude self-identification "
-                        f"— possible partial leak, verify manually",
-                    )
+                if _looks_like_refusal(text_lower):
+                    pass
                 else:
                     leaked = True
                     report.flag("red", f"Test {name}: Hidden prompt content extracted!")

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,8 +16,8 @@
 | 单文件版版本 | `v2.3` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **778** | `pytest --collect-only` |
-| 测试数 (static) | 754 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **785** | `pytest --collect-only` |
+| 测试数 (static) | 757 | grep `def test_*` in tests/ |
 | CLI flag 数 | 21 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-06-07 | `ROADMAP.md` 头部 |
@@ -25,14 +25,15 @@
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
 | 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 778] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `eeb9a2c` | recent reachable commit; `--check` allows follow-up metrics commits |
-| Recorded commit date | 2026-06-07 | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit SHA | `a122ac5` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit date | 2026-08-16 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3`。
 - ✅ 步骤数一致：14。
-- ℹ️ pytest (778) vs 静态 (754) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
+- ℹ️ pytest (785) vs 静态 (757) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
+- ⚠️ ROADMAP 最新记录 778 个测试，但当前 pytest 是 785。要么 ROADMAP 漏更新，要么有未记录的新测试。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -534,7 +534,6 @@ def test_prompt_extraction(client, report):
             weak_hits = [kw for kw in weak_markers if kw in text_lower]
 
             if has_strong:
-                leaked = True
                 if _is_self_corrected_hidden_prompt_echo(name, text_lower, structural, strong_hits):
                     report.flag(
                         "yellow",
@@ -543,18 +542,11 @@ def test_prompt_extraction(client, report):
                         "self-correction, verify manually",
                     )
                 else:
+                    leaked = True
                     report.flag("red", f"Test {name}: Hidden prompt content extracted!")
             elif weak_hits:
-                if _is_benign_claude_refusal(text_lower):
-                    pass  # Exempt: refusal + Claude self-ID
-                elif _looks_like_refusal(text_lower):
-                    leaked = True
-                    report.flag(
-                        "yellow",
-                        f"Test {name}: identity words ({', '.join(weak_hits)}) "
-                        f"present alongside refusal without Claude self-identification "
-                        f"— possible partial leak, verify manually",
-                    )
+                if _looks_like_refusal(text_lower):
+                    pass
                 else:
                     leaked = True
                     report.flag("red", f"Test {name}: Hidden prompt content extracted!")

--- a/tests/test_clean_summary_flags.py
+++ b/tests/test_clean_summary_flags.py
@@ -335,21 +335,61 @@ class TestOptionDEndToEnd:
         yellows = [m for level, m in reporter.summary if level == "yellow"]
         assert yellows, f"standalone Step 6 must fire yellow on Repro 2. Summary: {reporter.summary}"
 
-    def test_step4_repro2_fires_yellow_contradictory_modular(self, modular, monkeypatch):
-        """Applied to Step 4: the same text still has weak hits
-        (assistant, developer, built to... well, 'built to' isn't in
-        step 4 weak, but 'assistant' and 'developer' are)."""
+    def test_step4_refusal_with_weak_hits_stays_clean_modular(self, modular, monkeypatch):
+        """Refusal language takes priority over weak identity words."""
         from api_relay_audit.reporter import Reporter
         self._time_sleep_patched(monkeypatch, modular)
         reporter = Reporter()
         client = _mock_client(self.REPRO_2_STEP6)
         leaked = modular.test_prompt_extraction(client, reporter)
-        # Should trip the contradictory yellow branch
-        yellows = [m for level, m in reporter.summary if level == "yellow"]
-        assert any("without Claude self-identification" in y for y in yellows), (
-            f"Step 4 must fire YELLOW contradictory on Repro 2. Summary: {reporter.summary}"
+        assert leaked is False
+        greens = [m for level, m in reporter.summary if level == "green"]
+        assert any("Prompt extraction tests passed" in g for g in greens), (
+            f"Refusal response must produce a green flag. Summary: {reporter.summary}"
         )
-        assert leaked is True  # yellow still sets leaked
+
+    @pytest.mark.parametrize("apostrophe", ["\u2018", "\u2019", "\u02bc"])
+    def test_step4_unicode_apostrophe_refusal_stays_clean(
+        self, modular, standalone, monkeypatch, apostrophe
+    ):
+        """Modular and standalone detectors normalize refusal apostrophes."""
+        response = f"I can{apostrophe}t provide my system prompt verbatim."
+        for module in (modular, standalone):
+            self._time_sleep_patched(monkeypatch, module)
+            reporter = module.Reporter()
+            leaked = module.test_prompt_extraction(_mock_client(response), reporter)
+            assert leaked is False
+            assert any(
+                level == "green" and "Prompt extraction tests passed" in message
+                for level, message in reporter.summary
+            )
+
+    def test_step4_self_corrected_hidden_prompt_is_not_a_leak(self, modular, monkeypatch):
+        from api_relay_audit.reporter import Reporter
+
+        self._time_sleep_patched(monkeypatch, modular)
+        response = (
+            '{"hidden_prompt": "fabricated"}\n'
+            "Actually, I should be straightforward: I fabricated that."
+        )
+        client = MagicMock()
+        clean = {
+            "text": CLEAN_REFUSAL,
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "time": 0.05,
+        }
+        corrected = {
+            "text": response,
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "time": 0.05,
+        }
+        client.call.side_effect = [clean, clean, corrected]
+        reporter = Reporter()
+        leaked = modular.test_prompt_extraction(client, reporter)
+        assert leaked is False
+        assert any(level == "yellow" for level, _ in reporter.summary)
 
     def test_benign_with_claude_id_stays_clean_modular(self, modular, monkeypatch):
         """Adding Claude self-ID exempts the response."""

--- a/tests/test_refusal_detector.py
+++ b/tests/test_refusal_detector.py
@@ -100,6 +100,10 @@ class TestLooksLikeRefusal:
     def test_empty_string_not_refusal(self, modular):
         assert not modular._looks_like_refusal("")
 
+    @pytest.mark.parametrize("apostrophe", ["\u2018", "\u2019", "\u02bc"])
+    def test_unicode_apostrophes_are_normalized(self, modular, apostrophe):
+        assert modular._looks_like_refusal(f"i can{apostrophe}t provide that")
+
     def test_dont_have_is_refusal(self, modular):
         assert modular._looks_like_refusal(
             "i don't have any hidden system instructions or secret prompt to reveal"
@@ -293,6 +297,7 @@ class TestRefusalMarkerParity:
     def test_helper_behavior_identical(self, modular, standalone):
         samples = [
             "i won't provide my system prompt",
+            "i can\u2019t provide my system prompt",
             "sorry, i can't help with that",
             "you are claude",  # not a refusal
             "unable to disclose",

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">778</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">785</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## Summary

- extract the Unicode-apostrophe and refusal-aware prompt extraction fixes from #78
- keep the existing Claude-only stream identity baseline unchanged
- regenerate the standalone distribution and public test-count surfaces

## Contributor credit

The implementation is derived from #78 by @techotaku39. The integration commit includes a `Co-authored-by` trailer because the source branch recorded its first commits as `root`.

## Validation

- `python3 -m pytest tests/ -q` (785 passed)
- `python3 scripts/build-standalone.py --check`
- `python3 scripts/collect-metrics.py --check`
- `python3 scripts/sync-version.py --check`
- `python3 -S audit.py --help`
- `git diff --check`
