### PR TITLE
v3 draft: require explicit insecure TLS authorization

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -54,3 +54,22 @@ references:
         given-names: "Yang"
     year: 2026
     url: "https://arxiv.org/abs/2603.01919"
+  - type: article
+    title: "The Proxy Knows Too Much: Sealing LLM API Routers with Attested TEEs"
+    authors:
+      - family-names: "Xie"
+        given-names: "Sipeng"
+      - family-names: "Wu"
+        given-names: "Qianhong"
+      - family-names: "Lu"
+        given-names: "Hengrun"
+      - family-names: "Sun"
+        given-names: "Ziliang"
+      - family-names: "Wu"
+        given-names: "Qi"
+      - family-names: "Qin"
+        given-names: "Bo"
+      - family-names: "Wang"
+        given-names: "Qin"
+    year: 2026
+    url: "https://arxiv.org/abs/2606.16358"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Use it when you rely on a third-party AI API relay, OpenAI-compatible proxy, Cla
 - **Detect relay tampering:** prompt injection, prompt extraction, identity consistency signals, context truncation, tool-call rewriting, error-response leakage, and SSE stream anomalies.
 - **Run locally:** the standalone `audit.py` uses only Python stdlib plus `curl`; your API key is sent only to the relay URL you choose.
 - **Produce reviewable evidence:** each run generates a structured Markdown report with per-step findings and a final `LOW / MEDIUM / HIGH` verdict.
+- **Keep transport trust explicit:** curl verifies TLS certificates by default. `--allow-insecure-tls` is an opt-in diagnostic escape hatch; actual HTTPS use is reported and prevents a LOW verdict.
 
 ## Quick Start
 
@@ -144,8 +145,8 @@ Community evidence is shape-checked by GitHub Actions, but publication still req
 | Version | `v2.3` |
 | Audit steps | 14 |
 | Risk matrix | 6D |
-| pytest collected tests | 802 |
-| CLI flags | 21 |
+| pytest collected tests | 816 |
+| CLI flags | 22 |
 | Runtime profiles | `general`, `web3`, `full` |
 
 ## Example Report And Live Page
@@ -191,6 +192,10 @@ Tool-call rewriting means the relay modifies package-install commands or tool-li
 
 SSE anomalies are stream-level integrity issues in Anthropic-style streaming responses. API Relay Audit checks event types, usage monotonicity, thinking signatures, and stream model identity when the relay supports that format.
 
+### What if the relay uses a self-signed TLS certificate?
+
+The modular client may retry SSL/connect failures through curl, but curl still verifies the certificate by default. If you have independently verified that a self-signed relay is the intended target, opt in with `--allow-insecure-tls`. The flag only takes effect for HTTPS requests that actually use curl; such use is logged, shown in the report, and raises an otherwise LOW audit to MEDIUM because the evidence path was not authenticated end to end.
+
 ### What Web3 wallet risks does it check?
 
 With the `web3` or `full` profile, API Relay Audit checks transfer guidance, signed-transaction refusal, and private-key refusal behavior before wallet-related traffic is trusted.
@@ -211,7 +216,7 @@ This keeps modified network-service deployments accountable to the same public s
 
 ## Citation
 
-If you use API Relay Audit in research, security reports, or public relay evaluations, please cite the software with [CITATION.cff](./CITATION.cff). The citation file also records the two academic papers that inform the audit model: Liu et al., *Your Agent Is Mine* (arXiv:2604.08407) and Zhang et al., *Real Money, Fake Models* (arXiv:2603.01919).
+If you use API Relay Audit in research, security reports, or public relay evaluations, please cite the software with [CITATION.cff](./CITATION.cff). The citation file also records three academic papers that inform the project: Liu et al., *Your Agent Is Mine* (arXiv:2604.08407), Zhang et al., *Real Money, Fake Models* (arXiv:2603.01919), and Xie et al., *The Proxy Knows Too Much* (arXiv:2606.16358). The Xie et al. paper motivates the explicit evidence and transport trust boundaries in this hardening; this tool does not implement or claim TEE attestation.
 
 ## How to Contribute
 
@@ -333,8 +338,8 @@ API Relay Audit 也可以作为 agent skill 使用。
 | 版本 | `v2.3` |
 | 审计步骤 | 14 |
 | 风险矩阵 | 6D |
-| pytest collected tests | 802 |
-| CLI flags | 21 |
+| pytest collected tests | 816 |
+| CLI flags | 22 |
 | Runtime profiles | `general`, `web3`, `full` |
 
 ## 如何贡献

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,8 @@ item has a short rationale so future contributors (including future
 iterations of the author) can quickly reconstruct why a thing is or is not
 on the list.
 
-**Last updated**: 2026-08-16 (Step 10 terminal completeness added without
-changing the 6D risk matrix or TLS behavior)
+**Last updated**: 2026-08-16 (Step 10 terminal completeness shipped; explicit
+TLS downgrade authorization is isolated in a release:major v3 draft)
 
 **Threat model anchor**: Liu et al., *Your Agent Is Mine: Measuring
 Malicious Intermediary Attacks on the LLM Supply Chain*, arXiv:2604.08407.
@@ -309,6 +309,19 @@ Pick one of these to start the next session. Each is scoped to fit in a
 single session, has a clear spec, and does not require new infrastructure.
 Items marked ✅ closed or historical are retained for auditability only; do
 not pick them as new work unless new evidence reopens the decision.
+
+### v3 draft — explicit TLS downgrade authorization
+**Status**: implemented in a `release:major` draft and excluded from v2.4.
+The modular SSL/connect fallback and curl-only standalone verify certificates
+by default; `--allow-insecure-tls` is required before an HTTPS curl request
+may use `-k`. Actual use is warned once, recorded in the transparent log, and
+raises an otherwise LOW full-audit verdict to MEDIUM without adding D7.
+Connectivity mode reports the evidence downgrade but has no risk rating.
+This changes the historical self-signed-relay fallback behavior, so it must
+ship only with major-version migration notes and dedicated release validation.
+The implementation does not add TEE attestation, OpenAI stream parsing, or a
+new threat-taxonomy dimension.
+**Final test count**: 816/816 passing on the pre-v2.4 draft base.
 
 ### 0. v1.8.1 — app-layer vs edge-layer framework separation
 **Status**: deferred from v1.8 Codex review HIGH finding (2026-04-18)

--- a/SKILL.md
+++ b/SKILL.md
@@ -24,7 +24,7 @@ metadata:
 
 # API Relay Security Audit (API 中转站安全审计)
 
-A self-contained 14-step security audit for third-party AI API relay/proxy services (中转站). One script, zero config, full report. Threat taxonomy follows Liu et al., *Your Agent Is Mine*, arXiv:2604.08407. Infrastructure fingerprinting, latency variance, and upstream channel classification are sourced from Zhang et al., *Real Money, Fake Models*, arXiv:2603.01919.
+A self-contained 14-step security audit for third-party AI API relay/proxy services (中转站). One script, zero config, full report. Threat taxonomy follows Liu et al., *Your Agent Is Mine*, arXiv:2604.08407. Infrastructure fingerprinting, latency variance, and upstream channel classification are sourced from Zhang et al., *Real Money, Fake Models*, arXiv:2603.01919. Explicit relay-evidence and transport trust boundaries are informed by Xie et al., *The Proxy Knows Too Much*, arXiv:2606.16358; the tool does not implement TEE attestation.
 
 ## Quick Start (快速开始)
 
@@ -293,6 +293,7 @@ python audit.py [OPTIONS]
 | `--transparent-log` | No | -- | Path to append-only JSONL forensic log (arXiv §7.3 取证日志) |
 | `--warmup` | No | 0 | Send N benign requests before the audit to mitigate AC-1.b request-count gates (审计前预热次数) |
 | `--timeout` | No | 120 | Request timeout in seconds (请求超时秒数) |
+| `--allow-insecure-tls` | No | false | Allow HTTPS curl requests to skip certificate verification; actual use is warned, logged, and prevents a LOW rating (显式授权不安全 TLS) |
 | `--output` | No | stdout | Path for the Markdown report (报告输出路径) |
 
 ## Troubleshooting (常见问题)
