### PR TITLE
docs: fix v2.4 verification link

### DIFF
--- a/docs/releases/v2.4.md
+++ b/docs/releases/v2.4.md
@@ -33,7 +33,7 @@ dsh plugin --profile cc-tui add "github:toby-bridges/api-relay-audit#v2.4.0"
 Distribution work for this release focuses on DeepSeek Harness. Existing
 OpenClaw and Hermes skill files remain in the repository for direct users, but
 they are not v2.4 registry distribution targets. See the
-[v2.4.0 DSH verification](../distribution-verification-v2.4.0.md) for exact
+[v2.4.0 DSH verification](https://github.com/toby-bridges/api-relay-audit/blob/5c33c3d56aa3f839a7c897d8028509a2615b8805/docs/distribution-verification-v2.4.0.md) for exact
 tool versions, immutable resolution, runtime checks, and secret-scan results.
 
 ## Quick Start


### PR DESCRIPTION
## Summary

Use the immutable merge commit URL for the v2.4.0 DSH verification document so the same release note works in both repository Markdown and the public GitHub Release body.

## Verification

- `git diff --check`
- `python3 scripts/sync-version.py --check`
- `python3 -m pytest tests/test_skill_distribution.py tests/test_static_site.py -q` (19 passed)