### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ to one behavior or document.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=toby-bridges/api-relay-audit&type=Date)](https://www.star-history.com/#toby-bridges/api-relay-audit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=toby-bridges/api-relay-audit&type=Date)](https://star-history.dera.page/#toby-bridges/api-relay-audit&Date)
 
 <details id="chinese-readme">
 <summary>中文 README</summary>


### PR DESCRIPTION
The star history chart on the README is currently broken, so visitors can no longer see the project's growth at a glance. This change points the chart at a working mirror that serves both the chart image and the linked chart page, with no further configuration required.

This also restores the badge-free chart behavior that was intended, and the chart continues to track the toby-bridges/api-relay-audit repository.