@@ -303,7 +304,7 @@ python audit.py [OPTIONS]
 httpx.ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED]
 ```
 
-The script has built-in `curl` fallback. Look for `[Transport] Python SSL error, switching to curl` in output. No action needed -- it self-recovers.
+The modular client has a built-in curl fallback. Look for `[transport] Python SSL/connect error, switching to curl` in output. The retry still verifies TLS certificates by default. If the relay intentionally uses a self-signed certificate and you have independently verified the endpoint, rerun with `--allow-insecure-tls`; the first actual HTTPS curl use prints a warning and degrades an otherwise LOW full-audit verdict to MEDIUM.
 
 ### API Format Detection Failure (API 格式检测失败)
 

--- a/api_relay_audit/_transport.py
+++ b/api_relay_audit/_transport.py
@@ -24,7 +24,15 @@ def curl_loopback_no_proxy_args(url: str) -> list:
     return []
 
 
+def curl_insecure_tls_args(url: str, allow_insecure_tls: bool = False) -> list:
+    """Return ``-k`` only for explicitly authorised HTTPS requests."""
+    if allow_insecure_tls and urlparse(url).scheme.lower() == "https":
+        return ["-k"]
+    return []
+
+
 def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
+                   allow_insecure_tls: bool = False,
                    subprocess_module=subprocess) -> dict:
     """POST JSON through curl while keeping headers out of argv.
 
@@ -41,7 +49,8 @@ def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
             json.dump(body, tmp)
             body_path = tmp.name
 
-        cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), "-X", "POST", url,
+        cmd = ["curl", "-s", *curl_insecure_tls_args(url, allow_insecure_tls),
+               *curl_loopback_no_proxy_args(url), "-X", "POST", url,
                "--max-time", str(timeout), "--config", "-", "--data-binary", f"@{body_path}"]
         config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
         r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
@@ -68,9 +77,11 @@ def httpx_post_json(url: str, headers: dict, body: dict, timeout: int,
 
 
 def curl_get_json_data(url: str, headers: dict, timeout: int = 15,
+                       allow_insecure_tls: bool = False,
                        subprocess_module=subprocess) -> list:
     """GET JSON through curl and return the top-level ``data`` list."""
-    cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), url,
+    cmd = ["curl", "-s", *curl_insecure_tls_args(url, allow_insecure_tls),
+           *curl_loopback_no_proxy_args(url), url,
            "--max-time", str(timeout), "--config", "-"]
     config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
     r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
@@ -113,10 +124,12 @@ def httpx_raw_request(method: str, url: str, headers: dict, body: bytes,
 
 def curl_raw_request(method: str, url: str, headers: dict, body: bytes,
                      content_type: str, timeout: int, parser,
+                     allow_insecure_tls: bool = False,
                      subprocess_module=subprocess) -> dict:
     """Raw request through curl and parse ``curl -i`` output with ``parser``."""
     all_headers = {**headers, "content-type": content_type}
-    cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), "-i", "-X", method, url,
+    cmd = ["curl", "-s", *curl_insecure_tls_args(url, allow_insecure_tls),
+           *curl_loopback_no_proxy_args(url), "-i", "-X", method, url,
            "--max-time", str(timeout), "--data-binary", "@-"]
     for k, v in all_headers.items():
         cmd.extend(["-H", f"{k}: {v}"])

--- a/api_relay_audit/client.py
+++ b/api_relay_audit/client.py
@@ -7,8 +7,10 @@ Eliminates duplicated API calling logic across scripts.
 import hashlib
 import json
 import subprocess
+import sys
 import time
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 import httpx
 
@@ -43,7 +45,7 @@ def _extract_anthropic_text(content) -> str:
 
 
 def _parse_curl_i_output(output: str) -> dict:
-    """Parse ``curl -i`` (or ``curl -sk -i``) stdout into a response dict.
+    """Parse ``curl -s [-k] -i`` stdout into a response dict.
 
     Handles HTTP/1.x and HTTP/2 status lines and normalises ``\\r\\n`` line
     endings. A leading ``HTTP/X 100 Continue`` preface is skipped so the
@@ -275,8 +277,9 @@ class APIClient:
     On the first ``call()``, the client tries the Anthropic native message
     format and, if that fails, falls back to the OpenAI-compatible
     ``/chat/completions`` endpoint.  If a Python-level SSL error is
-    encountered, the transport silently switches to a ``curl -sk``
-    subprocess so the audit can continue against self-signed relays.
+    encountered, the transport switches to a certificate-verifying curl
+    subprocess. Certificate verification is disabled only when the caller
+    explicitly authorises it.
 
     Attributes:
         base_url: Root URL of the relay (trailing slash stripped).
@@ -284,10 +287,13 @@ class APIClient:
         model: Model identifier forwarded to the relay.
         timeout: Per-request timeout in seconds.
         verbose: If ``True``, diagnostic messages are printed to stdout.
+        allow_insecure_tls: Whether HTTPS curl requests may disable certificate
+            verification. Defaults to False.
     """
 
     def __init__(self, base_url: str, api_key: str, model: str,
-                 timeout: int = 120, verbose: bool = True):
+                 timeout: int = 120, verbose: bool = True,
+                 allow_insecure_tls: bool = False):
         """Initialise the client.
 
         Args:
@@ -297,14 +303,20 @@ class APIClient:
             model: Model identifier to include in every request body.
             timeout: HTTP / curl timeout in seconds. Defaults to 120.
             verbose: Whether to print diagnostic log lines. Defaults to True.
+            allow_insecure_tls: Permit curl to use ``-k`` for HTTPS requests.
+                Defaults to False. Merely granting permission does not mark it
+                as used; an HTTPS request must actually run through curl.
         """
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.model = model
         self.timeout = timeout
         self.verbose = verbose
+        self.allow_insecure_tls = allow_insecure_tls
         self._format = None   # "anthropic" | "openai" | None (auto)
         self._use_curl = False
+        self._insecure_tls_used = False
+        self._insecure_tls_warning_emitted = False
         self._transparent_logger = None  # Optional[TransparentLogger]
 
     @property
@@ -317,15 +329,48 @@ class APIClient:
         """
         return self._format
 
+    @property
+    def insecure_tls_used(self) -> bool:
+        """Return whether an HTTPS curl request actually disabled TLS checks."""
+        return self._insecure_tls_used
+
     def _log(self, msg: str):
         if self.verbose:
             print(msg)
+
+    def _authorise_insecure_tls_for(self, url: str) -> bool:
+        """Mark and authorise ``curl -k`` for one HTTPS request if allowed."""
+        authorised = (
+            self.allow_insecure_tls
+            and urlparse(url).scheme.lower() == "https"
+        )
+        if not authorised:
+            return False
+        self._insecure_tls_used = True
+        if not self._insecure_tls_warning_emitted:
+            print(
+                "  [WARNING] TLS certificate verification disabled for an HTTPS "
+                "curl request (--allow-insecure-tls). Audit evidence integrity is reduced.",
+                file=sys.stderr,
+            )
+            self._insecure_tls_warning_emitted = True
+        return True
+
+    def _tls_verification_disabled_for(self, url: str) -> bool:
+        """Return the per-request TLS state used by transparent logging."""
+        return bool(
+            self._use_curl
+            and self.allow_insecure_tls
+            and urlparse(url).scheme.lower() == "https"
+        )
 
     # -- Low-level transport --------------------------------------------------
 
     def _curl_post(self, url: str, headers: dict, body: dict) -> dict:
         return _transport.curl_post_json(
-            url, headers, body, self.timeout, subprocess_module=subprocess)
+            url, headers, body, self.timeout,
+            allow_insecure_tls=self._authorise_insecure_tls_for(url),
+            subprocess_module=subprocess)
 
     def _post(self, url: str, headers: dict, body: dict) -> dict:
         if self._use_curl:
@@ -544,10 +589,14 @@ class APIClient:
         return anthropic_result or openai_result or self._error_result("Both formats failed")
 
     def _handle_ssl_error(self, e: Exception) -> bool:
-        """Switch to curl on SSL errors. Returns True if retry is warranted."""
+        """Switch to curl on SSL/connect errors. Returns True for one retry.
+
+        Curl still verifies certificates unless ``allow_insecure_tls`` was
+        explicitly enabled by the caller.
+        """
         if not self._use_curl and ("SSL" in str(e) or "Connect" in type(e).__name__):
             self._use_curl = True
-            self._log("  [transport] Python SSL error, switching to curl")
+            self._log("  [transport] Python SSL/connect error, switching to curl")
             return True
         return False
 
@@ -591,6 +640,7 @@ class APIClient:
             "response_headers": response_headers,
             "tls_version": None,   # deferred to follow-up commit
             "tls_cipher": None,    # deferred to follow-up commit
+            "tls_verification_disabled": self._tls_verification_disabled_for(url),
             "elapsed_seconds": round(elapsed, 3),
             "transport": "curl" if self._use_curl else "httpx",
             "error": redact_error(error),
@@ -631,7 +681,9 @@ class APIClient:
             try:
                 if self._use_curl:
                     data = _transport.curl_get_json_data(
-                        url, headers, subprocess_module=subprocess)
+                        url, headers,
+                        allow_insecure_tls=self._authorise_insecure_tls_for(url),
+                        subprocess_module=subprocess)
                     if data:
                         self._log_transparent(
                             "get_models", url, "GET", None,
@@ -725,12 +777,14 @@ class APIClient:
                           body: bytes, content_type: str, timeout: int) -> dict:
         """Curl-based fallback for ``raw_request``.
 
-        Uses ``curl -sk -i -X <method>`` to capture both headers and body
-        on stdout. Ignores self-signed certificate errors (``-k``).
+        Uses ``curl -s -i -X <method>`` to capture both headers and body
+        on stdout. ``-k`` is added only for explicitly authorised HTTPS.
         """
         return _transport.curl_raw_request(
             method, url, headers, body, content_type, timeout,
-            parser=_parse_curl_i_output, subprocess_module=subprocess)
+            parser=_parse_curl_i_output,
+            allow_insecure_tls=self._authorise_insecure_tls_for(url),
+            subprocess_module=subprocess)
 
     # -- Streaming (Step 10 stream integrity) --------------------------------
 
@@ -856,7 +910,11 @@ class APIClient:
         incremental stream.
         """
         cmd = [
-            "curl", "-sk", *_transport.curl_loopback_no_proxy_args(url),
+            "curl", "-s",
+            *_transport.curl_insecure_tls_args(
+                url, self._authorise_insecure_tls_for(url)
+            ),
+            *_transport.curl_loopback_no_proxy_args(url),
             "-N", "--no-buffer", "-X", "POST", url,
             "--max-time", str(timeout),
             "-w", f"\n{CURL_STATUS_SENTINEL}%{{http_code}}\n",

--- a/api_relay_audit/connectivity.py
+++ b/api_relay_audit/connectivity.py
@@ -189,12 +189,14 @@ def _render_status(status: int) -> str:
 def _next_step(verdict: str, client) -> str:
     url = shlex.quote(client.base_url)
     model = shlex.quote(client.model)
+    insecure_tls_flag = " --allow-insecure-tls" if client.insecure_tls_used else ""
     if verdict in ("OK", "WARNING"):
         return (
             "Connectivity reached at least one chat format. For the full security audit, run:\n\n"
             "```bash\n"
             "export API_RELAY_AUDIT_KEY=sk-...\n"
-            f"python3 audit.py --key \"$API_RELAY_AUDIT_KEY\" --url {url} --model {model} --output report.md\n"
+            f"python3 audit.py --key \"$API_RELAY_AUDIT_KEY\" --url {url} "
+            f"--model {model}{insecure_tls_flag} --output report.md\n"
             "```"
         )
     return (
@@ -218,11 +220,20 @@ def render_connectivity_report(result: dict) -> str:
         "",
         "This is a quick connectivity check, not a security audit. It does not produce a LOW/MEDIUM/HIGH risk rating.",
         "",
+    ]
+    if client.insecure_tls_used:
+        lines.extend([
+            "> **WARNING:** TLS certificate verification was disabled for one or "
+            "more HTTPS requests under explicit `--allow-insecure-tls` authorization. "
+            "Connectivity was observed, but the transport was not authenticated end to end.",
+            "",
+        ])
+    lines.extend([
         "## Probe Results",
         "",
         "| Format | Endpoint | Auth style | HTTP status | Elapsed | Tokens | Text preview | Diagnostic |",
         "|---|---|---|---:|---:|---:|---|---|",
-    ]
+    ])
     for probe in result["probes"]:
         tokens = (
             f"{_render_token_count(probe.input_tokens)}/"

--- a/api_relay_audit/transparent_log.py
+++ b/api_relay_audit/transparent_log.py
@@ -2,11 +2,13 @@
 
 Records every API request made during an audit run with timestamp,
 URL, SHA-256 of request/response bytes, status code, response
-headers, and transport metadata. **Hash only, not body** — keeps
+headers, TLS-verification state, and transport metadata. **Hash only, not body** — keeps
 entries <=1.5 KB and avoids credential-at-rest risk.
 
-TLS metadata capture is deferred to a follow-up commit; the
+TLS protocol/cipher capture is deferred to a follow-up commit; the
 ``tls_version`` and ``tls_cipher`` fields are always ``null`` for now.
+``tls_verification_disabled`` records whether the individual request
+used explicitly authorised curl ``-k``.
 """
 
 import hashlib

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 722d1c65bf44ee9c8dff2a62a826800db09f2d3419396c739d6d19fcec63190a
-# standalone_body_sha256: 8040f23082bd40681bfdefc52a52af0d3657de5567df51fef3b05d1fab7cd54a
+# source_sha256: e77f094760d1c2cf5c8ae42e18a84d8c13a46c1df4e3bfc4c9219094d1d27132
+# standalone_body_sha256: 702215d4ec811bae1e06173a7be1a19fd88f9202e99dc05fbdf2e25ca2121354
 # END GENERATED STANDALONE HEADER
 
 """
@@ -54,11 +54,13 @@ from urllib.parse import urlparse
 
 Records every API request made during an audit run with timestamp,
 URL, SHA-256 of request/response bytes, status code, response
-headers, and transport metadata. **Hash only, not body** — keeps
+headers, TLS-verification state, and transport metadata. **Hash only, not body** — keeps
 entries <=1.5 KB and avoids credential-at-rest risk.
 
-TLS metadata capture is deferred to a follow-up commit; the
+TLS protocol/cipher capture is deferred to a follow-up commit; the
 ``tls_version`` and ``tls_cipher`` fields are always ``null`` for now.
+``tls_verification_disabled`` records whether the individual request
+used explicitly authorised curl ``-k``.
 """
 
 import hashlib
@@ -620,7 +622,15 @@ def curl_loopback_no_proxy_args(url: str) -> list:
     return []
 
 
+def curl_insecure_tls_args(url: str, allow_insecure_tls: bool = False) -> list:
+    """Return ``-k`` only for explicitly authorised HTTPS requests."""
+    if allow_insecure_tls and urlparse(url).scheme.lower() == "https":
+        return ["-k"]
+    return []
+
+
 def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
+                   allow_insecure_tls: bool = False,
                    subprocess_module=subprocess) -> dict:
     """POST JSON through curl while keeping headers out of argv.
 
@@ -637,7 +647,8 @@ def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
             json.dump(body, tmp)
             body_path = tmp.name
 
-        cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), "-X", "POST", url,
+        cmd = ["curl", "-s", *curl_insecure_tls_args(url, allow_insecure_tls),
+               *curl_loopback_no_proxy_args(url), "-X", "POST", url,
                "--max-time", str(timeout), "--config", "-", "--data-binary", f"@{body_path}"]
         config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
         r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
@@ -657,9 +668,11 @@ def curl_post_json(url: str, headers: dict, body: dict, timeout: int,
 
 
 def curl_get_json_data(url: str, headers: dict, timeout: int = 15,
+                       allow_insecure_tls: bool = False,
                        subprocess_module=subprocess) -> list:
     """GET JSON through curl and return the top-level ``data`` list."""
-    cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), url,
+    cmd = ["curl", "-s", *curl_insecure_tls_args(url, allow_insecure_tls),
+           *curl_loopback_no_proxy_args(url), url,
            "--max-time", str(timeout), "--config", "-"]
     config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
     r = subprocess_module.run(cmd, capture_output=True, text=True, input=config,
@@ -675,10 +688,12 @@ def curl_get_json_data(url: str, headers: dict, timeout: int = 15,
 
 def curl_raw_request(method: str, url: str, headers: dict, body: bytes,
                      content_type: str, timeout: int, parser,
+                     allow_insecure_tls: bool = False,
                      subprocess_module=subprocess) -> dict:
     """Raw request through curl and parse ``curl -i`` output with ``parser``."""
     all_headers = {**headers, "content-type": content_type}
-    cmd = ["curl", "-sk", *curl_loopback_no_proxy_args(url), "-i", "-X", method, url,
+    cmd = ["curl", "-s", *curl_insecure_tls_args(url, allow_insecure_tls),
+           *curl_loopback_no_proxy_args(url), "-i", "-X", method, url,
            "--max-time", str(timeout), "--data-binary", "@-"]
     for k, v in all_headers.items():
         cmd.extend(["-H", f"{k}: {v}"])
@@ -694,15 +709,20 @@ def curl_raw_request(method: str, url: str, headers: dict, body: bytes,
     except Exception as e:
         return {"status": 0, "headers": {}, "body": "", "error": str(e)}
 
-def httpx_post_json(url: str, headers: dict, body: dict, timeout: int) -> dict:
+def httpx_post_json(url: str, headers: dict, body: dict, timeout: int,
+                    allow_insecure_tls: bool = False) -> dict:
     """Standalone compatibility wrapper: use curl for the modular httpx slot."""
-    return curl_post_json(url, headers, body, timeout)
+    return curl_post_json(
+        url, headers, body, timeout, allow_insecure_tls=allow_insecure_tls
+    )
 
 
-def httpx_get_json_data(url: str, headers: dict, timeout: int = 15):
+def httpx_get_json_data(url: str, headers: dict, timeout: int = 15,
+                        allow_insecure_tls: bool = False):
     """Standalone compatibility wrapper: GET JSON through curl -i."""
     cmd = [
-        "curl", "-sk", *curl_loopback_no_proxy_args(url),
+        "curl", "-s", *curl_insecure_tls_args(url, allow_insecure_tls),
+        *curl_loopback_no_proxy_args(url),
         "-i", url, "--max-time", str(timeout), "--config", "-"
     ]
     config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
@@ -728,7 +748,8 @@ def httpx_get_json_data(url: str, headers: dict, timeout: int = 15):
 
 
 def httpx_raw_request(method: str, url: str, headers: dict, body: bytes,
-                      content_type: str, timeout: int) -> dict:
+                      content_type: str, timeout: int,
+                      allow_insecure_tls: bool = False) -> dict:
     """Standalone compatibility wrapper: raw request through curl -i."""
     return curl_raw_request(
         method,
@@ -738,11 +759,13 @@ def httpx_raw_request(method: str, url: str, headers: dict, body: bytes,
         content_type,
         timeout,
         parser=_parse_curl_i_output,
+        allow_insecure_tls=allow_insecure_tls,
     )
 
 
 class _StandaloneTransport:
     curl_loopback_no_proxy_args = staticmethod(curl_loopback_no_proxy_args)
+    curl_insecure_tls_args = staticmethod(curl_insecure_tls_args)
     curl_post_json = staticmethod(curl_post_json)
     httpx_post_json = staticmethod(httpx_post_json)
     curl_get_json_data = staticmethod(curl_get_json_data)
@@ -767,8 +790,10 @@ Eliminates duplicated API calling logic across scripts.
 import hashlib
 import json
 import subprocess
+import sys
 import time
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 
 
@@ -799,7 +824,7 @@ def _extract_anthropic_text(content) -> str:
 
 
 def _parse_curl_i_output(output: str) -> dict:
-    """Parse ``curl -i`` (or ``curl -sk -i``) stdout into a response dict.
+    """Parse ``curl -s [-k] -i`` stdout into a response dict.
 
     Handles HTTP/1.x and HTTP/2 status lines and normalises ``\\r\\n`` line
     endings. A leading ``HTTP/X 100 Continue`` preface is skipped so the
@@ -1031,8 +1056,9 @@ class APIClient:
     On the first ``call()``, the client tries the Anthropic native message
     format and, if that fails, falls back to the OpenAI-compatible
     ``/chat/completions`` endpoint.  If a Python-level SSL error is
-    encountered, the transport silently switches to a ``curl -sk``
-    subprocess so the audit can continue against self-signed relays.
+    encountered, the transport switches to a certificate-verifying curl
+    subprocess. Certificate verification is disabled only when the caller
+    explicitly authorises it.
 
     Attributes:
         base_url: Root URL of the relay (trailing slash stripped).
@@ -1040,10 +1066,13 @@ class APIClient:
         model: Model identifier forwarded to the relay.
         timeout: Per-request timeout in seconds.
         verbose: If ``True``, diagnostic messages are printed to stdout.
+        allow_insecure_tls: Whether HTTPS curl requests may disable certificate
+            verification. Defaults to False.
     """
 
     def __init__(self, base_url: str, api_key: str, model: str,
-                 timeout: int = 120, verbose: bool = True):
+                 timeout: int = 120, verbose: bool = True,
+                 allow_insecure_tls: bool = False):
         """Initialise the client.
 
         Args:
@@ -1053,14 +1082,20 @@ class APIClient:
             model: Model identifier to include in every request body.
             timeout: HTTP / curl timeout in seconds. Defaults to 120.
             verbose: Whether to print diagnostic log lines. Defaults to True.
+            allow_insecure_tls: Permit curl to use ``-k`` for HTTPS requests.
+                Defaults to False. Merely granting permission does not mark it
+                as used; an HTTPS request must actually run through curl.
         """
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.model = model
         self.timeout = timeout
         self.verbose = verbose
+        self.allow_insecure_tls = allow_insecure_tls
         self._format = None   # "anthropic" | "openai" | None (auto)
         self._use_curl = True
+        self._insecure_tls_used = False
+        self._insecure_tls_warning_emitted = False
         self._transparent_logger = None  # Optional[TransparentLogger]
 
     @property
@@ -1073,15 +1108,48 @@ class APIClient:
         """
         return self._format
 
+    @property
+    def insecure_tls_used(self) -> bool:
+        """Return whether an HTTPS curl request actually disabled TLS checks."""
+        return self._insecure_tls_used
+
     def _log(self, msg: str):
         if self.verbose:
             print(msg)
+
+    def _authorise_insecure_tls_for(self, url: str) -> bool:
+        """Mark and authorise ``curl -k`` for one HTTPS request if allowed."""
+        authorised = (
+            self.allow_insecure_tls
+            and urlparse(url).scheme.lower() == "https"
+        )
+        if not authorised:
+            return False
+        self._insecure_tls_used = True
+        if not self._insecure_tls_warning_emitted:
+            print(
+                "  [WARNING] TLS certificate verification disabled for an HTTPS "
+                "curl request (--allow-insecure-tls). Audit evidence integrity is reduced.",
+                file=sys.stderr,
+            )
+            self._insecure_tls_warning_emitted = True
+        return True
+
+    def _tls_verification_disabled_for(self, url: str) -> bool:
+        """Return the per-request TLS state used by transparent logging."""
+        return bool(
+            self._use_curl
+            and self.allow_insecure_tls
+            and urlparse(url).scheme.lower() == "https"
+        )
 
     # -- Low-level transport --------------------------------------------------
 
     def _curl_post(self, url: str, headers: dict, body: dict) -> dict:
         return _transport.curl_post_json(
-            url, headers, body, self.timeout, subprocess_module=subprocess)
+            url, headers, body, self.timeout,
+            allow_insecure_tls=self._authorise_insecure_tls_for(url),
+            subprocess_module=subprocess)
 
     def _post(self, url: str, headers: dict, body: dict) -> dict:
         if self._use_curl:
@@ -1300,10 +1368,14 @@ class APIClient:
         return anthropic_result or openai_result or self._error_result("Both formats failed")
 
     def _handle_ssl_error(self, e: Exception) -> bool:
-        """Switch to curl on SSL errors. Returns True if retry is warranted."""
+        """Switch to curl on SSL/connect errors. Returns True for one retry.
+
+        Curl still verifies certificates unless ``allow_insecure_tls`` was
+        explicitly enabled by the caller.
+        """
         if not self._use_curl and ("SSL" in str(e) or "Connect" in type(e).__name__):
             self._use_curl = True
-            self._log("  [transport] Python SSL error, switching to curl")
+            self._log("  [transport] Python SSL/connect error, switching to curl")
             return True
         return False
 
@@ -1346,6 +1418,7 @@ class APIClient:
             "response_headers": response_headers,
             "tls_version": None,   # deferred to follow-up commit
             "tls_cipher": None,    # deferred to follow-up commit
+            "tls_verification_disabled": self._tls_verification_disabled_for(url),
             "elapsed_seconds": round(elapsed, 3),
             "transport": "curl" if self._use_curl else "httpx",
             "error": redact_error(error),
@@ -1386,7 +1459,9 @@ class APIClient:
             try:
                 if self._use_curl:
                     data = _transport.curl_get_json_data(
-                        url, headers, subprocess_module=subprocess)
+                        url, headers,
+                        allow_insecure_tls=self._authorise_insecure_tls_for(url),
+                        subprocess_module=subprocess)
                     if data:
                         self._log_transparent(
                             "get_models", url, "GET", None,
@@ -1479,12 +1554,14 @@ class APIClient:
                           body: bytes, content_type: str, timeout: int) -> dict:
         """Curl-based fallback for ``raw_request``.
 
-        Uses ``curl -sk -i -X <method>`` to capture both headers and body
-        on stdout. Ignores self-signed certificate errors (``-k``).
+        Uses ``curl -s -i -X <method>`` to capture both headers and body
+        on stdout. ``-k`` is added only for explicitly authorised HTTPS.
         """
         return _transport.curl_raw_request(
             method, url, headers, body, content_type, timeout,
-            parser=_parse_curl_i_output, subprocess_module=subprocess)
+            parser=_parse_curl_i_output,
+            allow_insecure_tls=self._authorise_insecure_tls_for(url),
+            subprocess_module=subprocess)
 
     # -- Streaming (Step 10 stream integrity) --------------------------------
 
@@ -1589,7 +1666,11 @@ class APIClient:
         incremental stream.
         """
         cmd = [
-            "curl", "-sk", *_transport.curl_loopback_no_proxy_args(url),
+            "curl", "-s",
+            *_transport.curl_insecure_tls_args(
+                url, self._authorise_insecure_tls_for(url)
+            ),
+            *_transport.curl_loopback_no_proxy_args(url),
             "-N", "--no-buffer", "-X", "POST", url,
             "--max-time", str(timeout),
             "-w", f"\n{CURL_STATUS_SENTINEL}%{{http_code}}\n",
@@ -2001,12 +2082,14 @@ def _render_status(status: int) -> str:
 def _next_step(verdict: str, client) -> str:
     url = shlex.quote(client.base_url)
     model = shlex.quote(client.model)
+    insecure_tls_flag = " --allow-insecure-tls" if client.insecure_tls_used else ""
     if verdict in ("OK", "WARNING"):
         return (
             "Connectivity reached at least one chat format. For the full security audit, run:\n\n"
             "```bash\n"
             "export API_RELAY_AUDIT_KEY=sk-...\n"
-            f"python3 audit.py --key \"$API_RELAY_AUDIT_KEY\" --url {url} --model {model} --output report.md\n"
+            f"python3 audit.py --key \"$API_RELAY_AUDIT_KEY\" --url {url} "
+            f"--model {model}{insecure_tls_flag} --output report.md\n"
             "```"
         )
     return (
@@ -2030,11 +2113,20 @@ def render_connectivity_report(result: dict) -> str:
         "",
         "This is a quick connectivity check, not a security audit. It does not produce a LOW/MEDIUM/HIGH risk rating.",
         "",
+    ]
+    if client.insecure_tls_used:
+        lines.extend([
+            "> **WARNING:** TLS certificate verification was disabled for one or "
+            "more HTTPS requests under explicit `--allow-insecure-tls` authorization. "
+            "Connectivity was observed, but the transport was not authenticated end to end.",
+            "",
+        ])
+    lines.extend([
         "## Probe Results",
         "",
         "| Format | Endpoint | Auth style | HTTP status | Elapsed | Tokens | Text preview | Diagnostic |",
         "|---|---|---|---:|---:|---:|---|---|",
-    ]
+    ])
     for probe in result["probes"]:
         tokens = (
             f"{_render_token_count(probe.input_tokens)}/"
@@ -5064,6 +5156,12 @@ def parse_args():
                    help="Send N benign requests before the audit to mitigate "
                         "request-count-gated backdoors (AC-1.b). Default: 0")
     p.add_argument("--timeout", type=int, default=120, help="Request timeout in seconds")
+    p.add_argument("--allow-insecure-tls",
+        action="store_true",
+        help="Explicitly allow HTTPS curl requests to disable certificate "
+             "verification. Use only for relays with a known self-signed "
+             "certificate; actual use raises a LOW audit to MEDIUM.",
+    )
     p.add_argument("--output", default=None, help="Report output path (markdown)")
     p.add_argument("--transparent-log", default=None, metavar="PATH",
                    help="Path to an append-only JSONL forensic log (arXiv §7.3). "
@@ -6482,7 +6580,13 @@ def _run_step(name, reporter, step_fn, *args, default=None, crashes=None):
 
 def main():
     args = parse_args()
-    client = APIClient(args.url, args.key, args.model, timeout=args.timeout)
+    client = APIClient(
+        args.url,
+        args.key,
+        args.model,
+        timeout=args.timeout,
+        allow_insecure_tls=args.allow_insecure_tls,
+    )
 
     # v1.7.7: transparent forensic log (arXiv §7.3)
     _transparent_logger = None
@@ -6698,6 +6802,14 @@ def main():
     #   d1i or d2i or d3i or d4i or d4m or d5i or d6i or any_crashed -> MEDIUM
     #   else                                        -> LOW
     report.h2("14. Overall Rating")
+    tls_evidence_degraded = client.insecure_tls_used
+    if tls_evidence_degraded:
+        report.flag(
+            "yellow",
+            "TLS certificate verification was disabled for one or more HTTPS "
+            "curl requests under explicit `--allow-insecure-tls` authorization. "
+            "This is an evidence-integrity qualifier outside the 6D attack matrix.",
+        )
     any_step_crashed = bool(step_crashes)
     d1 = injection is not None and injection > 100
     d1i = injection is None
@@ -6761,7 +6873,8 @@ def main():
     elif d2:
         report.p("### MEDIUM RISK\n")
         report.p("No significant injection but instruction override detected.")
-    elif d1i or d2i or d3i or d4i or d4m or d5i or d6i or any_step_crashed:
+    elif (d1i or d2i or d3i or d4i or d4m or d5i or d6i
+          or any_step_crashed or tls_evidence_degraded):
         report.p("### MEDIUM RISK\n")
         medium_reasons = []
         if any_step_crashed:
@@ -6810,6 +6923,12 @@ def main():
                 "Web3 prompt injection test (Step 11) was **inconclusive**: all "
                 "three Web3 probes errored or produced ambiguous responses, so "
                 "Web3 safety behavior could not be verified."
+            )
+        if tls_evidence_degraded:
+            medium_reasons.append(
+                "TLS certificate verification was **disabled** for at least one "
+                "HTTPS request. The relay results may be usable for diagnostics, "
+                "but the transport evidence is not authenticated end to end."
             )
         report.p(" ".join(medium_reasons))
     else:

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,23 +16,23 @@
 | 单文件版版本 | `v2.3.1` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **802** | `pytest --collect-only` |
-| 测试数 (static) | 774 | grep `def test_*` in tests/ |
-| CLI flag 数 | 21 | grep `add_argument("--*")` |
+| 测试数 (pytest) | **816** | `pytest --collect-only` |
+| 测试数 (static) | 785 | grep `def test_*` in tests/ |
+| CLI flag 数 | 22 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-08-16 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
-| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 802] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `0eeadb1` | recent reachable commit; `--check` allows follow-up metrics commits |
+| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 802, 816] | grep `Final test count: N/N passing` |
+| Recorded commit SHA | `d291b25` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-08-16 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.3.1`。
 - ✅ 步骤数一致：14。
-- ℹ️ pytest (802) vs 静态 (774) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
+- ℹ️ pytest (816) vs 静态 (785) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/docs/python-code-explanation-zh.md
+++ b/docs/python-code-explanation-zh.md
@@ -120,7 +120,7 @@ client.call(messages, system=None, max_tokens=512)
 
 1. 统一不同供应商风格的请求格式。
 2. 自动探测 relay 究竟暴露的是 Anthropic 风格还是 OpenAI 风格。
-3. 在 Python HTTP 栈遇到 SSL/连接异常时，自动切换到 `curl -sk`。
+3. 在 Python HTTP 栈遇到 SSL/连接异常时，自动切换到仍验证证书的 `curl -s`；只有显式传入 `--allow-insecure-tls` 且实际请求为 HTTPS 时才追加 `-k`。
 4. 把两种协议的返回值归一化为同一数据结构。
 
 这几个目标叠在一起，形成了两个正交维度的状态：
@@ -139,8 +139,10 @@ client.call(messages, system=None, max_tokens=512)
 - `model`
 - `timeout`
 - `verbose`
+- `allow_insecure_tls = False`
 - `_format = None`
 - `_use_curl = False`
+- `_insecure_tls_used = False`
 
 其中 `_format` 的取值有三种：
 
@@ -155,7 +157,7 @@ client.call(messages, system=None, max_tokens=512)
 低层发送路径有两条：
 
 - `_post()`：常规路径，默认用 `httpx.post()`。
-- `_curl_post()`：降级路径，用子进程执行 `curl -sk`。
+- `_curl_post()`：降级路径，用子进程执行 `curl -s`，默认保持证书验证。
 
 #### `_post()` 的行为
 
@@ -171,17 +173,15 @@ client.call(messages, system=None, max_tokens=512)
 `_curl_post()` 构造的命令大致是：
 
 ```bash
-curl -sk -X POST URL --max-time TIMEOUT -H ... -d JSON
+curl -s [-k] -X POST URL --max-time TIMEOUT --config - --data-binary @BODY_FILE
 ```
 
-这里 `-sk` 的含义很关键：
+这里两个参数的边界很关键：
 
 - `-s`：静默输出。
-- `-k`：跳过证书校验。
+- `-k`：仅在 `--allow-insecure-tls` 已授权、目标是 HTTPS、且请求实际走 curl 时追加，用来跳过证书校验。
 
-这说明项目明确接受一个现实：很多被审计的 relay 可能挂在自签名证书、错误链路或者不规范 TLS 配置后面。审计工具的目标不是“严格拒绝不安全连接”，而是“尽可能继续把实验跑完”。
-
-这是典型的安全审计工具思维，而不是生产 SDK 思维。
+这使“换一种传输实现”和“降低 TLS 验证”成为两个独立决定：前者可以自动发生，后者必须由用户显式授权。仅仅传 flag 但没有实际走 HTTPS curl，不会把 `insecure_tls_used` 标为真。
 
 ### 3.4 协议适配：Anthropic 与 OpenAI 两套请求构造
 
@@ -284,7 +284,7 @@ OpenAI 也用同样的“非空文本”作为成功标准。
 
 代价是：如果 relay 在会话期间切换后端、或者不同路径支持不同协议，这个缓存结论可能不再成立。但对这个项目的目标来说，这个假设是合理的，因为审计对象通常是一个相对稳定的单个入口。
 
-### 3.7 SSL fallback：为什么是 `curl -sk`
+### 3.7 SSL fallback：安全 curl 重试与显式 `-k` 授权
 
 `_handle_ssl_error()` 的策略很简单：
 
@@ -303,9 +303,9 @@ OpenAI 也用同样的“非空文本”作为成功标准。
 
 换句话说，切到 curl 并不会自动决定“我要用 Anthropic 还是 OpenAI”，它只是在说：“同样的请求体，以另一种传输手段再试一次。”
 
-第三，这个回退本质上是“为了拿到结果而放松验证”。
+第三，这个回退只是“为了拿到结果而更换传输实现”，不会自动放松验证。
 
-生产 SDK 把证书校验关掉通常是坏实践；但安全审计工具面对的是“可疑系统”，核心目标是观测行为，而不是保障通信链的生产级可信性。因此这里更像一种故障旁路。
+Curl 默认继续验证证书。只有用户明确提供 `--allow-insecure-tls` 后，HTTPS curl 才使用 `-k`。第一次实际使用会告警，透明日志记录 `tls_verification_disabled: true`，完整审计的 LOW 结果至少提升为 MEDIUM；已有 HIGH 不受影响。这一状态属于证据完整性门，不新增 D7。
 
 ### 3.8 SSL fallback 的一个不对称细节
 
@@ -592,6 +592,7 @@ for k in range(lo, hi + 1, 10):
 - `--skip-infra`
 - `--skip-context`
 - `--timeout`
+- `--allow-insecure-tls`
 - `--output`
 
 其中：
@@ -1155,7 +1156,7 @@ pattern = rf"### {re.escape(test_name)}\s*\n\n(.*?)(?=\n###|\n##|$)"
 
 典型例子包括：
 
-- SSL 出问题就切 `curl -sk`
+- SSL/连接出问题可切换到安全 curl；跳过证书验证必须显式授权
 - token 注入用经验 delta，而不是严谨 tokenizer 校准
 - 报告用 Markdown，而不是正式 schema
 - 抽取靠正则，而不是 AST 或结构化中间表示

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -224,6 +224,12 @@ def parse_args():
                    help="Send N benign requests before the audit to mitigate "
                         "request-count-gated backdoors (AC-1.b). Default: 0")
     p.add_argument("--timeout", type=int, default=120, help="Request timeout in seconds")
+    p.add_argument("--allow-insecure-tls",
+        action="store_true",
+        help="Explicitly allow HTTPS curl requests to disable certificate "
+             "verification. Use only for relays with a known self-signed "
+             "certificate; actual use raises a LOW audit to MEDIUM.",
+    )
     p.add_argument("--output", default=None, help="Report output path (markdown)")
     p.add_argument("--transparent-log", default=None, metavar="PATH",
                    help="Path to an append-only JSONL forensic log (arXiv §7.3). "
@@ -1642,7 +1648,13 @@ def _run_step(name, reporter, step_fn, *args, default=None, crashes=None):
 
 def main():
     args = parse_args()
-    client = APIClient(args.url, args.key, args.model, timeout=args.timeout)
+    client = APIClient(
+        args.url,
+        args.key,
+        args.model,
+        timeout=args.timeout,
+        allow_insecure_tls=args.allow_insecure_tls,
+    )
 
     # v1.7.7: transparent forensic log (arXiv §7.3)
     _transparent_logger = None
@@ -1859,6 +1871,14 @@ def main():
     #   d1i or d2i or d3i or d4i or d4m or d5i or d6i or any_crashed -> MEDIUM
     #   else                                        -> LOW
     report.h2("14. Overall Rating")
+    tls_evidence_degraded = client.insecure_tls_used
+    if tls_evidence_degraded:
+        report.flag(
+            "yellow",
+            "TLS certificate verification was disabled for one or more HTTPS "
+            "curl requests under explicit `--allow-insecure-tls` authorization. "
+            "This is an evidence-integrity qualifier outside the 6D attack matrix.",
+        )
     any_step_crashed = bool(step_crashes)
     d1 = injection is not None and injection > 100
     d1i = injection is None
@@ -1922,7 +1942,8 @@ def main():
     elif d2:
         report.p("### MEDIUM RISK\n")
         report.p("No significant injection but instruction override detected.")
-    elif d1i or d2i or d3i or d4i or d4m or d5i or d6i or any_step_crashed:
+    elif (d1i or d2i or d3i or d4i or d4m or d5i or d6i
+          or any_step_crashed or tls_evidence_degraded):
         report.p("### MEDIUM RISK\n")
         medium_reasons = []
         if any_step_crashed:
@@ -1971,6 +1992,12 @@ def main():
                 "Web3 prompt injection test (Step 11) was **inconclusive**: all "
                 "three Web3 probes errored or produced ambiguous responses, so "
                 "Web3 safety behavior could not be verified."
+            )
+        if tls_evidence_degraded:
+            medium_reasons.append(
+                "TLS certificate verification was **disabled** for at least one "
+                "HTTPS request. The relay results may be usable for diagnostics, "
+                "but the transport evidence is not authenticated end to end."
             )
         report.p(" ".join(medium_reasons))
     else:

--- a/scripts/build-standalone.py
+++ b/scripts/build-standalone.py
@@ -64,15 +64,20 @@ class Section:
 
 
 STANDALONE_TRANSPORT_WRAPPERS = r'''
-def httpx_post_json(url: str, headers: dict, body: dict, timeout: int) -> dict:
+def httpx_post_json(url: str, headers: dict, body: dict, timeout: int,
+                    allow_insecure_tls: bool = False) -> dict:
     """Standalone compatibility wrapper: use curl for the modular httpx slot."""
-    return curl_post_json(url, headers, body, timeout)
+    return curl_post_json(
+        url, headers, body, timeout, allow_insecure_tls=allow_insecure_tls
+    )
 
 
-def httpx_get_json_data(url: str, headers: dict, timeout: int = 15):
+def httpx_get_json_data(url: str, headers: dict, timeout: int = 15,
+                        allow_insecure_tls: bool = False):
     """Standalone compatibility wrapper: GET JSON through curl -i."""
     cmd = [
-        "curl", "-sk", *curl_loopback_no_proxy_args(url),
+        "curl", "-s", *curl_insecure_tls_args(url, allow_insecure_tls),
+        *curl_loopback_no_proxy_args(url),
         "-i", url, "--max-time", str(timeout), "--config", "-"
     ]
     config = "\n".join(f'header = "{k}: {v}"' for k, v in headers.items())
@@ -98,7 +103,8 @@ def httpx_get_json_data(url: str, headers: dict, timeout: int = 15):
 
 
 def httpx_raw_request(method: str, url: str, headers: dict, body: bytes,
-                      content_type: str, timeout: int) -> dict:
+                      content_type: str, timeout: int,
+                      allow_insecure_tls: bool = False) -> dict:
     """Standalone compatibility wrapper: raw request through curl -i."""
     return curl_raw_request(
         method,
@@ -108,11 +114,13 @@ def httpx_raw_request(method: str, url: str, headers: dict, body: bytes,
         content_type,
         timeout,
         parser=_parse_curl_i_output,
+        allow_insecure_tls=allow_insecure_tls,
     )
 
 
 class _StandaloneTransport:
     curl_loopback_no_proxy_args = staticmethod(curl_loopback_no_proxy_args)
+    curl_insecure_tls_args = staticmethod(curl_insecure_tls_args)
     curl_post_json = staticmethod(curl_post_json)
     httpx_post_json = staticmethod(httpx_post_json)
     curl_get_json_data = staticmethod(curl_get_json_data)

--- a/scripts/context-test.py
+++ b/scripts/context-test.py
@@ -25,12 +25,23 @@ def parse_args():
     p.add_argument("--url", required=True, help="Base URL (e.g. https://xxx.com/v1)")
     p.add_argument("--model", default="claude-opus-4-6", help="Model name")
     p.add_argument("--timeout", type=int, default=120, help="Request timeout (seconds)")
+    p.add_argument(
+        "--allow-insecure-tls",
+        action="store_true",
+        help="Explicitly allow HTTPS curl requests to disable certificate verification.",
+    )
     return p.parse_args()
 
 
 def main():
     args = parse_args()
-    client = APIClient(args.url, args.key, args.model, timeout=args.timeout)
+    client = APIClient(
+        args.url,
+        args.key,
+        args.model,
+        timeout=args.timeout,
+        allow_insecure_tls=args.allow_insecure_tls,
+    )
 
     print(f"Context truncation test | {client.base_url} | {args.model}")
     print("=" * 50)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -49,9 +49,15 @@ class TestInit:
         assert client._use_curl is False
         assert client.timeout == 30
         assert client.verbose is False
+        assert client.allow_insecure_tls is False
+        assert client.insecure_tls_used is False
 
     def test_detected_format_initially_none(self, client):
         assert client.detected_format is None
+
+    def test_insecure_tls_used_is_read_only(self, client):
+        with pytest.raises(AttributeError):
+            client.insecure_tls_used = True
 
 
 # ---------------------------------------------------------------------------
@@ -318,7 +324,8 @@ class TestCurlFallback:
 
         cmd = mock_run.call_args[0][0]
         assert cmd[0] == "curl"
-        assert "-sk" in cmd
+        assert "-s" in cmd
+        assert "-k" not in cmd
         assert "https://relay.example.com/v1/messages" in cmd
         assert "--config" in cmd
         assert "-" in cmd
@@ -329,6 +336,51 @@ class TestCurlFallback:
         assert '{"model": "test"}' not in cmd
         config_input = mock_run.call_args[1].get("input", "")
         assert "x-api-key: sk-test" in config_input
+
+    @patch("api_relay_audit.client.subprocess.run")
+    def test_curl_post_uses_k_only_for_authorised_https(self, mock_run):
+        client = APIClient(
+            "https://relay.example.com/v1", "key", "model",
+            verbose=True, allow_insecure_tls=True,
+        )
+        client._use_curl = True
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"ok": true}')
+
+        client._curl_post("https://relay.example.com/v1/messages", {}, {})
+
+        cmd = mock_run.call_args[0][0]
+        assert "-s" in cmd
+        assert "-k" in cmd
+        assert client.insecure_tls_used is True
+
+    @patch("api_relay_audit.client.subprocess.run")
+    def test_insecure_tls_permission_is_not_used_for_http(self, mock_run):
+        client = APIClient(
+            "http://relay.example.com/v1", "key", "model",
+            verbose=False, allow_insecure_tls=True,
+        )
+        client._use_curl = True
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"ok": true}')
+
+        client._curl_post("http://relay.example.com/v1/messages", {}, {})
+
+        assert "-k" not in mock_run.call_args[0][0]
+        assert client.insecure_tls_used is False
+
+    @patch("api_relay_audit.client.subprocess.run")
+    def test_insecure_tls_warning_is_emitted_once(self, mock_run, capsys):
+        client = APIClient(
+            "https://relay.example.com/v1", "key", "model",
+            verbose=True, allow_insecure_tls=True,
+        )
+        client._use_curl = True
+        mock_run.return_value = MagicMock(returncode=0, stdout='{"ok": true}')
+
+        client._curl_post("https://relay.example.com/v1/messages", {}, {})
+        client._curl_post("https://relay.example.com/v1/messages", {}, {})
+
+        output = capsys.readouterr().err
+        assert output.count("TLS certificate verification disabled") == 1
 
     @patch("api_relay_audit.client.subprocess.run")
     def test_curl_post_bypasses_proxy_for_loopback(self, mock_run, client):
@@ -368,6 +420,7 @@ class TestCurlFallback:
         cmd = mock_run.call_args[0][0]
         assert "--noproxy" in cmd
         assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
+        assert "-k" not in cmd
 
     @patch("api_relay_audit.client.subprocess.run")
     def test_curl_raw_request_bypasses_proxy_for_loopback(self, mock_run):
@@ -393,6 +446,49 @@ class TestCurlFallback:
         cmd = mock_run.call_args[0][0]
         assert "--noproxy" in cmd
         assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
+        assert "-k" not in cmd
+
+    @patch("api_relay_audit.client.subprocess.run")
+    def test_authorised_https_get_and_raw_commands_use_k(self, mock_run):
+        client = APIClient(
+            "https://relay.example.com/v1", "key", "model",
+            verbose=False, allow_insecure_tls=True,
+        )
+        client._use_curl = True
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({"data": [{"id": "m1"}]})),
+            MagicMock(
+                returncode=0,
+                stdout=b"HTTP/1.1 400 Bad Request\r\n\r\nbad",
+                stderr=b"",
+            ),
+        ]
+
+        assert client.get_models() == [{"id": "m1"}]
+        client.raw_request("POST", "/v1/messages", {}, b"{}")
+
+        assert "-k" in mock_run.call_args_list[0][0][0]
+        assert "-k" in mock_run.call_args_list[1][0][0]
+        assert client.insecure_tls_used is True
+
+    @patch("api_relay_audit.client.subprocess.run")
+    def test_https_get_and_raw_commands_verify_tls_by_default(self, mock_run, client):
+        client._use_curl = True
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({"data": [{"id": "m1"}]})),
+            MagicMock(
+                returncode=0,
+                stdout=b"HTTP/1.1 400 Bad Request\r\n\r\nbad",
+                stderr=b"",
+            ),
+        ]
+
+        client.get_models()
+        client.raw_request("POST", "/v1/messages", {}, b"{}")
+
+        assert "-k" not in mock_run.call_args_list[0][0][0]
+        assert "-k" not in mock_run.call_args_list[1][0][0]
+        assert client.insecure_tls_used is False
 
 
 # ---------------------------------------------------------------------------
@@ -509,6 +605,8 @@ class TestAutoDetection:
             result = verbose_client.call([{"role": "user", "content": "hi"}])
 
         assert verbose_client._use_curl is True
+        assert verbose_client.insecure_tls_used is False
+        assert "-k" not in mock_run.call_args[0][0]
 
     @patch("api_relay_audit.client.httpx.post")
     def test_exception_returns_error_with_time(self, mock_post, client):

--- a/tests/test_client_stream.py
+++ b/tests/test_client_stream.py
@@ -490,8 +490,10 @@ class TestCurlNonzeroExitHandling:
         """Regression guard: a clean curl exit (returncode 0) must NOT
         set transport_error, even for streams without any events."""
         from io import BytesIO
+        captured_cmds = []
 
-        def mock_popen_factory(*args, **kwargs):
+        def mock_popen_factory(cmd, *args, **kwargs):
+            captured_cmds.append(cmd)
             proc = MagicMock()
             proc.stdin = MagicMock()
             proc.stdout = BytesIO(
@@ -516,6 +518,7 @@ class TestCurlNonzeroExitHandling:
 
         assert signals.transport_error is None
         assert signals.has_message_start is True
+        assert "-k" not in captured_cmds[0]
 
     def test_curl_http_error_status_sets_transport_error_on_non_sse_body(self):
         from io import BytesIO
@@ -632,8 +635,36 @@ class TestCurlNonzeroExitHandling:
         cmd = captured_cmds[0]
         assert "--noproxy" in cmd
         assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
+        assert "-k" not in cmd
 
+    def test_authorised_https_stream_uses_k(self):
+        captured_cmds = []
 
+        def mock_popen_factory(cmd, *args, **kwargs):
+            captured_cmds.append(cmd)
+            proc = MagicMock()
+            proc.stdin = MagicMock()
+            proc.stdout = BytesIO(
+                b'data: {"type":"message_start","message":{"model":"claude"}}\n\n'
+                b'data: {"type":"message_stop"}\n\n'
+            )
+            proc.stderr = BytesIO(b"")
+            proc.wait = MagicMock(return_value=None)
+            proc.returncode = 0
+            return proc
+
+        with patch("api_relay_audit.client.subprocess.Popen",
+                   side_effect=mock_popen_factory):
+            client = APIClient(
+                "https://relay.example.com/v1", "sk-test", "claude-opus-4-6",
+                verbose=False, allow_insecure_tls=True,
+            )
+            client._use_curl = True
+            signals = client.stream_call([{"role": "user", "content": "hi"}])
+
+        assert signals.transport_error is None
+        assert "-k" in captured_cmds[0]
+        assert client.insecure_tls_used is True
 # ---------------------------------------------------------------------------
 # APIClient.stream_call (integration tests with mocked httpx)
 # ---------------------------------------------------------------------------

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -7,13 +7,15 @@ from api_relay_audit.connectivity import CONNECTIVITY_PROMPT, run_connectivity_c
 
 
 class FakeClient:
-    def __init__(self, responses, api_key="sk-secret-connectivity"):
+    def __init__(self, responses, api_key="sk-secret-connectivity",
+                 insecure_tls_used=False):
         self.base_url = "https://relay.example.com/v1"
         self.api_key = api_key
         self.model = "claude-test"
         self.timeout = 17
         self._responses = list(responses)
         self.calls = []
+        self.insecure_tls_used = insecure_tls_used
 
     def raw_request(self, method, path, headers, body, content_type, timeout):
         self.calls.append({
@@ -119,6 +121,17 @@ def test_both_formats_success_reports_ok():
     assert result["successful_formats"] == ["Anthropic Chat", "OpenAI Chat"]
     assert "9/1" in result["markdown"]
     assert "8/1" in result["markdown"]
+
+
+def test_actual_insecure_tls_use_is_prominent_and_preserved_in_next_step():
+    client = FakeClient(
+        [anthropic_ok(), openai_ok()], insecure_tls_used=True,
+    )
+
+    result = run_connectivity_check(client)
+
+    assert "TLS certificate verification was disabled" in result["markdown"]
+    assert "--allow-insecure-tls" in result["markdown"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dual_distribution_parity.py
+++ b/tests/test_dual_distribution_parity.py
@@ -12,6 +12,7 @@ focused behavior/constant regression tests for public standalone semantics.
 """
 
 import ast
+import importlib.util
 import sys
 import re
 import subprocess
@@ -450,7 +451,41 @@ def test_public_help_flags_parity():
     modular_flags = _help_option_set(REPO_ROOT / "scripts" / "audit.py")
     standalone_flags = _help_option_set(REPO_ROOT / "audit.py")
     assert "--connectivity" in modular_flags
+    assert "--allow-insecure-tls" in modular_flags
     assert modular_flags == standalone_flags
+
+    context_help = _help_text(REPO_ROOT / "scripts" / "context-test.py")
+    assert "--allow-insecure-tls" in context_help
+
+
+def test_context_test_allow_insecure_tls_wiring(monkeypatch):
+    spec = importlib.util.spec_from_file_location(
+        "context_test_cli", REPO_ROOT / "scripts" / "context-test.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    seen = {}
+
+    class FakeClient:
+        def __init__(self, base_url, api_key, model, timeout=120,
+                     allow_insecure_tls=False):
+            seen["allow_insecure_tls"] = allow_insecure_tls
+            self.base_url = base_url
+
+    monkeypatch.setattr(module, "APIClient", FakeClient)
+    monkeypatch.setattr(module, "run_context_scan", lambda client: [])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "context-test.py", "--key", "sk-test", "--url",
+            "https://relay.example.com/v1", "--allow-insecure-tls",
+        ],
+    )
+
+    module.main()
+
+    assert seen["allow_insecure_tls"] is True
 
 
 def test_profile_help_matches_current_14_step_contract():
@@ -494,11 +529,13 @@ def test_connectivity_mode_exits_before_full_audit(monkeypatch, tmp_path):
     ]
 
     class FakeClient:
-        def __init__(self, base_url, api_key, model, timeout=120):
+        def __init__(self, base_url, api_key, model, timeout=120,
+                     allow_insecure_tls=False):
             self.base_url = base_url.rstrip("/")
             self.api_key = api_key
             self.model = model
             self.timeout = timeout
+            self.insecure_tls_used = False
 
         def set_transparent_logger(self, logger):
             pass
@@ -570,7 +607,10 @@ def _run_stubbed_audit_and_rating(module, monkeypatch, tmp_path, case_name, scen
         model = "claude-test"
 
         def __init__(self, *args, **kwargs):
-            pass
+            assert kwargs.get("allow_insecure_tls") is bool(
+                scenario.get("grant_insecure_tls", False)
+            )
+            self.insecure_tls_used = scenario.get("insecure_tls_used", False)
 
         def set_transparent_logger(self, logger):
             pass
@@ -636,23 +676,22 @@ def _run_stubbed_audit_and_rating(module, monkeypatch, tmp_path, case_name, scen
     )
 
     output = tmp_path / f"{module.__name__.replace('.', '_')}-{case_name}.md"
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "audit.py",
-            "--key",
-            "sk-test",
-            "--url",
-            "https://relay.example.com/v1",
-            "--model",
-            "claude-test",
-            "--profile",
-            "full",
-            "--output",
-            str(output),
-        ],
-    )
+    argv = [
+        "audit.py",
+        "--key",
+        "sk-test",
+        "--url",
+        "https://relay.example.com/v1",
+        "--model",
+        "claude-test",
+        "--profile",
+        "full",
+        "--output",
+        str(output),
+    ]
+    if scenario.get("grant_insecure_tls"):
+        argv.append("--allow-insecure-tls")
+    monkeypatch.setattr(sys, "argv", argv)
 
     module.main()
     return _extract_overall_rating(output.read_text(encoding="utf-8"))
@@ -662,12 +701,17 @@ def _run_stubbed_audit_and_rating(module, monkeypatch, tmp_path, case_name, scen
     ("case_name", "scenario", "expected"),
     [
         ("clean", {}, "LOW"),
+        ("insecure_tls_granted_not_used", {"grant_insecure_tls": True}, "LOW"),
         ("d1_only", {"injection": 101}, "MEDIUM"),
         ("d1_and_d2", {"injection": 101, "overridden": True}, "HIGH"),
         ("d3_substitution", {"substitution_detected": True}, "HIGH"),
         ("d4_medium", {"error_severity": "medium"}, "MEDIUM"),
         ("d4_high", {"error_severity": "high"}, "HIGH"),
         ("d5_anomaly", {"stream_verdict": "anomaly"}, "HIGH"),
+        ("insecure_tls_only", {"insecure_tls_used": True}, "MEDIUM"),
+        ("insecure_tls_with_d5", {
+            "insecure_tls_used": True, "stream_verdict": "anomaly",
+        }, "HIGH"),
         ("d6_inconclusive", {"web3_inconclusive": True}, "MEDIUM"),
         ("step_crash", {"crash_step": "test_models"}, "MEDIUM"),
     ],
@@ -794,6 +838,63 @@ def test_standalone_curl_post_keeps_large_body_out_of_argv(monkeypatch):
     assert "x" * 100 not in cmd_text
     assert "sk-test" not in cmd_text
     assert "x-api-key: sk-test" in kwargs["input"]
+    assert "-k" not in cmd
+    assert client.insecure_tls_used is False
+
+
+def test_standalone_authorised_https_curl_commands_use_k(monkeypatch):
+    """The generated curl-only artifact must wire explicit TLS permission
+    through POST, raw, and SSE paths without restoring unconditional -k."""
+    from io import BytesIO
+    from unittest.mock import MagicMock
+
+    standalone = _load_standalone_audit()
+    run_calls = []
+    popen_calls = []
+
+    class FakeRunResult:
+        returncode = 0
+        stdout = '{"ok": true}'
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        run_calls.append((cmd, kwargs))
+        if "-i" in cmd:
+            return type("RawResult", (), {
+                "returncode": 0,
+                "stdout": b"HTTP/1.1 400 Bad Request\r\n\r\nbad",
+                "stderr": b"",
+            })()
+        return FakeRunResult()
+
+    def fake_popen(cmd, *args, **kwargs):
+        popen_calls.append(cmd)
+        proc = MagicMock()
+        proc.stdin = MagicMock()
+        proc.stdout = BytesIO(
+            b'data: {"type":"message_start","message":{"model":"claude"}}\n\n'
+            b'data: {"type":"message_stop"}\n\n'
+        )
+        proc.stderr = BytesIO(b"")
+        proc.wait = MagicMock(return_value=None)
+        proc.returncode = 0
+        return proc
+
+    monkeypatch.setattr(standalone.subprocess, "run", fake_run)
+    monkeypatch.setattr(standalone.subprocess, "Popen", fake_popen)
+    client = standalone.APIClient(
+        "https://relay.example.com/v1", "sk-test", "claude-opus-4-6",
+        verbose=False, allow_insecure_tls=True,
+    )
+
+    client._curl_post("https://relay.example.com/v1/messages", {}, {})
+    client.raw_request("POST", "/v1/messages", {}, b"{}")
+    client.stream_call([{"role": "user", "content": "hi"}])
+
+    assert "-k" in run_calls[0][0]
+    assert "-k" in run_calls[1][0]
+    assert "-k" in popen_calls[0]
+    assert client.insecure_tls_used is True
 
 
 def test_standalone_get_models_bypasses_proxy_for_loopback(monkeypatch):
@@ -826,6 +927,7 @@ def test_standalone_get_models_bypasses_proxy_for_loopback(monkeypatch):
     cmd, _kwargs = calls[0]
     assert "--noproxy" in cmd
     assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
+    assert "-k" not in cmd
     assert standalone._transport.curl_loopback_no_proxy_args(
         "http://127.0.0.1:8765/v1/messages"
     ) == ["--noproxy", "localhost,127.0.0.1,::1"]
@@ -868,3 +970,4 @@ def test_standalone_stream_bypasses_proxy_for_loopback(monkeypatch):
     cmd = captured_cmds[0]
     assert "--noproxy" in cmd
     assert cmd[cmd.index("--noproxy") + 1] == "localhost,127.0.0.1,::1"
+    assert "-k" not in cmd

--- a/tests/test_transparent_log.py
+++ b/tests/test_transparent_log.py
@@ -193,6 +193,7 @@ class TestClientLogIntegration:
         assert len(entry["request_body_sha256"]) == 64
         assert len(entry["response_body_sha256"]) == 64
         assert entry["error"] is None
+        assert entry["tls_verification_disabled"] is False
 
     def test_call_error_logs_entry(self, tmp_path):
         """A failed call() still logs with error field set."""
@@ -290,9 +291,32 @@ class TestClientLogIntegration:
             "timestamp", "method", "url", "http_method",
             "request_body_sha256", "response_body_sha256",
             "status_code", "response_headers", "tls_version",
-            "tls_cipher", "elapsed_seconds", "transport", "error",
+            "tls_cipher", "tls_verification_disabled", "elapsed_seconds",
+            "transport", "error",
         }
         assert required.issubset(entry.keys())
+
+    def test_actual_insecure_curl_request_is_recorded(self, tmp_path):
+        client = APIClient(
+            "https://relay.example.com/v1", "sk-test-key", "claude-test",
+            timeout=10, verbose=False, allow_insecure_tls=True,
+        )
+        client._use_curl = True
+        path = str(tmp_path / "audit.jsonl")
+        logger = TransparentLogger(path)
+        client.set_transparent_logger(logger)
+        with patch("api_relay_audit.client.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=b"HTTP/1.1 400 Bad Request\r\n\r\nbad",
+                stderr=b"",
+            )
+            client.raw_request("POST", "/v1/messages", {}, b"{}")
+        logger.close()
+
+        entry = json.loads(open(path).readline())
+        assert entry["transport"] == "curl"
+        assert entry["tls_verification_disabled"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">802</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">816</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">


### PR DESCRIPTION
## Scope

Splits the TLS-only major-version work out of #84. This draft is explicitly excluded from v2.4.0. Stream terminal completeness is already handled separately by #89 and is not changed here.

- curl verifies TLS certificates by default in modular and standalone paths
- `--allow-insecure-tls` authorizes `-k` only for actual HTTPS curl requests
- actual insecure use is warned once and recorded per request
- an otherwise LOW full audit becomes MEDIUM without adding a risk-matrix dimension
- connectivity reports the evidence downgrade without inventing a risk rating

## Breaking boundary

Self-signed relays no longer continue through implicit `curl -k`. This requires a major release and migration notes. The draft does not implement TEE attestation or change the threat taxonomy.

## Verification

- `python3 -m pytest tests/ -q` -> 816 passed
- `python3 scripts/sync-version.py --check`
- `python3 scripts/build-standalone.py --check`
- `python3 scripts/collect-metrics.py --check`
- `python3 -S audit.py --help`
- `git diff --check`

Source split from #84.