### PR TITLE
feat: add structured Tool Call integrity probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use it when you rely on a third-party AI API relay, OpenAI-compatible proxy, Cla
 
 ## AI API Relay Security Audit
 
-- **Detect relay tampering:** prompt injection, prompt extraction, identity consistency signals, context truncation, tool-call rewriting, error-response leakage, and SSE stream anomalies.
+- **Detect relay tampering:** prompt injection, prompt extraction, identity consistency signals, context truncation, structured Tool Call and package-command rewriting, error-response leakage, and SSE stream anomalies.
 - **Run locally:** the standalone `audit.py` uses only Python stdlib plus `curl`; your API key is sent only to the relay URL you choose.
 - **Produce reviewable evidence:** each run generates a structured Markdown report with per-step findings and a final `LOW / MEDIUM / HIGH` verdict.
 
@@ -77,7 +77,7 @@ The canonical contract lives in [docs/query-families.md](./docs/query-families.m
 API Relay Audit checks whether a relay modifies the request or response path between you and the model:
 
 - Prompt safety: token injection, prompt extraction, instruction override, jailbreak resistance
-- Relay integrity: context truncation, tool-call substitution, error leakage, stream integrity
+- Relay integrity: context truncation, structured Tool Call and package-command substitution, error leakage, stream integrity
 - Model identity: non-Claude identity leaks, model substitution signals, Claude/OpenAI-compatible relay behavior
 - Web3 wallet safety: transfer guidance, signed-transaction refusal, private-key refusal
 
@@ -180,7 +180,7 @@ Community evidence is shape-checked by GitHub Actions, but publication still req
 | Version | `v2.4` |
 | Audit steps | 14 |
 | Risk matrix | 6D |
-| pytest collected tests | 808 |
+| pytest collected tests | 840 |
 | CLI flags | 22 |
 | Runtime profiles | `general`, `web3`, `full` |
 
@@ -221,7 +221,7 @@ Model substitution means the relay claims to provide one model but may expose ev
 
 ### What is tool-call rewriting?
 
-Tool-call rewriting means the relay modifies package-install commands or tool-like output in the model response. API Relay Audit sends pinned package commands and compares the returned text to detect proxy-layer supply-chain tampering.
+Tool-call rewriting means the relay modifies a structured tool name, JSON arguments, call count, or package-install command in the model response. Step 8 checks four pinned text commands plus one forced, non-streaming Anthropic/OpenAI Tool Call. The structured call is inspected only: the audit provides no executor, sends no tool result, and never executes returned content.
 
 ### What are SSE anomalies?
 
@@ -318,7 +318,7 @@ python audit.py --key <YOUR_KEY> --url <BASE_URL> --profile web3 --output report
 ## 核心覆盖
 
 - Prompt 安全: token injection、prompt extraction、instruction override、jailbreak
-- Relay 完整性: context truncation、tool-call substitution、error leakage、stream integrity
+- Relay 完整性: context truncation、结构化 Tool Call 与 package-command substitution、error leakage、stream integrity
 - 模型身份: 非 Claude 身份泄漏、模型替换信号、Claude / OpenAI 兼容中转行为
 - Web3 风险: 转账指引、签名拒绝、私钥泄漏拒绝
 
@@ -398,7 +398,7 @@ registry 分发与 release 验证以 DeepSeek Harness plugin 为主。
 | 版本 | `v2.4` |
 | 审计步骤 | 14 |
 | 风险矩阵 | 6D |
-| pytest collected tests | 808 |
+| pytest collected tests | 840 |
 | CLI flags | 22 |
 | Runtime profiles | `general`, `web3`, `full` |
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Community evidence is shape-checked by GitHub Actions, but publication still req
 | Version | `v2.4` |
 | Audit steps | 14 |
 | Risk matrix | 6D |
-| pytest collected tests | 840 |
+| pytest collected tests | 843 |
 | CLI flags | 22 |
 | Runtime profiles | `general`, `web3`, `full` |
 
@@ -398,7 +398,7 @@ registry 分发与 release 验证以 DeepSeek Harness plugin 为主。
 | 版本 | `v2.4` |
 | 审计步骤 | 14 |
 | 风险矩阵 | 6D |
-| pytest collected tests | 840 |
+| pytest collected tests | 843 |
 | CLI flags | 22 |
 | Runtime profiles | `general`, `web3`, `full` |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,9 @@ item has a short rationale so future contributors (including future
 iterations of the author) can quickly reconstruct why a thing is or is not
 on the list.
 
-**Last updated**: 2026-08-16 (DSH bundle added with strict adapter/runtime
-boundaries; Step 10 completeness remains in the existing 6D risk matrix)
+**Last updated**: 2026-08-24 (Step 8 gained non-streaming Anthropic/OpenAI
+structured Tool Call integrity while preserving standalone generation,
+tri-state verdicts, the 14-step contract, and D3 risk semantics)
 
 **Threat model anchor**: Liu et al., *Your Agent Is Mine: Measuring
 Malicious Intermediary Attacks on the LLM Supply Chain*, arXiv:2604.08407.
@@ -22,6 +23,25 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
 ---
 
 ## ✅ Shipped
+
+### 2026-08-24 follow-up — Structured Tool Call integrity
+- **Step 8 deepened without adding a step**: the four AC-1.a package-command
+  text probes remain, followed by one forced, non-streaming structured Tool
+  Call using a randomized tool name and canary arguments.
+- **Anthropic/OpenAI adapters**: `APIClient.call_tool_probe()` emits strict
+  one-tool schemas, disables parallel calls, normalizes both response shapes,
+  and records a hash-only transparent-log entry as `tool_call_probe`.
+- **No execution surface**: the audit exposes no executor callback, sends no
+  `tool_result`, and never runs returned tool names or arguments.
+- **Tri-state and D3 semantics preserved**: exact name/arguments/count is
+  `clean`; any mutation is `anomaly` and D3/HIGH; unsupported strict tools,
+  HTTP/format errors, or zero calls are D3i/MEDIUM. An anomaly always takes
+  priority over an inconclusive sibling path.
+- **Dual distribution preserved**: `tool_call_integrity.py` is a standalone
+  generator section, with curl-path and modular/standalone risk-parity tests.
+  Streaming Tool Call fragment reassembly remains a future Step 10 extension.
+- **Final test count**: 840/840 passing (808 baseline, +32 structured probe,
+  client adapter, orchestration, extractor, and standalone parity cases).
 
 ### 2026-08-16 distribution — DeepSeek Harness bundle
 - **Two-profile bundle**: the repository package installs into DSH web and
@@ -790,19 +810,16 @@ modular-only, with `--profile full` gate.
 
 ## 🛠 Medium-term ideas (1-3 month horizon)
 
-### 6. Full AC-1 tool_call support (as opposed to AC-1.a text echo)
-**Status**: backlog item from Step 8
-**Scope**: ~150 LOC — `APIClient.tool_call()` method + structured
-tool_call payload inspection + matching probe set
-**Why**: Step 8 currently catches AC-1.a (typosquat on plain text echoes)
-via text-level comparison. A more specific attack — rewriting the
-`tool_calls` JSON payload but leaving plain text alone — is not caught.
-Paper §4.2.1 notes: "the compromised dependency is cached locally and
-re-imported across future sessions, giving the attacker a durable
-supply-chain foothold."
-**Cost vs benefit**: marginal coverage uplift over AC-1.a (all observed
-wild samples were AC-1.a). Defer until the first wild AC-1 case is
-reported.
+### 6. Full non-streaming AC-1 tool_call support ✅ shipped 2026-08-24
+**Status**: completed in Step 8
+**Delivered**: `APIClient.call_tool_probe()` plus
+`api_relay_audit/tool_call_integrity.py` now inspect strict Anthropic and
+OpenAI structured Tool Calls for name, JSON-argument, type, and call-count
+mutation. The existing AC-1.a text probes remain as a complementary path.
+**Boundary**: this probe is deliberately non-streaming and observe-only; it
+does not execute calls or submit tool results. Anthropic/OpenAI streaming
+fragment reassembly belongs to a future Step 10 enhancement rather than this
+completed item.
 
 ### 7. Schema deviation anomaly detection (paper §7.2)
 **Status**: paper lists it as a detection dimension; we don't implement

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ contributor, arXiv:2026-04-26, 正交威胁轴：模型替换质量欺诈 vs 我
 - **Dual distribution preserved**: `tool_call_integrity.py` is a standalone
   generator section, with curl-path and modular/standalone risk-parity tests.
   Streaming Tool Call fragment reassembly remains a future Step 10 extension.
-- **Final test count**: 840/840 passing (808 baseline, +32 structured probe,
+- **Final test count**: 843/843 passing (808 baseline, +35 structured probe,
   client adapter, orchestration, extractor, and standalone parity cases).
 
 ### 2026-08-16 distribution — DeepSeek Harness bundle

--- a/api_relay_audit/client.py
+++ b/api_relay_audit/client.py
@@ -403,6 +403,169 @@ class APIClient:
             "raw": data,
         }
 
+    def _prepare_tool_probe_anthropic(self, messages, tool_spec, max_tokens=256):
+        url = self.base_url
+        if url.endswith("/v1"):
+            url = url[:-3]
+        url += "/v1/messages"
+
+        body = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "messages": messages,
+            "tools": [{**tool_spec, "strict": True}],
+            "tool_choice": {
+                "type": "tool",
+                "name": tool_spec["name"],
+                "disable_parallel_tool_use": True,
+            },
+        }
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }
+        return url, headers, body
+
+    def _call_tool_probe_anthropic(self, messages, tool_spec, max_tokens=256,
+                                   prepared=None):
+        url, headers, body = prepared or self._prepare_tool_probe_anthropic(
+            messages, tool_spec, max_tokens=max_tokens)
+        data = self._post(url, headers, body)
+        if "_http_error" in data:
+            return self._error_result(data["_http_error"])
+
+        tool_calls = []
+        content = data.get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                block_type = block.get("type")
+                tool_like = block_type == "tool_use" or any(
+                    key in block for key in ("id", "name", "input")
+                )
+                if not tool_like:
+                    continue
+                arguments = block.get("input")
+                arguments_error = None
+                if not isinstance(arguments, dict):
+                    arguments_error = "Anthropic tool input was not a JSON object"
+                    arguments = None
+                tool_calls.append({
+                    "type": "function" if block_type == "tool_use" else block_type,
+                    "id": block.get("id"),
+                    "name": block.get("name"),
+                    "arguments": arguments,
+                    "arguments_error": arguments_error,
+                })
+
+        usage = data.get("usage", {})
+        return {
+            "tool_calls": tool_calls,
+            "stop_reason": data.get("stop_reason"),
+            "input_tokens": usage.get("input_tokens", 0),
+            "output_tokens": usage.get("output_tokens", 0),
+            "raw": data,
+        }
+
+    def _prepare_tool_probe_openai(self, messages, tool_spec, max_tokens=256):
+        url = self.base_url
+        if not url.endswith("/v1"):
+            url += "/v1"
+        url += "/chat/completions"
+
+        body = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "messages": messages,
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": tool_spec["name"],
+                    "description": tool_spec["description"],
+                    "parameters": tool_spec["input_schema"],
+                    "strict": True,
+                },
+            }],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": tool_spec["name"]},
+            },
+            "parallel_tool_calls": False,
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "content-type": "application/json",
+        }
+        return url, headers, body
+
+    def _call_tool_probe_openai(self, messages, tool_spec, max_tokens=256,
+                                prepared=None):
+        url, headers, body = prepared or self._prepare_tool_probe_openai(
+            messages, tool_spec, max_tokens=max_tokens)
+        data = self._post(url, headers, body)
+        if "_http_error" in data:
+            return self._error_result(data["_http_error"])
+
+        choices = data.get("choices", [])
+        choice = choices[0] if isinstance(choices, list) and choices else {}
+        if not isinstance(choice, dict):
+            choice = {}
+        message = choice.get("message", {})
+        if not isinstance(message, dict):
+            message = {}
+        raw_calls = message.get("tool_calls", [])
+        if not isinstance(raw_calls, list):
+            raw_calls = []
+
+        tool_calls = []
+        for raw_call in raw_calls:
+            if not isinstance(raw_call, dict):
+                continue
+            call_type = raw_call.get("type")
+            if call_type == "function":
+                function = raw_call.get("function", {})
+                if not isinstance(function, dict):
+                    function = {}
+                raw_arguments = function.get("arguments")
+                arguments = None
+                arguments_error = None
+                if not isinstance(raw_arguments, str):
+                    arguments_error = "OpenAI tool arguments were not a JSON string"
+                else:
+                    try:
+                        arguments = json.loads(raw_arguments)
+                    except (TypeError, ValueError):
+                        arguments_error = "invalid JSON arguments"
+                    if arguments_error is None and not isinstance(arguments, dict):
+                        arguments_error = "OpenAI tool arguments were not a JSON object"
+                        arguments = None
+                name = function.get("name")
+            else:
+                custom = raw_call.get("custom", {})
+                if not isinstance(custom, dict):
+                    custom = {}
+                name = custom.get("name")
+                arguments = None
+                arguments_error = "Unexpected non-function Tool Call type"
+            tool_calls.append({
+                "type": call_type,
+                "id": raw_call.get("id"),
+                "name": name,
+                "arguments": arguments,
+                "arguments_error": arguments_error,
+            })
+
+        usage = data.get("usage", {})
+        return {
+            "tool_calls": tool_calls,
+            "stop_reason": choice.get("finish_reason"),
+            "input_tokens": usage.get("prompt_tokens", 0),
+            "output_tokens": usage.get("completion_tokens", 0),
+            "raw": data,
+        }
+
     # -- Public API -----------------------------------------------------------
 
     def ensure_format(self):
@@ -478,6 +641,54 @@ class APIClient:
             elapsed = time.time() - start
             self._log_transparent(
                 "call", self._resolve_call_url(), "POST",
+                request_body, None, 0, None, elapsed, str(e))
+            return self._error_result(e, time=elapsed)
+
+    def call_tool_probe(self, messages, tool_spec, max_tokens=256):
+        """Request one inert client Tool Call without ever executing it.
+
+        ``tool_spec`` uses the protocol-neutral Anthropic shape (``name``,
+        ``description``, ``input_schema``). The client forces that tool,
+        disables parallel calls, and normalizes Anthropic/OpenAI responses
+        into a shared ``tool_calls`` list. No executor callback exists and no
+        ``tool_result`` follow-up request is sent.
+        """
+        start = time.time()
+        request_url = self._resolve_call_url()
+        request_body = json.dumps({})
+        try:
+            if self._format is None:
+                self.ensure_format()
+            if self._format == "anthropic":
+                prepared = self._prepare_tool_probe_anthropic(
+                    messages, tool_spec, max_tokens=max_tokens)
+                request_url, _, wire_body = prepared
+                request_body = json.dumps(wire_body)
+                result = self._call_tool_probe_anthropic(
+                    messages, tool_spec, max_tokens=max_tokens,
+                    prepared=prepared)
+            elif self._format == "openai":
+                prepared = self._prepare_tool_probe_openai(
+                    messages, tool_spec, max_tokens=max_tokens)
+                request_url, _, wire_body = prepared
+                request_body = json.dumps(wire_body)
+                result = self._call_tool_probe_openai(
+                    messages, tool_spec, max_tokens=max_tokens,
+                    prepared=prepared)
+            else:
+                result = self._error_result(
+                    "Could not detect API format for structured Tool Call probe")
+            result["time"] = time.time() - start
+            self._log_transparent(
+                "tool_call_probe", request_url, "POST",
+                request_body, json.dumps(result.get("raw", {})),
+                200 if "error" not in result else 0,
+                None, result["time"], result.get("error"))
+            return result
+        except Exception as e:
+            elapsed = time.time() - start
+            self._log_transparent(
+                "tool_call_probe", request_url, "POST",
                 request_body, None, 0, None, elapsed, str(e))
             return self._error_result(e, time=elapsed)
 

--- a/api_relay_audit/error_leakage.py
+++ b/api_relay_audit/error_leakage.py
@@ -290,6 +290,18 @@ def _redact_api_key(text: str, api_key: str) -> str:
     return text
 
 
+def redact_sensitive_text(text: str, api_key: str = "") -> str:
+    """Redact the caller credential and known secret shapes from report text."""
+    if not isinstance(text, str):
+        text = str(text)
+    if not isinstance(api_key, str):
+        api_key = ""
+    text = _redact_api_key(text, api_key)
+    for pattern, _kind in SECRET_REGEX_PATTERNS:
+        text = pattern.sub("<REDACTED_SECRET>", text)
+    return text
+
+
 def _mk_hit(severity: str, kind: str, snippet: str, where: str, api_key: str) -> dict:
     """Build a single hit dict with snippet redaction applied unconditionally.
 

--- a/api_relay_audit/tool_call_integrity.py
+++ b/api_relay_audit/tool_call_integrity.py
@@ -7,6 +7,8 @@ returned tool call and never sends a ``tool_result`` follow-up request.
 import json
 import uuid
 
+from api_relay_audit.error_leakage import redact_sensitive_text
+
 
 PROBE_PROMPT = (
     "Call the provided record tool exactly once with the exact arguments "
@@ -35,8 +37,8 @@ def _json_deep_equal(left, right):
     return left == right
 
 
-def format_tool_calls_preview(calls, max_chars=240):
-    """Return a Markdown-safe, bounded preview of arguments only."""
+def format_tool_calls_preview(calls, max_chars=240, api_key=""):
+    """Return a redacted, Markdown-safe, bounded preview of arguments only."""
     arguments = [
         call.get("arguments") if isinstance(call, dict) else None
         for call in calls
@@ -47,6 +49,7 @@ def format_tool_calls_preview(calls, max_chars=240):
         separators=(",", ":"),
         default=str,
     )
+    text = redact_sensitive_text(text, api_key)
     text = text.replace("|", "\\|").replace("`", "\\`")
     limit = max(3, int(max_chars))
     if len(text) > limit:
@@ -59,14 +62,15 @@ def analyze_tool_call_integrity(response, expected_name, expected_arguments):
     if not isinstance(response, dict):
         response = {}
     if "error" in response:
-        error = str(response.get("error", ""))[:200]
         return {
             "verdict": "inconclusive",
             "expected_count": 1,
             "received_count": 0,
             "name_match": None,
             "arguments_match": None,
-            "findings": [f"Structured Tool Call probe failed: {error}"],
+            "findings": [
+                "Structured Tool Call probe failed; support could not be verified"
+            ],
         }
     calls = response.get("tool_calls", [])
     if not isinstance(calls, list) or any(not isinstance(call, dict) for call in calls):
@@ -107,15 +111,9 @@ def analyze_tool_call_integrity(response, expected_name, expected_arguments):
             f"Tool call count changed: expected 1, received {len(calls)}"
         )
     if not type_match:
-        findings.append(
-            f"Tool call type changed: expected 'function', "
-            f"received {call.get('type')!r}"
-        )
+        findings.append("Tool call type differed from the forced function type")
     if not name_match:
-        findings.append(
-            f"Tool name changed: expected {expected_name!r}, "
-            f"received {call.get('name')!r}"
-        )
+        findings.append("Tool name differed from the forced canary name")
     if call.get("arguments_error"):
         findings.append(
             f"Tool arguments could not be parsed: {call['arguments_error']}"

--- a/api_relay_audit/tool_call_integrity.py
+++ b/api_relay_audit/tool_call_integrity.py
@@ -1,0 +1,186 @@
+"""Structured Tool Call integrity analysis for Step 8.
+
+The detector inspects inert client-tool requests only.  It never executes a
+returned tool call and never sends a ``tool_result`` follow-up request.
+"""
+
+import json
+import uuid
+
+
+PROBE_PROMPT = (
+    "Call the provided record tool exactly once with the exact arguments "
+    "encoded in its schema. Do not answer in text."
+)
+PROBE_DESCRIPTION = (
+    "Record an inert relay-audit canary. This tool performs no I/O, "
+    "has no side effects, and will not be executed. Call it exactly once."
+)
+
+
+def _json_deep_equal(left, right):
+    """Compare parsed JSON values without Python's bool/int coercion."""
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return (
+            left.keys() == right.keys()
+            and all(_json_deep_equal(left[key], right[key]) for key in left)
+        )
+    if isinstance(left, list):
+        return (
+            len(left) == len(right)
+            and all(_json_deep_equal(a, b) for a, b in zip(left, right))
+        )
+    return left == right
+
+
+def format_tool_calls_preview(calls, max_chars=240):
+    """Return a Markdown-safe, bounded preview of arguments only."""
+    arguments = [
+        call.get("arguments") if isinstance(call, dict) else None
+        for call in calls
+    ]
+    text = json.dumps(
+        arguments,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=str,
+    )
+    text = text.replace("|", "\\|").replace("`", "\\`")
+    limit = max(3, int(max_chars))
+    if len(text) > limit:
+        return text[:limit - 3] + "..."
+    return text
+
+
+def analyze_tool_call_integrity(response, expected_name, expected_arguments):
+    """Compare a normalized Tool Call response with the forced expectation."""
+    if not isinstance(response, dict):
+        response = {}
+    if "error" in response:
+        error = str(response.get("error", ""))[:200]
+        return {
+            "verdict": "inconclusive",
+            "expected_count": 1,
+            "received_count": 0,
+            "name_match": None,
+            "arguments_match": None,
+            "findings": [f"Structured Tool Call probe failed: {error}"],
+        }
+    calls = response.get("tool_calls", [])
+    if not isinstance(calls, list) or any(not isinstance(call, dict) for call in calls):
+        return {
+            "verdict": "inconclusive",
+            "expected_count": 1,
+            "received_count": 0,
+            "name_match": None,
+            "arguments_match": None,
+            "findings": ["Structured Tool Call response format was invalid"],
+        }
+    if not calls:
+        claimed_tool_stop = response.get("stop_reason") in {"tool_use", "tool_calls"}
+        return {
+            "verdict": "anomaly" if claimed_tool_stop else "inconclusive",
+            "expected_count": 1,
+            "received_count": 0,
+            "name_match": None,
+            "arguments_match": None,
+            "findings": ([
+                "Response claimed a Tool Call stop reason but contained zero Tool Calls"
+            ] if claimed_tool_stop else [
+                "Forced tool request returned no structured Tool Call; "
+                "support could not be verified"
+            ]),
+        }
+    call = calls[0]
+    count_match = len(calls) == 1
+    type_match = call.get("type") == "function"
+    name_match = call.get("name") == expected_name
+    arguments_match = (
+        call.get("arguments_error") is None
+        and _json_deep_equal(call.get("arguments"), expected_arguments)
+    )
+    findings = []
+    if not count_match:
+        findings.append(
+            f"Tool call count changed: expected 1, received {len(calls)}"
+        )
+    if not type_match:
+        findings.append(
+            f"Tool call type changed: expected 'function', "
+            f"received {call.get('type')!r}"
+        )
+    if not name_match:
+        findings.append(
+            f"Tool name changed: expected {expected_name!r}, "
+            f"received {call.get('name')!r}"
+        )
+    if call.get("arguments_error"):
+        findings.append(
+            f"Tool arguments could not be parsed: {call['arguments_error']}"
+        )
+    elif not arguments_match:
+        findings.append("Tool arguments differed from the forced canary payload")
+    return {
+        "verdict": (
+            "clean"
+            if count_match and type_match and name_match and arguments_match
+            else "anomaly"
+        ),
+        "expected_count": 1,
+        "received_count": len(calls),
+        "name_match": name_match,
+        "arguments_match": arguments_match,
+        "findings": findings,
+    }
+
+
+def run_tool_call_integrity_test(client, nonce_factory=None):
+    """Send one inert structured probe and return its tri-state analysis.
+
+    The returned Tool Call is inspected only.  This function intentionally has
+    no executor callback and never sends a follow-up tool result.
+    """
+    if nonce_factory is None:
+        nonce_factory = lambda: uuid.uuid4().hex
+    nonce = str(nonce_factory())
+    tool_name = f"record_probe_{nonce[:12]}"
+    expected_arguments = {
+        "probe_token": f"TC_{nonce}",
+        "sequence": 1,
+        "mode": "observe_only",
+    }
+    tool_spec = {
+        "name": tool_name,
+        "description": PROBE_DESCRIPTION,
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "probe_token": {
+                    "type": "string",
+                    "enum": [expected_arguments["probe_token"]],
+                },
+                "sequence": {"type": "integer", "enum": [1]},
+                "mode": {"type": "string", "enum": ["observe_only"]},
+            },
+            "required": ["probe_token", "sequence", "mode"],
+            "additionalProperties": False,
+        },
+    }
+    response = client.call_tool_probe(
+        [{"role": "user", "content": PROBE_PROMPT}],
+        tool_spec,
+        max_tokens=256,
+    )
+    result = analyze_tool_call_integrity(
+        response,
+        expected_name=tool_name,
+        expected_arguments=expected_arguments,
+    )
+    result["expected_name"] = tool_name
+    result["expected_arguments"] = expected_arguments
+    result["received_calls"] = (
+        response.get("tool_calls", []) if isinstance(response, dict) else []
+    )
+    return result

--- a/api_relay_audit/tool_substitution.py
+++ b/api_relay_audit/tool_substitution.py
@@ -6,12 +6,10 @@ return path, e.g. ``pip install requests`` -> ``pip install reqeusts``
 command and comparing the returned text character-by-character against the
 expected string.
 
-This is a text-echo surrogate for the paper's AC-1.a attack: a content-based
-substitution rule in a malicious router will fire on any response body
-containing a package-install pattern, regardless of whether it arrives via a
-tool_call JSON payload or plain text. It does NOT catch AC-1 rewrites that
-target only structured tool_call payloads while leaving plaintext alone --
-that is deferred to a future step that needs APIClient tool-calling support.
+This module implements Step 8's complementary text path. Content-based
+package substitution rules often fire on plain text, while
+``tool_call_integrity.py`` independently covers non-streaming structured
+Anthropic/OpenAI Tool Calls that leave plaintext untouched.
 
 Reference: Liu, Shou, Wen, Chen, Fang, Feng,
 "Your Agent Is Mine: Measuring Malicious Intermediary Attacks on the

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 1cf00fc214575eb3f6fd92e84cc8a596451ec9bf1409b2bd9a150c5dbdb30a56
-# standalone_body_sha256: 510f914cf8ed38cb9068f4f5a16c4576593726cdca1f059ddc28181a819ff3cb
+# source_sha256: 49bb2b7d0ec531ddd7b6c7deafd233a5554578687203e667398b195c9b3e8f9c
+# standalone_body_sha256: 6dc89c322e3dffebe16db29d869bc2281f0609fe395c625648a3e2ac9217ba64
 # END GENERATED STANDALONE HEADER
 
 """
@@ -1159,6 +1159,169 @@ class APIClient:
             "raw": data,
         }
 
+    def _prepare_tool_probe_anthropic(self, messages, tool_spec, max_tokens=256):
+        url = self.base_url
+        if url.endswith("/v1"):
+            url = url[:-3]
+        url += "/v1/messages"
+
+        body = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "messages": messages,
+            "tools": [{**tool_spec, "strict": True}],
+            "tool_choice": {
+                "type": "tool",
+                "name": tool_spec["name"],
+                "disable_parallel_tool_use": True,
+            },
+        }
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }
+        return url, headers, body
+
+    def _call_tool_probe_anthropic(self, messages, tool_spec, max_tokens=256,
+                                   prepared=None):
+        url, headers, body = prepared or self._prepare_tool_probe_anthropic(
+            messages, tool_spec, max_tokens=max_tokens)
+        data = self._post(url, headers, body)
+        if "_http_error" in data:
+            return self._error_result(data["_http_error"])
+
+        tool_calls = []
+        content = data.get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                block_type = block.get("type")
+                tool_like = block_type == "tool_use" or any(
+                    key in block for key in ("id", "name", "input")
+                )
+                if not tool_like:
+                    continue
+                arguments = block.get("input")
+                arguments_error = None
+                if not isinstance(arguments, dict):
+                    arguments_error = "Anthropic tool input was not a JSON object"
+                    arguments = None
+                tool_calls.append({
+                    "type": "function" if block_type == "tool_use" else block_type,
+                    "id": block.get("id"),
+                    "name": block.get("name"),
+                    "arguments": arguments,
+                    "arguments_error": arguments_error,
+                })
+
+        usage = data.get("usage", {})
+        return {
+            "tool_calls": tool_calls,
+            "stop_reason": data.get("stop_reason"),
+            "input_tokens": usage.get("input_tokens", 0),
+            "output_tokens": usage.get("output_tokens", 0),
+            "raw": data,
+        }
+
+    def _prepare_tool_probe_openai(self, messages, tool_spec, max_tokens=256):
+        url = self.base_url
+        if not url.endswith("/v1"):
+            url += "/v1"
+        url += "/chat/completions"
+
+        body = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "messages": messages,
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": tool_spec["name"],
+                    "description": tool_spec["description"],
+                    "parameters": tool_spec["input_schema"],
+                    "strict": True,
+                },
+            }],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": tool_spec["name"]},
+            },
+            "parallel_tool_calls": False,
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "content-type": "application/json",
+        }
+        return url, headers, body
+
+    def _call_tool_probe_openai(self, messages, tool_spec, max_tokens=256,
+                                prepared=None):
+        url, headers, body = prepared or self._prepare_tool_probe_openai(
+            messages, tool_spec, max_tokens=max_tokens)
+        data = self._post(url, headers, body)
+        if "_http_error" in data:
+            return self._error_result(data["_http_error"])
+
+        choices = data.get("choices", [])
+        choice = choices[0] if isinstance(choices, list) and choices else {}
+        if not isinstance(choice, dict):
+            choice = {}
+        message = choice.get("message", {})
+        if not isinstance(message, dict):
+            message = {}
+        raw_calls = message.get("tool_calls", [])
+        if not isinstance(raw_calls, list):
+            raw_calls = []
+
+        tool_calls = []
+        for raw_call in raw_calls:
+            if not isinstance(raw_call, dict):
+                continue
+            call_type = raw_call.get("type")
+            if call_type == "function":
+                function = raw_call.get("function", {})
+                if not isinstance(function, dict):
+                    function = {}
+                raw_arguments = function.get("arguments")
+                arguments = None
+                arguments_error = None
+                if not isinstance(raw_arguments, str):
+                    arguments_error = "OpenAI tool arguments were not a JSON string"
+                else:
+                    try:
+                        arguments = json.loads(raw_arguments)
+                    except (TypeError, ValueError):
+                        arguments_error = "invalid JSON arguments"
+                    if arguments_error is None and not isinstance(arguments, dict):
+                        arguments_error = "OpenAI tool arguments were not a JSON object"
+                        arguments = None
+                name = function.get("name")
+            else:
+                custom = raw_call.get("custom", {})
+                if not isinstance(custom, dict):
+                    custom = {}
+                name = custom.get("name")
+                arguments = None
+                arguments_error = "Unexpected non-function Tool Call type"
+            tool_calls.append({
+                "type": call_type,
+                "id": raw_call.get("id"),
+                "name": name,
+                "arguments": arguments,
+                "arguments_error": arguments_error,
+            })
+
+        usage = data.get("usage", {})
+        return {
+            "tool_calls": tool_calls,
+            "stop_reason": choice.get("finish_reason"),
+            "input_tokens": usage.get("prompt_tokens", 0),
+            "output_tokens": usage.get("completion_tokens", 0),
+            "raw": data,
+        }
+
     # -- Public API -----------------------------------------------------------
 
     def ensure_format(self):
@@ -1234,6 +1397,54 @@ class APIClient:
             elapsed = time.time() - start
             self._log_transparent(
                 "call", self._resolve_call_url(), "POST",
+                request_body, None, 0, None, elapsed, str(e))
+            return self._error_result(e, time=elapsed)
+
+    def call_tool_probe(self, messages, tool_spec, max_tokens=256):
+        """Request one inert client Tool Call without ever executing it.
+
+        ``tool_spec`` uses the protocol-neutral Anthropic shape (``name``,
+        ``description``, ``input_schema``). The client forces that tool,
+        disables parallel calls, and normalizes Anthropic/OpenAI responses
+        into a shared ``tool_calls`` list. No executor callback exists and no
+        ``tool_result`` follow-up request is sent.
+        """
+        start = time.time()
+        request_url = self._resolve_call_url()
+        request_body = json.dumps({})
+        try:
+            if self._format is None:
+                self.ensure_format()
+            if self._format == "anthropic":
+                prepared = self._prepare_tool_probe_anthropic(
+                    messages, tool_spec, max_tokens=max_tokens)
+                request_url, _, wire_body = prepared
+                request_body = json.dumps(wire_body)
+                result = self._call_tool_probe_anthropic(
+                    messages, tool_spec, max_tokens=max_tokens,
+                    prepared=prepared)
+            elif self._format == "openai":
+                prepared = self._prepare_tool_probe_openai(
+                    messages, tool_spec, max_tokens=max_tokens)
+                request_url, _, wire_body = prepared
+                request_body = json.dumps(wire_body)
+                result = self._call_tool_probe_openai(
+                    messages, tool_spec, max_tokens=max_tokens,
+                    prepared=prepared)
+            else:
+                result = self._error_result(
+                    "Could not detect API format for structured Tool Call probe")
+            result["time"] = time.time() - start
+            self._log_transparent(
+                "tool_call_probe", request_url, "POST",
+                request_body, json.dumps(result.get("raw", {})),
+                200 if "error" not in result else 0,
+                None, result["time"], result.get("error"))
+            return result
+        except Exception as e:
+            elapsed = time.time() - start
+            self._log_transparent(
+                "tool_call_probe", request_url, "POST",
                 request_body, None, 0, None, elapsed, str(e))
             return self._error_result(e, time=elapsed)
 
@@ -2238,6 +2449,198 @@ def run_context_scan(client, coarse_steps=None, sleep_between=2):
 
 
 # ============================================================
+# Structured Tool Call integrity detector
+# ============================================================
+
+"""Structured Tool Call integrity analysis for Step 8.
+
+The detector inspects inert client-tool requests only.  It never executes a
+returned tool call and never sends a ``tool_result`` follow-up request.
+"""
+
+import json
+import uuid
+
+
+PROBE_PROMPT = (
+    "Call the provided record tool exactly once with the exact arguments "
+    "encoded in its schema. Do not answer in text."
+)
+PROBE_DESCRIPTION = (
+    "Record an inert relay-audit canary. This tool performs no I/O, "
+    "has no side effects, and will not be executed. Call it exactly once."
+)
+
+
+def _json_deep_equal(left, right):
+    """Compare parsed JSON values without Python's bool/int coercion."""
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return (
+            left.keys() == right.keys()
+            and all(_json_deep_equal(left[key], right[key]) for key in left)
+        )
+    if isinstance(left, list):
+        return (
+            len(left) == len(right)
+            and all(_json_deep_equal(a, b) for a, b in zip(left, right))
+        )
+    return left == right
+
+
+def format_tool_calls_preview(calls, max_chars=240):
+    """Return a Markdown-safe, bounded preview of arguments only."""
+    arguments = [
+        call.get("arguments") if isinstance(call, dict) else None
+        for call in calls
+    ]
+    text = json.dumps(
+        arguments,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=str,
+    )
+    text = text.replace("|", "\\|").replace("`", "\\`")
+    limit = max(3, int(max_chars))
+    if len(text) > limit:
+        return text[:limit - 3] + "..."
+    return text
+
+
+def analyze_tool_call_integrity(response, expected_name, expected_arguments):
+    """Compare a normalized Tool Call response with the forced expectation."""
+    if not isinstance(response, dict):
+        response = {}
+    if "error" in response:
+        error = str(response.get("error", ""))[:200]
+        return {
+            "verdict": "inconclusive",
+            "expected_count": 1,
+            "received_count": 0,
+            "name_match": None,
+            "arguments_match": None,
+            "findings": [f"Structured Tool Call probe failed: {error}"],
+        }
+    calls = response.get("tool_calls", [])
+    if not isinstance(calls, list) or any(not isinstance(call, dict) for call in calls):
+        return {
+            "verdict": "inconclusive",
+            "expected_count": 1,
+            "received_count": 0,
+            "name_match": None,
+            "arguments_match": None,
+            "findings": ["Structured Tool Call response format was invalid"],
+        }
+    if not calls:
+        claimed_tool_stop = response.get("stop_reason") in {"tool_use", "tool_calls"}
+        return {
+            "verdict": "anomaly" if claimed_tool_stop else "inconclusive",
+            "expected_count": 1,
+            "received_count": 0,
+            "name_match": None,
+            "arguments_match": None,
+            "findings": ([
+                "Response claimed a Tool Call stop reason but contained zero Tool Calls"
+            ] if claimed_tool_stop else [
+                "Forced tool request returned no structured Tool Call; "
+                "support could not be verified"
+            ]),
+        }
+    call = calls[0]
+    count_match = len(calls) == 1
+    type_match = call.get("type") == "function"
+    name_match = call.get("name") == expected_name
+    arguments_match = (
+        call.get("arguments_error") is None
+        and _json_deep_equal(call.get("arguments"), expected_arguments)
+    )
+    findings = []
+    if not count_match:
+        findings.append(
+            f"Tool call count changed: expected 1, received {len(calls)}"
+        )
+    if not type_match:
+        findings.append(
+            f"Tool call type changed: expected 'function', "
+            f"received {call.get('type')!r}"
+        )
+    if not name_match:
+        findings.append(
+            f"Tool name changed: expected {expected_name!r}, "
+            f"received {call.get('name')!r}"
+        )
+    if call.get("arguments_error"):
+        findings.append(
+            f"Tool arguments could not be parsed: {call['arguments_error']}"
+        )
+    elif not arguments_match:
+        findings.append("Tool arguments differed from the forced canary payload")
+    return {
+        "verdict": (
+            "clean"
+            if count_match and type_match and name_match and arguments_match
+            else "anomaly"
+        ),
+        "expected_count": 1,
+        "received_count": len(calls),
+        "name_match": name_match,
+        "arguments_match": arguments_match,
+        "findings": findings,
+    }
+
+
+def run_tool_call_integrity_test(client, nonce_factory=None):
+    """Send one inert structured probe and return its tri-state analysis.
+
+    The returned Tool Call is inspected only.  This function intentionally has
+    no executor callback and never sends a follow-up tool result.
+    """
+    if nonce_factory is None:
+        nonce_factory = lambda: uuid.uuid4().hex
+    nonce = str(nonce_factory())
+    tool_name = f"record_probe_{nonce[:12]}"
+    expected_arguments = {
+        "probe_token": f"TC_{nonce}",
+        "sequence": 1,
+        "mode": "observe_only",
+    }
+    tool_spec = {
+        "name": tool_name,
+        "description": PROBE_DESCRIPTION,
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "probe_token": {
+                    "type": "string",
+                    "enum": [expected_arguments["probe_token"]],
+                },
+                "sequence": {"type": "integer", "enum": [1]},
+                "mode": {"type": "string", "enum": ["observe_only"]},
+            },
+            "required": ["probe_token", "sequence", "mode"],
+            "additionalProperties": False,
+        },
+    }
+    response = client.call_tool_probe(
+        [{"role": "user", "content": PROBE_PROMPT}],
+        tool_spec,
+        max_tokens=256,
+    )
+    result = analyze_tool_call_integrity(
+        response,
+        expected_name=tool_name,
+        expected_arguments=expected_arguments,
+    )
+    result["expected_name"] = tool_name
+    result["expected_arguments"] = expected_arguments
+    result["received_calls"] = (
+        response.get("tool_calls", []) if isinstance(response, dict) else []
+    )
+    return result
+
+
+# ============================================================
 # Tool-call substitution detector
 # ============================================================
 
@@ -2249,12 +2652,10 @@ return path, e.g. ``pip install requests`` -> ``pip install reqeusts``
 command and comparing the returned text character-by-character against the
 expected string.
 
-This is a text-echo surrogate for the paper's AC-1.a attack: a content-based
-substitution rule in a malicious router will fire on any response body
-containing a package-install pattern, regardless of whether it arrives via a
-tool_call JSON payload or plain text. It does NOT catch AC-1 rewrites that
-target only structured tool_call payloads while leaving plaintext alone --
-that is deferred to a future step that needs APIClient tool-calling support.
+This module implements Step 8's complementary text path. Content-based
+package substitution rules often fire on plain text, while
+``tool_call_integrity.py`` independently covers non-streaming structured
+Anthropic/OpenAI Tool Calls that leave plaintext untouched.
 
 Reference: Liu, Shou, Wen, Chen, Fang, Feng,
 "Your Agent Is Mine: Measuring Malicious Intermediary Attacks on the
@@ -4881,7 +5282,7 @@ API Relay Security Audit Tool v2.4
 
 Full 14-step audit: infrastructure recon, model list, token injection,
 prompt extraction, instruction conflict + identity, jailbreak, context
-length, tool-call substitution (AC-1.a), error response leakage (AC-2),
+length, tool-call integrity (AC-1 / AC-1.a), error response leakage (AC-2),
 stream integrity (AC-1 SSE), Web3 prompt injection (profile=web3|full),
 infrastructure fingerprint, latency variance, upstream channel classifier.
 Threat taxonomy follows Liu et al., *Your Agent Is Mine*, arXiv:2604.08407
@@ -5027,7 +5428,8 @@ def parse_args():
                         "(10K/50K/100K/200K chars) to lower token cost. "
                         "Default is the full scan.")
     p.add_argument("--skip-tool-substitution", action="store_true",
-                   help="Skip tool-call package substitution test (AC-1.a)")
+                   help="Skip the entire Step 8 tool-call integrity test "
+                        "(text AC-1.a and structured AC-1 probes)")
     p.add_argument("--skip-error-leakage", action="store_true",
                    help="Skip error response header leakage test (Step 9, AC-2 adjacent)")
     p.add_argument("--aggressive-error-probes", action="store_true",
@@ -5698,21 +6100,21 @@ def test_jailbreak(client, report):
 
 
 def test_tool_substitution(client, report):
-    report.h2("8. Tool-Call Package Substitution (AC-1.a)")
+    report.h2("8. Tool-Call Integrity (AC-1 / AC-1.a)")
     report.p(
-        "Ask the model to echo exact package-install commands and verify "
-        "character-level integrity on the return path. A malicious middleware "
-        "running AC-1.a rewrites package names (e.g. `requests` -> `reqeusts` "
-        "typosquat) before the response reaches the client, giving the attacker "
-        "a durable supply-chain foothold on the agent's host. "
+        "Verify both package-install text and one inert, non-streaming structured "
+        "Tool Call on the return path. The structured call is inspected only: "
+        "the audit provides no executor, sends no tool result, and never runs "
+        "returned content. A malicious middleware can rewrite a tool name, "
+        "arguments, call count, or package command before it reaches the client. "
         "Reference: Liu et al., *Your Agent Is Mine*, arXiv:2604.08407 section 4.2.1.\n"
     )
-    report.p(
-        "Limitation: this is a text-echo surrogate. It does not catch AC-1 "
-        "rewrites that target only structured tool_call payloads.\n"
-    )
 
-    results, detected, inconclusive = run_tool_substitution_test(client, sleep=1.0)
+    report.h3("Package-command text probes (AC-1.a)")
+
+    results, text_detected, text_inconclusive = run_tool_substitution_test(
+        client, sleep=1.0,
+    )
 
     report.p("| Manager | Expected | Received | Verdict |")
     report.p("|---------|----------|----------|---------|")
@@ -5742,31 +6144,104 @@ def test_tool_substitution(client, report):
         for manager, error in error_diagnostics:
             report.p(f"- {manager}: {format_diagnosis(_diagnosis_for_error(error))}")
 
-    if detected:
+    if text_detected:
         subs = sum(1 for r in results if r["verdict"] == "substituted")
+        report.p(
+            f"🔴 **Package-command substitution detected (AC-1.a): "
+            f"{subs}/{len(results)} probes rewritten on return path.**"
+        )
+    elif text_inconclusive:
+        report.p(
+            "🟡 **Package-command text probes INCONCLUSIVE: every probe errored.**"
+        )
+    elif error_count > 0:
+        report.p(
+            f"Tool-call substitution test partially skipped "
+            f"({error_count}/{len(results)} probes errored).",
+        )
+    else:
+        report.p("🟢 Package-command text probes preserved exactly.")
+
+    report.h3("Structured Tool Call probe (non-streaming)")
+    try:
+        structured = run_tool_call_integrity_test(client)
+    except Exception as exc:
+        structured = {
+            "verdict": "inconclusive",
+            "expected_count": 1,
+            "received_count": 0,
+            "name_match": None,
+            "arguments_match": None,
+            "findings": [f"Structured probe failed: {exc}"],
+            "received_calls": [],
+        }
+
+    def _match_label(value):
+        if value is None:
+            return "unknown"
+        return "true" if value else "false"
+
+    report.p(f"**Structured verdict**: `{structured['verdict']}`")
+    report.p(
+        f"**Expected calls**: `{structured['expected_count']}` | "
+        f"**Observed calls**: `{structured['received_count']}`"
+    )
+    report.p(
+        f"**Tool name match**: `{_match_label(structured.get('name_match'))}` | "
+        f"**Arguments match**: `{_match_label(structured.get('arguments_match'))}`"
+    )
+    preview = format_tool_calls_preview(structured.get("received_calls", []))
+    report.p(f"**Received arguments preview**: `{preview}`")
+    if structured.get("findings"):
+        report.p("\n**Structured findings:**")
+        for finding in structured["findings"]:
+            safe = str(finding)[:240].replace("|", "\\|").replace("`", "\\`").replace("\n", " ")
+            report.p(f"- {safe}")
+
+    structured_anomaly = structured["verdict"] == "anomaly"
+    structured_inconclusive = structured["verdict"] == "inconclusive"
+    detected = text_detected or structured_anomaly
+    inconclusive = not detected and (text_inconclusive or structured_inconclusive)
+
+    if detected:
+        paths = []
+        if text_detected:
+            paths.append("package-command text")
+        if structured_anomaly:
+            paths.append("structured Tool Call")
         report.flag(
             "red",
-            f"Tool-call package substitution detected (AC-1.a): "
-            f"{subs}/{len(results)} probes rewritten on return path",
+            "Tool-call integrity anomaly detected (AC-1 / AC-1.a): "
+            + " and ".join(paths)
+            + " path failed integrity checks",
         )
     elif inconclusive:
+        paths = []
+        if text_inconclusive:
+            paths.append("package-command text")
+        if structured_inconclusive:
+            paths.append("structured Tool Call")
         report.flag(
             "yellow",
-            "Tool-call substitution test INCONCLUSIVE: every probe errored. "
-            "The relay may be blocking plaintext echo -- re-run with a different "
-            "model or consider this a red flag in itself.",
+            "Tool-call integrity test INCONCLUSIVE: "
+            + " and ".join(paths)
+            + " path could not be verified",
         )
     elif error_count > 0:
         report.flag(
             "yellow",
-            f"Tool-call substitution test partially skipped "
-            f"({error_count}/{len(results)} probes errored)",
+            f"No tool-call integrity anomaly detected, but "
+            f"{error_count}/{len(results)} package-command probes errored",
         )
     else:
-        report.flag("green", "No tool-call package substitution detected")
+        report.flag(
+            "green",
+            "Tool-call integrity clean: package-command text and structured "
+            "tool name, arguments, and call count all matched",
+        )
 
     state = "detected" if detected else ("inconclusive" if inconclusive else "clean")
-    print(f"  Done: tool-call substitution ({state})")
+    print(f"  Done: tool-call integrity ({state})")
     return detected, inconclusive
 
 
@@ -6601,18 +7076,18 @@ def main():
     else:
         print("[7/14] Context length test (skipped)")
 
-    # 8. Tool-call package substitution (AC-1.a)
+    # 8. Tool-call integrity (text AC-1.a + structured AC-1)
     substitution_detected = False
     substitution_inconclusive = False
     if not args.skip_tool_substitution:
-        print("[8/14] Tool-call substitution test...")
+        print("[8/14] Tool-call integrity test...")
         substitution_detected, substitution_inconclusive = _run_step(
-            "Step 8 tool substitution", report,
+            "Step 8 tool-call integrity", report,
             test_tool_substitution, client, report,
             default=(False, True), crashes=step_crashes,
         )
     else:
-        print("[8/14] Tool-call substitution test (skipped)")
+        print("[8/14] Tool-call integrity test (skipped)")
 
     # 9. Error response header leakage (AC-2 adjacent)
     err_severity = "none"
@@ -6696,8 +7171,8 @@ def main():
     #   D1i = Step 3 crashed / inconclusive                 (Step 3)
     #   D2  = user instructions overridden                  (Step 5)
     #   D2i = Step 5 crashed / inconclusive                 (Step 5)
-    #   D3  = tool-call package substitution detected       (Step 8)
-    #   D3i = Step 8 inconclusive (all probes errored)      (Step 8)
+    #   D3  = text or structured Tool Call anomaly          (Step 8)
+    #   D3i = Step 8 text/structured path inconclusive      (Step 8)
     #   D4  = error response leakage (critical or high)     (Step 9)
     #   D4m = error response leakage (medium only)          (Step 9)
     #   D4i = Step 9 inconclusive                           (Step 9)
@@ -6732,9 +7207,10 @@ def main():
         reasons = []
         if d3:
             reasons.append(
-                "**Tool-call package substitution detected (AC-1.a).** "
-                "A malicious middleware is rewriting package-install commands "
-                "on the return path -- a code-execution-level finding."
+                "**Tool-call integrity anomaly detected (AC-1 / AC-1.a).** "
+                "A malicious middleware may be rewriting a structured tool name, "
+                "arguments, call count, or package-install command on the return "
+                "path -- a code-execution-level finding."
             )
         if err_severity == "critical":
             reasons.append(
@@ -6798,9 +7274,9 @@ def main():
             )
         if d3i:
             medium_reasons.append(
-                "Tool-call substitution test (Step 8) was **inconclusive**: "
-                "every probe errored, so the relay's AC-1.a behavior could not "
-                "be verified -- a relay that blocks plaintext echo is itself a red flag."
+                "Tool-call integrity test (Step 8) was **inconclusive**: at least "
+                "one text or structured Tool Call path could not be verified. "
+                "The relay may reject strict tool schemas or block the probe format."
             )
         if d4m:
             medium_reasons.append(

--- a/audit.py
+++ b/audit.py
@@ -4,8 +4,8 @@
 # Regenerate after modular audit changes with:
 #   python3 scripts/build-standalone.py
 # CI verifies this generated artifact plus key behavior regressions.
-# source_sha256: 49bb2b7d0ec531ddd7b6c7deafd233a5554578687203e667398b195c9b3e8f9c
-# standalone_body_sha256: 6dc89c322e3dffebe16db29d869bc2281f0609fe395c625648a3e2ac9217ba64
+# source_sha256: 080a946c55345e6c3a82b26976b8c13fdd39228efb5bc831deaeadb166e58db9
+# standalone_body_sha256: 974a59b8083b38e56119e3fe5abda52f83a6a212491ac416eaefc2ac8cfad06e
 # END GENERATED STANDALONE HEADER
 
 """
@@ -2462,6 +2462,7 @@ import json
 import uuid
 
 
+
 PROBE_PROMPT = (
     "Call the provided record tool exactly once with the exact arguments "
     "encoded in its schema. Do not answer in text."
@@ -2489,8 +2490,8 @@ def _json_deep_equal(left, right):
     return left == right
 
 
-def format_tool_calls_preview(calls, max_chars=240):
-    """Return a Markdown-safe, bounded preview of arguments only."""
+def format_tool_calls_preview(calls, max_chars=240, api_key=""):
+    """Return a redacted, Markdown-safe, bounded preview of arguments only."""
     arguments = [
         call.get("arguments") if isinstance(call, dict) else None
         for call in calls
@@ -2501,6 +2502,7 @@ def format_tool_calls_preview(calls, max_chars=240):
         separators=(",", ":"),
         default=str,
     )
+    text = redact_sensitive_text(text, api_key)
     text = text.replace("|", "\\|").replace("`", "\\`")
     limit = max(3, int(max_chars))
     if len(text) > limit:
@@ -2513,14 +2515,15 @@ def analyze_tool_call_integrity(response, expected_name, expected_arguments):
     if not isinstance(response, dict):
         response = {}
     if "error" in response:
-        error = str(response.get("error", ""))[:200]
         return {
             "verdict": "inconclusive",
             "expected_count": 1,
             "received_count": 0,
             "name_match": None,
             "arguments_match": None,
-            "findings": [f"Structured Tool Call probe failed: {error}"],
+            "findings": [
+                "Structured Tool Call probe failed; support could not be verified"
+            ],
         }
     calls = response.get("tool_calls", [])
     if not isinstance(calls, list) or any(not isinstance(call, dict) for call in calls):
@@ -2561,15 +2564,9 @@ def analyze_tool_call_integrity(response, expected_name, expected_arguments):
             f"Tool call count changed: expected 1, received {len(calls)}"
         )
     if not type_match:
-        findings.append(
-            f"Tool call type changed: expected 'function', "
-            f"received {call.get('type')!r}"
-        )
+        findings.append("Tool call type differed from the forced function type")
     if not name_match:
-        findings.append(
-            f"Tool name changed: expected {expected_name!r}, "
-            f"received {call.get('name')!r}"
-        )
+        findings.append("Tool name differed from the forced canary name")
     if call.get("arguments_error"):
         findings.append(
             f"Tool arguments could not be parsed: {call['arguments_error']}"
@@ -3798,6 +3795,18 @@ def _redact_api_key(text: str, api_key: str) -> str:
             "<REDACTED_PREFIX>",
             text,
         )
+    return text
+
+
+def redact_sensitive_text(text: str, api_key: str = "") -> str:
+    """Redact the caller credential and known secret shapes from report text."""
+    if not isinstance(text, str):
+        text = str(text)
+    if not isinstance(api_key, str):
+        api_key = ""
+    text = _redact_api_key(text, api_key)
+    for pattern, _kind in SECRET_REGEX_PATTERNS:
+        text = pattern.sub("<REDACTED_SECRET>", text)
     return text
 
 
@@ -6165,14 +6174,16 @@ def test_tool_substitution(client, report):
     report.h3("Structured Tool Call probe (non-streaming)")
     try:
         structured = run_tool_call_integrity_test(client)
-    except Exception as exc:
+    except Exception:
         structured = {
             "verdict": "inconclusive",
             "expected_count": 1,
             "received_count": 0,
             "name_match": None,
             "arguments_match": None,
-            "findings": [f"Structured probe failed: {exc}"],
+            "findings": [
+                "Structured Tool Call probe failed; support could not be verified"
+            ],
             "received_calls": [],
         }
 
@@ -6190,7 +6201,10 @@ def test_tool_substitution(client, report):
         f"**Tool name match**: `{_match_label(structured.get('name_match'))}` | "
         f"**Arguments match**: `{_match_label(structured.get('arguments_match'))}`"
     )
-    preview = format_tool_calls_preview(structured.get("received_calls", []))
+    preview = format_tool_calls_preview(
+        structured.get("received_calls", []),
+        api_key=getattr(client, "api_key", ""),
+    )
     report.p(f"**Received arguments preview**: `{preview}`")
     if structured.get("findings"):
         report.p("\n**Structured findings:**")

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,23 +16,23 @@
 | 单文件版版本 | `v2.4` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **808** | `pytest --collect-only` |
-| 测试数 (static) | 778 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **840** | `pytest --collect-only` |
+| 测试数 (static) | 807 | grep `def test_*` in tests/ |
 | CLI flag 数 | 22 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
-| ROADMAP 上次更新 | 2026-08-16 | `ROADMAP.md` 头部 |
+| ROADMAP 上次更新 | 2026-08-24 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
-| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 808] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `ef3a15b` | recent reachable commit; `--check` allows follow-up metrics commits |
+| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 808, 840] | grep `Final test count: N/N passing` |
+| Recorded commit SHA | `00ce802` | recent reachable commit; `--check` allows follow-up metrics commits |
 | Recorded commit date | 2026-08-16 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.4`。
 - ✅ 步骤数一致：14。
-- ℹ️ pytest (808) vs 静态 (778) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
+- ℹ️ pytest (840) vs 静态 (807) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/docs/_metrics.md
+++ b/docs/_metrics.md
@@ -16,23 +16,23 @@
 | 单文件版版本 | `v2.4` | `audit.py` docstring |
 | 步骤数 (Step N) | **14** | grep `Step N` in `scripts/audit.py` |
 | 步骤数 (单文件版) | 14 | grep `Step N` in `audit.py` |
-| 测试数 (pytest) | **840** | `pytest --collect-only` |
-| 测试数 (static) | 807 | grep `def test_*` in tests/ |
+| 测试数 (pytest) | **843** | `pytest --collect-only` |
+| 测试数 (static) | 810 | grep `def test_*` in tests/ |
 | CLI flag 数 | 22 | grep `add_argument("--*")` |
 | profile 选项 | general, web3, full | argparse choices |
 | ROADMAP 上次更新 | 2026-08-24 | `ROADMAP.md` 头部 |
 | Codex review 提及次数 | 4 | grep `Codex review (cycle\|round)` 在 Shipped 节 |
 | Codex review 已编号轮次（最大） | 6 | grep `Nth Codex review round` |
 | Codex bug 累计（最新声称） | 18 | grep `cumulative N real bug` |
-| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 808, 840] | grep `Final test count: N/N passing` |
-| Recorded commit SHA | `00ce802` | recent reachable commit; `--check` allows follow-up metrics commits |
-| Recorded commit date | 2026-08-16 | recent reachable commit; `--check` allows follow-up metrics commits |
+| 测试数演进 (ROADMAP) | [546, 560, 562, 586, 642, 700, 808, 843] | grep `Final test count: N/N passing` |
+| Recorded commit SHA | `af926cd` | recent reachable commit; `--check` allows follow-up metrics commits |
+| Recorded commit date | 2026-08-24 | recent reachable commit; `--check` allows follow-up metrics commits |
 
 ## 一致性自检
 
 - ✅ 版本一致：两份都是 `v2.4`。
 - ✅ 步骤数一致：14。
-- ℹ️ pytest (840) vs 静态 (807) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
+- ℹ️ pytest (843) vs 静态 (810) 差距 >20，多出来的来自 parametrize/fixture——以 pytest 为准。
 
 ## 人工 review 边界（脚本抓不到，每次发布要人工核对）
 

--- a/docs/discoverability.md
+++ b/docs/discoverability.md
@@ -61,7 +61,7 @@ Observed at: 2026-06-01T06:27:04Z
 | Issue | Labels | Discovery role |
 | --- | --- | --- |
 | [#31 Track relay prompt injection examples and detection gaps](https://github.com/toby-bridges/api-relay-audit/issues/31) | `documentation`, `enhancement` | Long-tail prompt injection landing surface. |
-| [#32 Improve tool-call rewriting detection for structured tool payloads](https://github.com/toby-bridges/api-relay-audit/issues/32) | `enhancement`, `help wanted` | Tool-call rewriting contributor task. |
+| [#32 Improve tool-call rewriting detection for structured tool payloads](https://github.com/toby-bridges/api-relay-audit/issues/32) | `enhancement`, `help wanted` | Implemented by the Step 8 structured Tool Call integrity probe; closes when this change merges. |
 | [#33 Document Web3 wallet prompt injection threat model](https://github.com/toby-bridges/api-relay-audit/issues/33) | `documentation`, `help wanted` | Web3 wallet prompt injection landing surface. |
 | [#34 Track LLM proxy security test cases](https://github.com/toby-bridges/api-relay-audit/issues/34) | `documentation`, `enhancement` | LLM proxy security landing surface. |
 | [#35 SSE stream integrity: known relay anomaly patterns](https://github.com/toby-bridges/api-relay-audit/issues/35) | `documentation`, `enhancement` | SSE anomaly landing surface. |

--- a/docs/examples/sanitized-audit-report.fixture.json
+++ b/docs/examples/sanitized-audit-report.fixture.json
@@ -72,12 +72,12 @@
     },
     {
       "step_number": 8,
-      "step_name": "Tool-call rewriting",
+      "step_name": "Tool-call integrity",
       "step_status": "run",
       "verdict": "clean",
       "severity": "none",
-      "summary": "Pinned package-command probes remain unchanged in the fixture.",
-      "evidence_redacted": "pip, npm, cargo, and go command echoes match expected fixture text."
+      "summary": "Four pinned package commands plus one inert structured call match the expected tool name, arguments, and count.",
+      "evidence_redacted": "pip, npm, cargo, and go command echoes match; structured verdict=clean, expectedCount=1, receivedCount=1, nameMatch=true, argumentsMatch=true."
     },
     {
       "step_number": 9,

--- a/docs/examples/sanitized-audit-report.md
+++ b/docs/examples/sanitized-audit-report.md
@@ -25,7 +25,7 @@ real relay domains, API keys, wallet material, or private traffic.
 - Prompt injection: synthetic hidden-token delta shown as an anomaly.
 - Prompt extraction: one synthetic extraction result is shown as an anomaly.
 - Context length: inconclusive, not clean.
-- Tool-call rewriting: clean in this fixture.
+- Tool-call integrity: package-command text plus one inert structured Tool Call are clean in this fixture.
 - Error leakage: redacted internal path leak shown as an anomaly.
 - SSE anomalies: clean in this fixture.
 - Web3 wallet checks: clean in this fixture.
@@ -42,13 +42,27 @@ real relay domains, API keys, wallet material, or private traffic.
 | 5 | Instruction conflict and identity | `run` | `clean` | `none` | The fixture response respects the user-supplied identity instruction. |
 | 6 | Jailbreak extraction | `run` | `clean` | `none` | Jailbreak-style extraction probes are refused in the fixture. |
 | 7 | Context length | `run` | `inconclusive` | `medium` | The fixture includes an inconclusive context result to show that inconclusive is not clean. |
-| 8 | Tool-call rewriting | `run` | `clean` | `none` | Pinned package-command probes remain unchanged in the fixture. |
+| 8 | Tool-call integrity | `run` | `clean` | `none` | Four pinned package commands plus one inert structured call match the expected tool name, arguments, and count. |
 | 9 | Error response leakage | `run` | `anomaly` | `medium` | The fixture shows a redacted internal path leak without exposing real infrastructure. |
 | 10 | SSE stream integrity | `run` | `clean` | `none` | Anthropic-style stream events follow the expected fixture sequence. |
 | 11 | Web3 wallet prompt injection | `run` | `clean` | `none` | Wallet-safety refusal probes are handled safely in the fixture. |
 | 12 | Infrastructure fingerprint | `run` | `informational` | `none` | The fixture records an unknown relay framework without treating it as unsafe. |
 | 13 | Latency variance | `run` | `informational` | `none` | Latency observations are stable in the fixture. |
 | 14 | Upstream channel classifier | `run` | `inconclusive` | `medium` | The upstream channel cannot be classified from the fixture evidence. |
+
+### Step 8 Structured Evidence (Sanitized)
+
+| Field | Value |
+| --- | --- |
+| Structured verdict | `clean` |
+| Expected calls | `1` |
+| Observed calls | `1` |
+| Tool name match | `true` |
+| Arguments match | `true` |
+
+The fixture omits the randomized tool name and canary value. A live report
+shows only an escaped, length-bounded argument preview and never executes or
+returns a tool result.
 
 ## What This Example Shows
 

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -928,14 +928,16 @@ def test_tool_substitution(client, report):
     report.h3("Structured Tool Call probe (non-streaming)")
     try:
         structured = run_tool_call_integrity_test(client)
-    except Exception as exc:
+    except Exception:
         structured = {
             "verdict": "inconclusive",
             "expected_count": 1,
             "received_count": 0,
             "name_match": None,
             "arguments_match": None,
-            "findings": [f"Structured probe failed: {exc}"],
+            "findings": [
+                "Structured Tool Call probe failed; support could not be verified"
+            ],
             "received_calls": [],
         }
 
@@ -953,7 +955,10 @@ def test_tool_substitution(client, report):
         f"**Tool name match**: `{_match_label(structured.get('name_match'))}` | "
         f"**Arguments match**: `{_match_label(structured.get('arguments_match'))}`"
     )
-    preview = format_tool_calls_preview(structured.get("received_calls", []))
+    preview = format_tool_calls_preview(
+        structured.get("received_calls", []),
+        api_key=getattr(client, "api_key", ""),
+    )
     report.p(f"**Received arguments preview**: `{preview}`")
     if structured.get("findings"):
         report.p("\n**Structured findings:**")

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -4,7 +4,7 @@ API Relay Security Audit Tool v2.4
 
 Full 14-step audit: infrastructure recon, model list, token injection,
 prompt extraction, instruction conflict + identity, jailbreak, context
-length, tool-call substitution (AC-1.a), error response leakage (AC-2),
+length, tool-call integrity (AC-1 / AC-1.a), error response leakage (AC-2),
 stream integrity (AC-1 SSE), Web3 prompt injection (profile=web3|full),
 infrastructure fingerprint, latency variance, upstream channel classifier.
 Threat taxonomy follows Liu et al., *Your Agent Is Mine*, arXiv:2604.08407
@@ -67,6 +67,10 @@ from api_relay_audit.refusal import (
 )
 from api_relay_audit.reporter import Reporter
 from api_relay_audit.stream_integrity import analyze_stream
+from api_relay_audit.tool_call_integrity import (
+    format_tool_calls_preview,
+    run_tool_call_integrity_test,
+)
 from api_relay_audit.tool_substitution import run_tool_substitution_test
 from api_relay_audit.web3.injection_probes import run_web3_injection_probes
 
@@ -187,7 +191,8 @@ def parse_args():
                         "(10K/50K/100K/200K chars) to lower token cost. "
                         "Default is the full scan.")
     p.add_argument("--skip-tool-substitution", action="store_true",
-                   help="Skip tool-call package substitution test (AC-1.a)")
+                   help="Skip the entire Step 8 tool-call integrity test "
+                        "(text AC-1.a and structured AC-1 probes)")
     p.add_argument("--skip-error-leakage", action="store_true",
                    help="Skip error response header leakage test (Step 9, AC-2 adjacent)")
     p.add_argument("--aggressive-error-probes", action="store_true",
@@ -858,21 +863,21 @@ def test_jailbreak(client, report):
 
 
 def test_tool_substitution(client, report):
-    report.h2("8. Tool-Call Package Substitution (AC-1.a)")
+    report.h2("8. Tool-Call Integrity (AC-1 / AC-1.a)")
     report.p(
-        "Ask the model to echo exact package-install commands and verify "
-        "character-level integrity on the return path. A malicious middleware "
-        "running AC-1.a rewrites package names (e.g. `requests` -> `reqeusts` "
-        "typosquat) before the response reaches the client, giving the attacker "
-        "a durable supply-chain foothold on the agent's host. "
+        "Verify both package-install text and one inert, non-streaming structured "
+        "Tool Call on the return path. The structured call is inspected only: "
+        "the audit provides no executor, sends no tool result, and never runs "
+        "returned content. A malicious middleware can rewrite a tool name, "
+        "arguments, call count, or package command before it reaches the client. "
         "Reference: Liu et al., *Your Agent Is Mine*, arXiv:2604.08407 section 4.2.1.\n"
     )
-    report.p(
-        "Limitation: this is a text-echo surrogate. It does not catch AC-1 "
-        "rewrites that target only structured tool_call payloads.\n"
-    )
 
-    results, detected, inconclusive = run_tool_substitution_test(client, sleep=1.0)
+    report.h3("Package-command text probes (AC-1.a)")
+
+    results, text_detected, text_inconclusive = run_tool_substitution_test(
+        client, sleep=1.0,
+    )
 
     report.p("| Manager | Expected | Received | Verdict |")
     report.p("|---------|----------|----------|---------|")
@@ -902,31 +907,104 @@ def test_tool_substitution(client, report):
         for manager, error in error_diagnostics:
             report.p(f"- {manager}: {format_diagnosis(_diagnosis_for_error(error))}")
 
-    if detected:
+    if text_detected:
         subs = sum(1 for r in results if r["verdict"] == "substituted")
+        report.p(
+            f"🔴 **Package-command substitution detected (AC-1.a): "
+            f"{subs}/{len(results)} probes rewritten on return path.**"
+        )
+    elif text_inconclusive:
+        report.p(
+            "🟡 **Package-command text probes INCONCLUSIVE: every probe errored.**"
+        )
+    elif error_count > 0:
+        report.p(
+            f"Tool-call substitution test partially skipped "
+            f"({error_count}/{len(results)} probes errored).",
+        )
+    else:
+        report.p("🟢 Package-command text probes preserved exactly.")
+
+    report.h3("Structured Tool Call probe (non-streaming)")
+    try:
+        structured = run_tool_call_integrity_test(client)
+    except Exception as exc:
+        structured = {
+            "verdict": "inconclusive",
+            "expected_count": 1,
+            "received_count": 0,
+            "name_match": None,
+            "arguments_match": None,
+            "findings": [f"Structured probe failed: {exc}"],
+            "received_calls": [],
+        }
+
+    def _match_label(value):
+        if value is None:
+            return "unknown"
+        return "true" if value else "false"
+
+    report.p(f"**Structured verdict**: `{structured['verdict']}`")
+    report.p(
+        f"**Expected calls**: `{structured['expected_count']}` | "
+        f"**Observed calls**: `{structured['received_count']}`"
+    )
+    report.p(
+        f"**Tool name match**: `{_match_label(structured.get('name_match'))}` | "
+        f"**Arguments match**: `{_match_label(structured.get('arguments_match'))}`"
+    )
+    preview = format_tool_calls_preview(structured.get("received_calls", []))
+    report.p(f"**Received arguments preview**: `{preview}`")
+    if structured.get("findings"):
+        report.p("\n**Structured findings:**")
+        for finding in structured["findings"]:
+            safe = str(finding)[:240].replace("|", "\\|").replace("`", "\\`").replace("\n", " ")
+            report.p(f"- {safe}")
+
+    structured_anomaly = structured["verdict"] == "anomaly"
+    structured_inconclusive = structured["verdict"] == "inconclusive"
+    detected = text_detected or structured_anomaly
+    inconclusive = not detected and (text_inconclusive or structured_inconclusive)
+
+    if detected:
+        paths = []
+        if text_detected:
+            paths.append("package-command text")
+        if structured_anomaly:
+            paths.append("structured Tool Call")
         report.flag(
             "red",
-            f"Tool-call package substitution detected (AC-1.a): "
-            f"{subs}/{len(results)} probes rewritten on return path",
+            "Tool-call integrity anomaly detected (AC-1 / AC-1.a): "
+            + " and ".join(paths)
+            + " path failed integrity checks",
         )
     elif inconclusive:
+        paths = []
+        if text_inconclusive:
+            paths.append("package-command text")
+        if structured_inconclusive:
+            paths.append("structured Tool Call")
         report.flag(
             "yellow",
-            "Tool-call substitution test INCONCLUSIVE: every probe errored. "
-            "The relay may be blocking plaintext echo -- re-run with a different "
-            "model or consider this a red flag in itself.",
+            "Tool-call integrity test INCONCLUSIVE: "
+            + " and ".join(paths)
+            + " path could not be verified",
         )
     elif error_count > 0:
         report.flag(
             "yellow",
-            f"Tool-call substitution test partially skipped "
-            f"({error_count}/{len(results)} probes errored)",
+            f"No tool-call integrity anomaly detected, but "
+            f"{error_count}/{len(results)} package-command probes errored",
         )
     else:
-        report.flag("green", "No tool-call package substitution detected")
+        report.flag(
+            "green",
+            "Tool-call integrity clean: package-command text and structured "
+            "tool name, arguments, and call count all matched",
+        )
 
     state = "detected" if detected else ("inconclusive" if inconclusive else "clean")
-    print(f"  Done: tool-call substitution ({state})")
+    print(f"  Done: tool-call integrity ({state})")
     return detected, inconclusive
 
 
@@ -1762,18 +1840,18 @@ def main():
     else:
         print("[7/14] Context length test (skipped)")
 
-    # 8. Tool-call package substitution (AC-1.a)
+    # 8. Tool-call integrity (text AC-1.a + structured AC-1)
     substitution_detected = False
     substitution_inconclusive = False
     if not args.skip_tool_substitution:
-        print("[8/14] Tool-call substitution test...")
+        print("[8/14] Tool-call integrity test...")
         substitution_detected, substitution_inconclusive = _run_step(
-            "Step 8 tool substitution", report,
+            "Step 8 tool-call integrity", report,
             test_tool_substitution, client, report,
             default=(False, True), crashes=step_crashes,
         )
     else:
-        print("[8/14] Tool-call substitution test (skipped)")
+        print("[8/14] Tool-call integrity test (skipped)")
 
     # 9. Error response header leakage (AC-2 adjacent)
     err_severity = "none"
@@ -1857,8 +1935,8 @@ def main():
     #   D1i = Step 3 crashed / inconclusive                 (Step 3)
     #   D2  = user instructions overridden                  (Step 5)
     #   D2i = Step 5 crashed / inconclusive                 (Step 5)
-    #   D3  = tool-call package substitution detected       (Step 8)
-    #   D3i = Step 8 inconclusive (all probes errored)      (Step 8)
+    #   D3  = text or structured Tool Call anomaly          (Step 8)
+    #   D3i = Step 8 text/structured path inconclusive      (Step 8)
     #   D4  = error response leakage (critical or high)     (Step 9)
     #   D4m = error response leakage (medium only)          (Step 9)
     #   D4i = Step 9 inconclusive                           (Step 9)
@@ -1893,9 +1971,10 @@ def main():
         reasons = []
         if d3:
             reasons.append(
-                "**Tool-call package substitution detected (AC-1.a).** "
-                "A malicious middleware is rewriting package-install commands "
-                "on the return path -- a code-execution-level finding."
+                "**Tool-call integrity anomaly detected (AC-1 / AC-1.a).** "
+                "A malicious middleware may be rewriting a structured tool name, "
+                "arguments, call count, or package-install command on the return "
+                "path -- a code-execution-level finding."
             )
         if err_severity == "critical":
             reasons.append(
@@ -1959,9 +2038,9 @@ def main():
             )
         if d3i:
             medium_reasons.append(
-                "Tool-call substitution test (Step 8) was **inconclusive**: "
-                "every probe errored, so the relay's AC-1.a behavior could not "
-                "be verified -- a relay that blocks plaintext echo is itself a red flag."
+                "Tool-call integrity test (Step 8) was **inconclusive**: at least "
+                "one text or structured Tool Call path could not be verified. "
+                "The relay may reject strict tool schemas or block the probe format."
             )
         if d4m:
             medium_reasons.append(

--- a/scripts/build-standalone.py
+++ b/scripts/build-standalone.py
@@ -46,6 +46,7 @@ SOURCE_PATHS = (
     "api_relay_audit/refusal.py",
     "api_relay_audit/reporter.py",
     "api_relay_audit/stream_integrity.py",
+    "api_relay_audit/tool_call_integrity.py",
     "api_relay_audit/tool_substitution.py",
     "api_relay_audit/transparent_log.py",
     "api_relay_audit/web3/injection_probes.py",
@@ -400,6 +401,10 @@ SECTIONS = (
     Section(
         "Context length scan",
         "api_relay_audit/context.py",
+    ),
+    Section(
+        "Structured Tool Call integrity detector",
+        "api_relay_audit/tool_call_integrity.py",
     ),
     Section(
         "Tool-call substitution detector",

--- a/scripts/build-standalone.py
+++ b/scripts/build-standalone.py
@@ -405,6 +405,7 @@ SECTIONS = (
     Section(
         "Structured Tool Call integrity detector",
         "api_relay_audit/tool_call_integrity.py",
+        drop_import_prefixes=("from api_relay_audit.error_leakage import ",),
     ),
     Section(
         "Tool-call substitution detector",

--- a/scripts/extract-data.py
+++ b/scripts/extract-data.py
@@ -101,16 +101,22 @@ def parse_report(file_path):
     if "owned_by: openai" in content_lower:
         api_format = "Both" if "owned_by: vertex-ai" in content_lower else "OpenAI"
 
-    # Tool-call package substitution (Step 8, AC-1.a)
+    # Tool-call integrity (Step 8, structured fields are optional for legacy data)
     tool_substitution = {"detected": False, "probes": []}
     sub_section_match = re.search(
-        r"## 8\. Tool-Call Package Substitution.*?(?=\n## |\Z)",
+        r"## 8\. (?:Tool-Call Integrity|Tool-Call Package Substitution)"
+        r".*?(?=\n## |\Z)",
         content, re.DOTALL,
     )
     if sub_section_match:
         section = sub_section_match.group(0)
         # Detection verdict from the flag line
-        if "SUBSTITUTED" in section or "substitution detected" in section.lower():
+        if (
+            "SUBSTITUTED" in section
+            or "substitution detected" in section.lower()
+            or "integrity anomaly detected" in section.lower()
+            or "**Structured verdict**: `anomaly`" in section
+        ):
             tool_substitution["detected"] = True
         # Parse the per-probe table rows
         for line in section.split("\n"):
@@ -138,6 +144,31 @@ def parse_report(file_path):
                     "received": parts[2].strip("`"),
                     "verdict": verdict,
                 })
+
+        structured_verdict = re.search(
+            r"\*\*Structured verdict\*\*:\s*`([^`]+)`", section)
+        if structured_verdict:
+            expected_count = re.search(
+                r"\*\*Expected calls\*\*:\s*`(\d+)`", section)
+            received_count = re.search(
+                r"\*\*Observed calls\*\*:\s*`(\d+)`", section)
+            name_match = re.search(
+                r"\*\*Tool name match\*\*:\s*`(true|false|unknown)`", section)
+            arguments_match = re.search(
+                r"\*\*Arguments match\*\*:\s*`(true|false|unknown)`", section)
+
+            def parse_optional_bool(match):
+                if not match or match.group(1) == "unknown":
+                    return None
+                return match.group(1) == "true"
+
+            tool_substitution["structured"] = {
+                "verdict": structured_verdict.group(1),
+                "expectedCount": int(expected_count.group(1)) if expected_count else None,
+                "receivedCount": int(received_count.group(1)) if received_count else None,
+                "nameMatch": parse_optional_bool(name_match),
+                "argumentsMatch": parse_optional_bool(arguments_match),
+            }
 
     # Error response leakage (Step 9, AC-2 adjacent)
     error_leakage = {"severity": "none", "triggers": []}

--- a/tests/test_client_tool_probe.py
+++ b/tests/test_client_tool_probe.py
@@ -1,0 +1,272 @@
+"""Public-interface tests for APIClient structured Tool Call probes."""
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+from api_relay_audit.client import APIClient
+from api_relay_audit.transparent_log import TransparentLogger, sha256hex
+
+
+def make_client(format_name):
+    client = APIClient(
+        "https://relay.example.com/v1",
+        "sk-test-key",
+        "claude-test",
+        timeout=30,
+        verbose=False,
+    )
+    client._format = format_name
+    return client
+
+
+TOOL_SPEC = {
+    "name": "record_probe_fixed",
+    "description": "Record an inert canary without executing anything.",
+    "input_schema": {
+        "type": "object",
+        "properties": {"probe_token": {"type": "string"}},
+        "required": ["probe_token"],
+        "additionalProperties": False,
+    },
+}
+
+
+@patch("api_relay_audit.client.httpx.post")
+def test_anthropic_tool_probe_forces_one_strict_tool_and_normalizes_response(
+    mock_post,
+):
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "content": [
+            {"type": "text", "text": "calling now"},
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "record_probe_fixed",
+                "input": {"probe_token": "TC_fixed"},
+            },
+        ],
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 11, "output_tokens": 4},
+    }
+    mock_post.return_value = response
+    client = make_client("anthropic")
+
+    result = client.call_tool_probe(
+        [{"role": "user", "content": "call it"}],
+        TOOL_SPEC,
+        max_tokens=256,
+    )
+
+    assert result["tool_calls"] == [{
+        "type": "function",
+        "id": "toolu_1",
+        "name": "record_probe_fixed",
+        "arguments": {"probe_token": "TC_fixed"},
+        "arguments_error": None,
+    }]
+    assert result["stop_reason"] == "tool_use"
+    assert result["input_tokens"] == 11
+    assert result["output_tokens"] == 4
+    assert result["raw"] == response.json.return_value
+    assert result["time"] >= 0
+
+    called_url = mock_post.call_args.args[0]
+    body = mock_post.call_args.kwargs["json"]
+    assert called_url == "https://relay.example.com/v1/messages"
+    assert body["tools"] == [{**TOOL_SPEC, "strict": True}]
+    assert body["tool_choice"] == {
+        "type": "tool",
+        "name": "record_probe_fixed",
+        "disable_parallel_tool_use": True,
+    }
+    assert "tool_result" not in str(body)
+
+
+@patch("api_relay_audit.client.httpx.post")
+def test_openai_tool_probe_forces_one_strict_function_and_parses_arguments(
+    mock_post,
+):
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "choices": [{
+            "message": {
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "record_probe_fixed",
+                        "arguments": '{"probe_token":"TC_fixed"}',
+                    },
+                }],
+            },
+            "finish_reason": "tool_calls",
+        }],
+        "usage": {"prompt_tokens": 13, "completion_tokens": 5},
+    }
+    mock_post.return_value = response
+    client = make_client("openai")
+
+    result = client.call_tool_probe(
+        [{"role": "user", "content": "call it"}],
+        TOOL_SPEC,
+        max_tokens=256,
+    )
+
+    assert result["tool_calls"] == [{
+        "type": "function",
+        "id": "call_1",
+        "name": "record_probe_fixed",
+        "arguments": {"probe_token": "TC_fixed"},
+        "arguments_error": None,
+    }]
+    assert result["stop_reason"] == "tool_calls"
+    assert result["input_tokens"] == 13
+    assert result["output_tokens"] == 5
+
+    called_url = mock_post.call_args.args[0]
+    body = mock_post.call_args.kwargs["json"]
+    assert called_url == "https://relay.example.com/v1/chat/completions"
+    assert body["tools"] == [{
+        "type": "function",
+        "function": {
+            "name": TOOL_SPEC["name"],
+            "description": TOOL_SPEC["description"],
+            "parameters": TOOL_SPEC["input_schema"],
+            "strict": True,
+        },
+    }]
+    assert body["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "record_probe_fixed"},
+    }
+    assert body["parallel_tool_calls"] is False
+    assert "tool_result" not in str(body)
+
+
+@patch("api_relay_audit.client.httpx.post")
+def test_openai_tool_probe_preserves_multiple_calls_and_invalid_arguments(
+    mock_post,
+):
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "choices": [{
+            "message": {"tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "record_probe_fixed",
+                        "arguments": "{not-json",
+                    },
+                },
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {
+                        "name": "unexpected_tool",
+                        "arguments": "[]",
+                    },
+                },
+            ]},
+            "finish_reason": "tool_calls",
+        }],
+        "usage": {},
+    }
+    mock_post.return_value = response
+    client = make_client("openai")
+
+    result = client.call_tool_probe([], TOOL_SPEC)
+
+    assert len(result["tool_calls"]) == 2
+    assert result["tool_calls"][0]["arguments"] is None
+    assert result["tool_calls"][0]["arguments_error"] == "invalid JSON arguments"
+    assert result["tool_calls"][1]["arguments"] is None
+    assert result["tool_calls"][1]["arguments_error"] == (
+        "OpenAI tool arguments were not a JSON object"
+    )
+
+
+@patch("api_relay_audit.client.httpx.post")
+def test_tool_probe_http_error_uses_existing_error_shape(mock_post):
+    response = MagicMock(status_code=400, text="strict tools unsupported")
+    mock_post.return_value = response
+    client = make_client("anthropic")
+
+    result = client.call_tool_probe([], TOOL_SPEC)
+
+    assert result["error"] == "HTTP 400: strict tools unsupported"
+    assert result["diagnosis"]["category"] == "bad-request"
+    assert result["time"] >= 0
+
+
+@patch("api_relay_audit.client.httpx.post")
+def test_tool_probe_transparent_log_hashes_exact_wire_body(mock_post, tmp_path):
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "choices": [{"message": {"tool_calls": []}, "finish_reason": "stop"}],
+        "usage": {},
+    }
+    mock_post.return_value = response
+    client = make_client("openai")
+    log_path = tmp_path / "tool-probe.jsonl"
+    logger = TransparentLogger(str(log_path))
+    client.set_transparent_logger(logger)
+
+    client.call_tool_probe(
+        [{"role": "user", "content": "call it"}], TOOL_SPEC, max_tokens=256)
+    logger.close()
+
+    entry = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+    wire_body = mock_post.call_args.kwargs["json"]
+    assert entry["method"] == "tool_call_probe"
+    assert entry["request_body_sha256"] == sha256hex(json.dumps(wire_body))
+    assert "sk-test-key" not in log_path.read_text(encoding="utf-8")
+
+
+@patch("api_relay_audit.client.httpx.post")
+def test_tool_probe_uses_existing_format_detection_before_adapter(mock_post):
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "content": [],
+        "stop_reason": "end_turn",
+        "usage": {},
+    }
+    mock_post.return_value = response
+    client = make_client(None)
+
+    def detect_format():
+        client._format = "anthropic"
+        return True
+
+    client.ensure_format = MagicMock(side_effect=detect_format)
+
+    result = client.call_tool_probe([], TOOL_SPEC)
+
+    client.ensure_format.assert_called_once_with()
+    assert result["tool_calls"] == []
+    assert mock_post.call_args.args[0].endswith("/messages")
+
+
+@patch("api_relay_audit.client.httpx.post")
+def test_anthropic_tool_probe_preserves_tool_like_block_type_mutation(mock_post):
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "content": [{
+            "type": "custom_tool",
+            "id": "toolu_1",
+            "name": "record_probe_fixed",
+            "input": {"probe_token": "TC_fixed"},
+        }],
+        "stop_reason": "tool_use",
+        "usage": {},
+    }
+    mock_post.return_value = response
+    client = make_client("anthropic")
+
+    result = client.call_tool_probe([], TOOL_SPEC)
+
+    assert result["tool_calls"][0]["type"] == "custom_tool"
+    assert result["tool_calls"][0]["arguments"] == {"probe_token": "TC_fixed"}

--- a/tests/test_dual_distribution_parity.py
+++ b/tests/test_dual_distribution_parity.py
@@ -480,6 +480,52 @@ def test_standalone_ensure_format_real_body_detects_anthropic(monkeypatch):
     assert calls[0][2]["max_tokens"] == 1
 
 
+def test_standalone_tool_probe_uses_curl_adapter_and_normalizes_call(monkeypatch):
+    """The generated public interface must retain the curl-only transport."""
+    standalone = _load_standalone_audit()
+    client = standalone.APIClient(
+        "https://relay.example.com/v1",
+        "sk-test",
+        "claude-3-haiku",
+        verbose=False,
+    )
+    client._format = "anthropic"
+    calls = []
+
+    def fake_curl_post(url, headers, body):
+        calls.append((url, headers, body))
+        return {
+            "content": [{
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "record_probe_fixed",
+                "input": {"probe_token": "TC_fixed"},
+            }],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 9, "output_tokens": 3},
+        }
+
+    monkeypatch.setattr(client, "_curl_post", fake_curl_post)
+    result = client.call_tool_probe(
+        [{"role": "user", "content": "call it"}],
+        {
+            "name": "record_probe_fixed",
+            "description": "inert",
+            "input_schema": {
+                "type": "object",
+                "properties": {"probe_token": {"type": "string"}},
+                "required": ["probe_token"],
+                "additionalProperties": False,
+            },
+        },
+    )
+
+    assert result["tool_calls"][0]["arguments"] == {"probe_token": "TC_fixed"}
+    assert calls[0][0] == "https://relay.example.com/v1/messages"
+    assert calls[0][2]["tools"][0]["strict"] is True
+    assert calls[0][2]["tool_choice"]["disable_parallel_tool_use"] is True
+
+
 def _help_option_set(path):
     text = _help_text(path)
     return set(re.findall(r"--[a-z0-9-]+", text))
@@ -745,14 +791,20 @@ def _run_stubbed_audit_and_rating(module, monkeypatch, tmp_path, case_name, scen
         "test_instruction_conflict",
         lambda *args: scenario.get("overridden", False),
     )
-    monkeypatch.setattr(
-        module,
-        "test_tool_substitution",
-        lambda *args: (
-            scenario.get("substitution_detected", False),
-            scenario.get("substitution_inconclusive", False),
-        ),
-    )
+    if scenario.get("forbid_tool_substitution"):
+        def forbidden_tool_substitution(*args):
+            raise AssertionError("skip flag must not send any Step 8 request")
+
+        monkeypatch.setattr(module, "test_tool_substitution", forbidden_tool_substitution)
+    else:
+        monkeypatch.setattr(
+            module,
+            "test_tool_substitution",
+            lambda *args: (
+                scenario.get("substitution_detected", False),
+                scenario.get("substitution_inconclusive", False),
+            ),
+        )
     monkeypatch.setattr(
         module,
         "test_error_leakage",
@@ -779,23 +831,22 @@ def _run_stubbed_audit_and_rating(module, monkeypatch, tmp_path, case_name, scen
     )
 
     output = tmp_path / f"{module.__name__.replace('.', '_')}-{case_name}.md"
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "audit.py",
-            "--key",
-            "sk-test",
-            "--url",
-            "https://relay.example.com/v1",
-            "--model",
-            "claude-test",
-            "--profile",
-            "full",
-            "--output",
-            str(output),
-        ],
-    )
+    argv = [
+        "audit.py",
+        "--key",
+        "sk-test",
+        "--url",
+        "https://relay.example.com/v1",
+        "--model",
+        "claude-test",
+        "--profile",
+        "full",
+        "--output",
+        str(output),
+    ]
+    if scenario.get("skip_tool_substitution"):
+        argv.append("--skip-tool-substitution")
+    monkeypatch.setattr(sys, "argv", argv)
 
     module.main()
     return _extract_overall_rating(output.read_text(encoding="utf-8"))
@@ -808,6 +859,12 @@ def _run_stubbed_audit_and_rating(module, monkeypatch, tmp_path, case_name, scen
         ("d1_only", {"injection": 101}, "MEDIUM"),
         ("d1_and_d2", {"injection": 101, "overridden": True}, "HIGH"),
         ("d3_substitution", {"substitution_detected": True}, "HIGH"),
+        ("d3_inconclusive", {"substitution_inconclusive": True}, "MEDIUM"),
+        (
+            "step8_skipped",
+            {"skip_tool_substitution": True, "forbid_tool_substitution": True},
+            "LOW",
+        ),
         ("d4_medium", {"error_severity": "medium"}, "MEDIUM"),
         ("d4_high", {"error_severity": "high"}, "HIGH"),
         ("d5_anomaly", {"stream_verdict": "anomaly"}, "HIGH"),

--- a/tests/test_dual_distribution_parity.py
+++ b/tests/test_dual_distribution_parity.py
@@ -526,6 +526,32 @@ def test_standalone_tool_probe_uses_curl_adapter_and_normalizes_call(monkeypatch
     assert calls[0][2]["tool_choice"]["disable_parallel_tool_use"] is True
 
 
+def test_standalone_tool_call_preview_redacts_secret_values():
+    standalone = _load_standalone_audit()
+    caller_key = "sk-caller-key-abcdefghijklmnopqrstuvwxyz"
+    upstream_key = "sk-upstream-key-abcdefghijklmnopqrstuvwxyz"
+
+    preview = standalone.format_tool_calls_preview(
+        [{
+            "type": "function",
+            "name": "must-not-be-rendered",
+            "arguments": {
+                "caller": caller_key,
+                "upstream": upstream_key,
+            },
+            "arguments_error": None,
+        }],
+        max_chars=500,
+        api_key=caller_key,
+    )
+
+    assert caller_key not in preview
+    assert caller_key[:8] not in preview
+    assert upstream_key not in preview
+    assert "must-not-be-rendered" not in preview
+    assert "<REDACTED" in preview
+
+
 def _help_option_set(path):
     text = _help_text(path)
     return set(re.findall(r"--[a-z0-9-]+", text))

--- a/tests/test_example_report.py
+++ b/tests/test_example_report.py
@@ -129,7 +129,7 @@ def test_fixture_steps_cover_report_surface_and_verdicts():
         assert step["verdict"] in VERDICTS
         assert step["severity"] in SEVERITIES
     assert any("Web3" in step["step_name"] for step in steps)
-    assert any("Tool-call rewriting" == step["step_name"] for step in steps)
+    assert any("Tool-call integrity" == step["step_name"] for step in steps)
     assert any("SSE" in step["step_name"] for step in steps)
 
 

--- a/tests/test_extract_data_tool_calls.py
+++ b/tests/test_extract_data_tool_calls.py
@@ -1,0 +1,60 @@
+"""Extractor coverage for backward-compatible Step 8 structured fields."""
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "extract-data.py"
+SPEC = importlib.util.spec_from_file_location("extract_data", SCRIPT)
+extract_data = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(extract_data)
+
+
+def test_new_step8_report_extracts_optional_structured_verdict(tmp_path):
+    report = tmp_path / "audit-relay.md"
+    report.write_text(
+        """**Target**: `https://relay.example/v1`
+
+## 8. Tool-Call Integrity (AC-1 / AC-1.a)
+
+| Manager | Expected | Received | Verdict |
+|---------|----------|----------|---------|
+| pip | `pip install requests==2.31.0` | `pip install requests==2.31.0` | 🟢 exact |
+
+**Structured verdict**: `clean`
+**Expected calls**: `1` | **Observed calls**: `1`
+**Tool name match**: `true` | **Arguments match**: `true`
+""",
+        encoding="utf-8",
+    )
+
+    result = extract_data.parse_report(report)["toolSubstitution"]
+
+    assert result["detected"] is False
+    assert result["probes"][0]["verdict"] == "exact"
+    assert result["structured"] == {
+        "verdict": "clean",
+        "expectedCount": 1,
+        "receivedCount": 1,
+        "nameMatch": True,
+        "argumentsMatch": True,
+    }
+
+
+def test_legacy_step8_report_keeps_original_shape(tmp_path):
+    report = tmp_path / "audit-legacy.md"
+    report.write_text(
+        """## 8. Tool-Call Package Substitution (AC-1.a)
+
+| Manager | Expected | Received | Verdict |
+|---------|----------|----------|---------|
+| npm | `npm install lodash@4.17.21` | `npm install lodasb@4.17.21` | 🔴 SUBSTITUTED |
+""",
+        encoding="utf-8",
+    )
+
+    result = extract_data.parse_report(report)["toolSubstitution"]
+
+    assert result["detected"] is True
+    assert result["probes"][0]["verdict"] == "substituted"
+    assert "structured" not in result

--- a/tests/test_step8_tool_integrity.py
+++ b/tests/test_step8_tool_integrity.py
@@ -89,3 +89,41 @@ def test_text_anomaly_wins_over_structured_inconclusive(monkeypatch):
 
     assert audit.test_tool_substitution(MagicMock(), report) == (True, False)
     assert report.summary[-1][0] == "red"
+
+
+def test_structured_report_hides_tool_name_and_redacts_secrets(monkeypatch):
+    caller_key = "sk-caller-key-abcdefghijklmnopqrstuvwxyz"
+    upstream_key = "sk-upstream-key-abcdefghijklmnopqrstuvwxyz"
+    malicious_name = "read_private_file"
+    structured = _structured("anomaly")
+    structured["received_calls"] = [{
+        "type": "function",
+        "id": "tool-1",
+        "name": malicious_name,
+        "arguments": {
+            "caller": caller_key,
+            "upstream": upstream_key,
+        },
+        "arguments_error": None,
+    }]
+    monkeypatch.setattr(
+        audit,
+        "run_tool_substitution_test",
+        MagicMock(return_value=TEXT_CLEAN),
+    )
+    monkeypatch.setattr(
+        audit,
+        "run_tool_call_integrity_test",
+        MagicMock(return_value=structured),
+    )
+    client = MagicMock()
+    client.api_key = caller_key
+    report = Reporter()
+
+    assert audit.test_tool_substitution(client, report) == (True, False)
+    rendered = "".join(report.sections)
+    assert malicious_name not in rendered
+    assert caller_key not in rendered
+    assert caller_key[:8] not in rendered
+    assert upstream_key not in rendered
+    assert "<REDACTED" in rendered

--- a/tests/test_step8_tool_integrity.py
+++ b/tests/test_step8_tool_integrity.py
@@ -1,0 +1,91 @@
+"""Step 8 orchestration tests for text and structured Tool Call probes."""
+
+from unittest.mock import MagicMock
+
+import scripts.audit as audit
+from api_relay_audit.reporter import Reporter
+
+
+TEXT_CLEAN = ([
+    {
+        "manager": "pip",
+        "expected": "pip install requests==2.31.0",
+        "received": "pip install requests==2.31.0",
+        "verdict": "exact",
+    }
+], False, False)
+
+TEXT_ANOMALY = ([
+    {
+        "manager": "pip",
+        "expected": "pip install requests==2.31.0",
+        "received": "pip install reqeusts==2.31.0",
+        "verdict": "substituted",
+    }
+], True, False)
+
+
+def _structured(verdict):
+    return {
+        "verdict": verdict,
+        "expected_count": 1,
+        "received_count": 1 if verdict != "inconclusive" else 0,
+        "name_match": True if verdict == "clean" else None,
+        "arguments_match": True if verdict == "clean" else None,
+        "findings": [] if verdict == "clean" else [f"structured {verdict}"],
+        "received_calls": [],
+    }
+
+
+def test_text_clean_and_structured_clean_is_step8_clean(monkeypatch):
+    monkeypatch.setattr(audit, "run_tool_substitution_test", MagicMock(return_value=TEXT_CLEAN))
+    monkeypatch.setattr(
+        audit,
+        "run_tool_call_integrity_test",
+        MagicMock(return_value=_structured("clean")),
+        raising=False,
+    )
+    report = Reporter()
+
+    assert audit.test_tool_substitution(MagicMock(), report) == (False, False)
+    assert report.summary[-1][0] == "green"
+    assert "Tool-Call Integrity (AC-1 / AC-1.a)" in "".join(report.sections)
+
+
+def test_structured_anomaly_sets_d3(monkeypatch):
+    monkeypatch.setattr(audit, "run_tool_substitution_test", MagicMock(return_value=TEXT_CLEAN))
+    monkeypatch.setattr(
+        audit,
+        "run_tool_call_integrity_test",
+        MagicMock(return_value=_structured("anomaly")),
+    )
+    report = Reporter()
+
+    assert audit.test_tool_substitution(MagicMock(), report) == (True, False)
+    assert report.summary[-1][0] == "red"
+
+
+def test_structured_inconclusive_sets_d3i(monkeypatch):
+    monkeypatch.setattr(audit, "run_tool_substitution_test", MagicMock(return_value=TEXT_CLEAN))
+    monkeypatch.setattr(
+        audit,
+        "run_tool_call_integrity_test",
+        MagicMock(return_value=_structured("inconclusive")),
+    )
+    report = Reporter()
+
+    assert audit.test_tool_substitution(MagicMock(), report) == (False, True)
+    assert report.summary[-1][0] == "yellow"
+
+
+def test_text_anomaly_wins_over_structured_inconclusive(monkeypatch):
+    monkeypatch.setattr(audit, "run_tool_substitution_test", MagicMock(return_value=TEXT_ANOMALY))
+    monkeypatch.setattr(
+        audit,
+        "run_tool_call_integrity_test",
+        MagicMock(return_value=_structured("inconclusive")),
+    )
+    report = Reporter()
+
+    assert audit.test_tool_substitution(MagicMock(), report) == (True, False)
+    assert report.summary[-1][0] == "red"

--- a/tests/test_tool_call_integrity.py
+++ b/tests/test_tool_call_integrity.py
@@ -65,8 +65,10 @@ def test_changed_tool_name_is_anomaly():
     assert result["name_match"] is False
     assert result["arguments_match"] is True
     assert result["findings"] == [
-        "Tool name changed: expected 'record_probe_fixed', received 'read_private_file'"
+        "Tool name differed from the forced canary name"
     ]
+    assert "record_probe_fixed" not in result["findings"][0]
+    assert "read_private_file" not in result["findings"][0]
 
 
 def test_changed_arguments_are_anomaly_even_when_json_key_order_is_irrelevant():
@@ -232,8 +234,9 @@ def test_probe_error_is_inconclusive():
     assert result["name_match"] is None
     assert result["arguments_match"] is None
     assert result["findings"] == [
-        "Structured Tool Call probe failed: HTTP 400 strict tools unsupported"
+        "Structured Tool Call probe failed; support could not be verified"
     ]
+    assert "strict tools unsupported" not in result["findings"][0]
 
 
 def test_malformed_normalized_response_is_inconclusive():
@@ -291,7 +294,7 @@ def test_non_function_tool_type_is_anomaly():
 
     assert result["verdict"] == "anomaly"
     assert result["findings"] == [
-        "Tool call type changed: expected 'function', received 'custom'"
+        "Tool call type differed from the forced function type"
     ]
 
 
@@ -380,3 +383,27 @@ def test_tool_call_preview_is_escaped_and_bounded():
     assert "\\`" in preview
     assert "must-not-be-rendered" not in preview
     assert preview.endswith("...")
+
+
+def test_tool_call_preview_redacts_caller_key_and_secret_shapes():
+    caller_key = "sk-caller-key-abcdefghijklmnopqrstuvwxyz"
+    leaked_key = "sk-upstream-key-abcdefghijklmnopqrstuvwxyz"
+
+    preview = format_tool_calls_preview(
+        [{
+            "type": "function",
+            "name": "must-not-be-rendered",
+            "arguments": {
+                "caller": caller_key,
+                "upstream": leaked_key,
+            },
+            "arguments_error": None,
+        }],
+        max_chars=500,
+        api_key=caller_key,
+    )
+
+    assert caller_key not in preview
+    assert caller_key[:8] not in preview
+    assert leaked_key not in preview
+    assert "<REDACTED" in preview

--- a/tests/test_tool_call_integrity.py
+++ b/tests/test_tool_call_integrity.py
@@ -1,0 +1,382 @@
+"""Behavior tests for structured Tool Call integrity detection."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from api_relay_audit.tool_call_integrity import (
+    analyze_tool_call_integrity,
+    format_tool_calls_preview,
+    run_tool_call_integrity_test,
+)
+
+
+def test_exact_single_tool_call_is_clean():
+    expected = {"probe_token": "TC_fixed", "sequence": 1, "mode": "observe_only"}
+    response = {
+        "tool_calls": [
+            {
+                "type": "function",
+                "id": "tool-1",
+                "name": "record_probe_fixed",
+                "arguments": dict(expected),
+                "arguments_error": None,
+            }
+        ],
+        "stop_reason": "tool_use",
+    }
+
+    result = analyze_tool_call_integrity(
+        response,
+        expected_name="record_probe_fixed",
+        expected_arguments=expected,
+    )
+
+    assert result == {
+        "verdict": "clean",
+        "expected_count": 1,
+        "received_count": 1,
+        "name_match": True,
+        "arguments_match": True,
+        "findings": [],
+    }
+
+
+def test_changed_tool_name_is_anomaly():
+    expected = {"probe_token": "TC_fixed", "sequence": 1, "mode": "observe_only"}
+    response = {
+        "tool_calls": [{
+            "type": "function",
+            "id": "tool-1",
+            "name": "read_private_file",
+            "arguments": dict(expected),
+            "arguments_error": None,
+        }],
+        "stop_reason": "tool_use",
+    }
+
+    result = analyze_tool_call_integrity(
+        response,
+        expected_name="record_probe_fixed",
+        expected_arguments=expected,
+    )
+
+    assert result["verdict"] == "anomaly"
+    assert result["name_match"] is False
+    assert result["arguments_match"] is True
+    assert result["findings"] == [
+        "Tool name changed: expected 'record_probe_fixed', received 'read_private_file'"
+    ]
+
+
+def test_changed_arguments_are_anomaly_even_when_json_key_order_is_irrelevant():
+    expected = {"probe_token": "TC_fixed", "sequence": 1, "mode": "observe_only"}
+    response = {
+        "tool_calls": [{
+            "type": "function",
+            "id": "tool-1",
+            "name": "record_probe_fixed",
+            "arguments": {
+                "mode": "observe_only",
+                "sequence": 2,
+                "probe_token": "TC_fixed",
+            },
+            "arguments_error": None,
+        }],
+        "stop_reason": "tool_use",
+    }
+
+    result = analyze_tool_call_integrity(
+        response,
+        expected_name="record_probe_fixed",
+        expected_arguments=expected,
+    )
+
+    assert result["verdict"] == "anomaly"
+    assert result["name_match"] is True
+    assert result["arguments_match"] is False
+    assert result["findings"] == ["Tool arguments differed from the forced canary payload"]
+
+
+def test_json_argument_types_are_compared_strictly():
+    result = analyze_tool_call_integrity(
+        {
+            "tool_calls": [{
+                "type": "function",
+                "id": "tool-1",
+                "name": "record_probe_fixed",
+                "arguments": {
+                    "probe_token": "TC_fixed",
+                    "sequence": True,
+                    "mode": "observe_only",
+                },
+                "arguments_error": None,
+            }],
+            "stop_reason": "tool_use",
+        },
+        expected_name="record_probe_fixed",
+        expected_arguments={
+            "probe_token": "TC_fixed",
+            "sequence": 1,
+            "mode": "observe_only",
+        },
+    )
+
+    assert result["verdict"] == "anomaly"
+    assert result["arguments_match"] is False
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"probe_token": "TC_fixed", "sequence": 1},
+        {
+            "probe_token": "TC_fixed",
+            "sequence": 1,
+            "mode": "observe_only",
+            "extra": "injected",
+        },
+    ],
+)
+def test_missing_or_extra_json_fields_are_anomalies(arguments):
+    result = analyze_tool_call_integrity(
+        {
+            "tool_calls": [{
+                "type": "function",
+                "id": "tool-1",
+                "name": "record_probe_fixed",
+                "arguments": arguments,
+                "arguments_error": None,
+            }],
+            "stop_reason": "tool_use",
+        },
+        expected_name="record_probe_fixed",
+        expected_arguments={
+            "probe_token": "TC_fixed",
+            "sequence": 1,
+            "mode": "observe_only",
+        },
+    )
+
+    assert result["verdict"] == "anomaly"
+    assert result["arguments_match"] is False
+
+
+def test_extra_tool_call_is_anomaly():
+    expected = {"probe_token": "TC_fixed", "sequence": 1, "mode": "observe_only"}
+    clean_call = {
+        "type": "function",
+        "id": "tool-1",
+        "name": "record_probe_fixed",
+        "arguments": dict(expected),
+        "arguments_error": None,
+    }
+    response = {
+        "tool_calls": [clean_call, {**clean_call, "id": "tool-2"}],
+        "stop_reason": "tool_use",
+    }
+
+    result = analyze_tool_call_integrity(
+        response,
+        expected_name="record_probe_fixed",
+        expected_arguments=expected,
+    )
+
+    assert result["verdict"] == "anomaly"
+    assert result["received_count"] == 2
+    assert result["findings"] == ["Tool call count changed: expected 1, received 2"]
+
+
+def test_no_tool_call_is_inconclusive_when_relay_does_not_honor_forcing():
+    result = analyze_tool_call_integrity(
+        {"tool_calls": [], "stop_reason": "stop"},
+        expected_name="record_probe_fixed",
+        expected_arguments={"probe_token": "TC_fixed"},
+    )
+
+    assert result == {
+        "verdict": "inconclusive",
+        "expected_count": 1,
+        "received_count": 0,
+        "name_match": None,
+        "arguments_match": None,
+        "findings": [
+            "Forced tool request returned no structured Tool Call; support could not be verified"
+        ],
+    }
+
+
+def test_tool_stop_reason_without_calls_is_anomaly():
+    result = analyze_tool_call_integrity(
+        {"tool_calls": [], "stop_reason": "tool_calls"},
+        expected_name="record_probe_fixed",
+        expected_arguments={"probe_token": "TC_fixed"},
+    )
+
+    assert result["verdict"] == "anomaly"
+    assert result["received_count"] == 0
+    assert result["findings"] == [
+        "Response claimed a Tool Call stop reason but contained zero Tool Calls"
+    ]
+
+
+def test_probe_error_is_inconclusive():
+    result = analyze_tool_call_integrity(
+        {"error": "HTTP 400 strict tools unsupported"},
+        expected_name="record_probe_fixed",
+        expected_arguments={"probe_token": "TC_fixed"},
+    )
+
+    assert result["verdict"] == "inconclusive"
+    assert result["received_count"] == 0
+    assert result["name_match"] is None
+    assert result["arguments_match"] is None
+    assert result["findings"] == [
+        "Structured Tool Call probe failed: HTTP 400 strict tools unsupported"
+    ]
+
+
+def test_malformed_normalized_response_is_inconclusive():
+    result = analyze_tool_call_integrity(
+        {"tool_calls": "not-a-list", "stop_reason": None},
+        expected_name="record_probe_fixed",
+        expected_arguments={"probe_token": "TC_fixed"},
+    )
+
+    assert result["verdict"] == "inconclusive"
+    assert result["received_count"] == 0
+    assert result["findings"] == [
+        "Structured Tool Call response format was invalid"
+    ]
+
+
+def test_invalid_json_arguments_are_anomaly():
+    result = analyze_tool_call_integrity(
+        {
+            "tool_calls": [{
+                "type": "function",
+                "id": "tool-1",
+                "name": "record_probe_fixed",
+                "arguments": None,
+                "arguments_error": "invalid JSON arguments",
+            }],
+            "stop_reason": "tool_calls",
+        },
+        expected_name="record_probe_fixed",
+        expected_arguments={"probe_token": "TC_fixed"},
+    )
+
+    assert result["verdict"] == "anomaly"
+    assert result["arguments_match"] is False
+    assert result["findings"] == [
+        "Tool arguments could not be parsed: invalid JSON arguments"
+    ]
+
+
+def test_non_function_tool_type_is_anomaly():
+    result = analyze_tool_call_integrity(
+        {
+            "tool_calls": [{
+                "type": "custom",
+                "id": "tool-1",
+                "name": "record_probe_fixed",
+                "arguments": {"probe_token": "TC_fixed"},
+                "arguments_error": None,
+            }],
+            "stop_reason": "tool_calls",
+        },
+        expected_name="record_probe_fixed",
+        expected_arguments={"probe_token": "TC_fixed"},
+    )
+
+    assert result["verdict"] == "anomaly"
+    assert result["findings"] == [
+        "Tool call type changed: expected 'function', received 'custom'"
+    ]
+
+
+def test_runner_builds_inert_strict_probe_and_returns_clean_verdict():
+    nonce = "0123456789abcdef0123456789abcdef"
+    client = MagicMock()
+
+    def respond(messages, tool_spec, max_tokens=256):
+        assert messages == [{
+            "role": "user",
+            "content": (
+                "Call the provided record tool exactly once with the exact "
+                "arguments encoded in its schema. Do not answer in text."
+            ),
+        }]
+        assert tool_spec == {
+            "name": "record_probe_0123456789ab",
+            "description": (
+                "Record an inert relay-audit canary. This tool performs no I/O, "
+                "has no side effects, and will not be executed. Call it exactly once."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "probe_token": {"type": "string", "enum": [f"TC_{nonce}"]},
+                    "sequence": {"type": "integer", "enum": [1]},
+                    "mode": {"type": "string", "enum": ["observe_only"]},
+                },
+                "required": ["probe_token", "sequence", "mode"],
+                "additionalProperties": False,
+            },
+        }
+        return {
+            "tool_calls": [{
+                "type": "function",
+                "id": "tool-1",
+                "name": tool_spec["name"],
+                "arguments": {
+                    "mode": "observe_only",
+                    "sequence": 1,
+                    "probe_token": f"TC_{nonce}",
+                },
+                "arguments_error": None,
+            }],
+            "stop_reason": "tool_use",
+        }
+
+    client.call_tool_probe.side_effect = respond
+
+    result = run_tool_call_integrity_test(client, nonce_factory=lambda: nonce)
+
+    assert result["verdict"] == "clean"
+    assert result["expected_name"] == "record_probe_0123456789ab"
+    assert result["expected_arguments"] == {
+        "probe_token": f"TC_{nonce}",
+        "sequence": 1,
+        "mode": "observe_only",
+    }
+    assert result["received_calls"][0]["name"] == "record_probe_0123456789ab"
+    client.call_tool_probe.assert_called_once()
+
+
+def test_runner_treats_non_object_client_result_as_format_error():
+    client = MagicMock()
+    client.call_tool_probe.return_value = None
+
+    result = run_tool_call_integrity_test(client, nonce_factory=lambda: "fixed")
+
+    assert result["verdict"] == "inconclusive"
+    assert result["received_calls"] == []
+
+
+def test_tool_call_preview_is_escaped_and_bounded():
+    preview = format_tool_calls_preview(
+        [{
+            "type": "function",
+            "name": "must-not-be-rendered",
+            "arguments": {"command": "bad|`" + "x" * 200},
+            "arguments_error": None,
+        }],
+        max_chars=80,
+    )
+
+    assert len(preview) <= 80
+    assert "\\|" in preview
+    assert "\\`" in preview
+    assert "must-not-be-rendered" not in preview
+    assert preview.endswith("...")

--- a/web/guides/audit-claude-api-relay-safely.html
+++ b/web/guides/audit-claude-api-relay-safely.html
@@ -37,7 +37,7 @@ python audit.py \
     <tr><td>Identity</td><td>Non-Claude identity leaks, model substitution wording, and stream model identity where available.</td></tr>
     <tr><td>Streaming</td><td>Anthropic-style SSE event types, usage monotonicity, thinking signature presence, and stream model consistency.</td></tr>
     <tr><td>Prompt path</td><td>Token injection, prompt extraction, instruction conflict, and jailbreak behavior.</td></tr>
-    <tr><td>Tool path</td><td>Text-echo package command integrity for tool-call rewriting risks.</td></tr>
+    <tr><td>Tool path</td><td>Package-command text plus inert structured Tool Call integrity for name, JSON arguments, type, and call count.</td></tr>
   </table>
 
   <h2>Interpreting inconclusive results</h2>

--- a/web/index.html
+++ b/web/index.html
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">840</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">843</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">

--- a/web/index.html
+++ b/web/index.html
@@ -85,7 +85,7 @@
           "name": "What is tool-call rewriting?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Tool-call rewriting means the relay modifies package-install commands or tool-like output in the model response. API Relay Audit compares pinned package commands against returned text to detect proxy-layer supply-chain tampering."
+            "text": "Tool-call rewriting means the relay modifies a structured tool name, JSON arguments, call count, or package-install command. Step 8 checks four pinned text commands plus one inert, non-streaming Anthropic/OpenAI Tool Call without executing it."
           }
         },
         {
@@ -383,7 +383,7 @@ footer a:hover{color:var(--text)}
   <div class="hero-stats">
     <div class="stat"><div class="stat-num">14</div><div class="stat-label" data-i18n="stat_steps">Audit Steps</div></div>
     <div class="stat"><div class="stat-num">6D</div><div class="stat-label" data-i18n="stat_matrix">Risk Matrix</div></div>
-    <div class="stat"><div class="stat-num">808</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
+    <div class="stat"><div class="stat-num">840</div><div class="stat-label" data-i18n="stat_tests">Unit Tests</div></div>
     <div class="stat"><div class="stat-num">0</div><div class="stat-label" data-i18n="stat_deps">Dependencies (standalone)</div></div>
   </div>
   <div class="hero-cta">
@@ -643,9 +643,9 @@ footer a:hover{color:var(--text)}
       <p data-i18n="step_ctx_desc">5 canary markers + binary search pinpoint the real context window boundary. Is your 200K context really 200K?</p>
     </div>
     <div class="step">
-      <div class="step-num" data-i18n="step_tool_label">Step 8 (AC-1.a)</div>
-      <h3 data-i18n="step_tool_title">Tool-Call Rewriting</h3>
-      <p data-i18n="step_tool_desc">Checks if the relay silently modifies package install commands in responses — typosquatting supply-chain attacks at the proxy layer.</p>
+      <div class="step-num" data-i18n="step_tool_label">Step 8 (AC-1 / AC-1.a)</div>
+      <h3 data-i18n="step_tool_title">Tool-Call Integrity</h3>
+      <p data-i18n="step_tool_desc">Checks four package-command echoes plus one inert structured Tool Call for name, JSON-argument, type, or call-count rewriting. Returned calls are never executed.</p>
     </div>
     <div class="step">
       <div class="step-num" data-i18n="step_err_label">Step 9 (AC-2)</div>
@@ -680,7 +680,7 @@ footer a:hover{color:var(--text)}
       <tr><td data-i18n="cmp_identity">Identity Substitution</td><td class="check">&#10003;</td><td class="check">&#10003;</td><td class="cross">&#10005;</td></tr>
       <tr><td data-i18n="cmp_jailbreak">Jailbreak Resistance</td><td class="check">&#10003;</td><td class="cross">&#10005;</td><td class="cross">&#10005;</td></tr>
       <tr><td data-i18n="cmp_context">Context Truncation</td><td class="check">&#10003;</td><td class="cross">&#10005;</td><td class="cross">&#10005;</td></tr>
-      <tr><td data-i18n="cmp_tool">Tool-Call Rewriting (AC-1.a)</td><td class="check">&#10003;</td><td class="cross">&#10005;</td><td class="cross">&#10005;</td></tr>
+      <tr><td data-i18n="cmp_tool">Tool-Call Integrity (AC-1 / AC-1.a)</td><td class="check">&#10003;</td><td class="cross">&#10005;</td><td class="cross">&#10005;</td></tr>
       <tr><td data-i18n="cmp_error">Error Response Leakage (AC-2)</td><td class="check">&#10003;</td><td class="cross">&#10005;</td><td class="cross">&#10005;</td></tr>
       <tr><td data-i18n="cmp_stream">Stream Integrity (SSE)</td><td class="check">&#10003;</td><td class="check">&#10003;</td><td class="cross">&#10005;</td></tr>
       <tr><td data-i18n="cmp_web3">Web3 Injection</td><td class="check">&#10003;</td><td class="cross">&#10005;</td><td class="cross">&#10005;</td></tr>
@@ -748,7 +748,7 @@ footer a:hover{color:var(--text)}
   </div>
   <div class="faq-item">
     <div class="faq-q" onclick="toggleFaq(this)" data-i18n="faq_q5">What is tool-call rewriting?</div>
-    <div class="faq-a" data-i18n="faq_a5">Tool-call rewriting means the relay modifies package-install commands or tool-like output in the model response. API Relay Audit compares pinned package commands against returned text to detect proxy-layer supply-chain tampering.</div>
+    <div class="faq-a" data-i18n="faq_a5">Tool-call rewriting means the relay modifies a structured tool name, JSON arguments, call count, or package-install command. Step 8 checks four pinned text commands plus one inert, non-streaming Anthropic/OpenAI Tool Call without executing it.</div>
   </div>
   <div class="faq-item">
     <div class="faq-q" onclick="toggleFaq(this)" data-i18n="faq_q6">What are SSE anomalies?</div>
@@ -1073,13 +1073,13 @@ const i18n={
     step_extract_label:"Step 4 & 6",step_extract_title:"Prompt 提取",step_extract_desc:"3 种攻击向量尝试提取隐藏 system prompt：直接复述、翻译法、JSON 接龙。加上越狱防护测试。",
     step_id_label:"Step 5",step_id_title:"身份一致性信号",step_id_desc:'身份关键词集合检测 "Claude" 路由是否泄漏 GPT、DeepSeek、GLM、Qwen 或其他模型身份。这是证据信号，需结合 metadata、request id 或 stream signature 才能提出 provider-level 结论。',
     step_ctx_label:"Step 7",step_ctx_title:"上下文截断",step_ctx_desc:"5 个 canary 标记 + 二分查找精确定位真实上下文窗口边界。你的 200K context 真的有 200K 吗？",
-    step_tool_label:"Step 8 (AC-1.a)",step_tool_title:"工具调用改写",step_tool_desc:"检测中转站是否在返回路径上偷改包安装命令 — 代理层面的拼写投毒供应链攻击。",
+    step_tool_label:"Step 8 (AC-1 / AC-1.a)",step_tool_title:"工具调用完整性",step_tool_desc:"检测 4 条包安装命令和 1 个惰性结构化 Tool Call 的工具名、JSON 参数、类型及调用数量是否被改写；返回内容绝不执行。",
     step_err_label:"Step 9 (AC-2)",step_err_title:"错误响应泄漏",step_err_desc:"7 种故意破坏的请求探测 API Key、环境变量、文件路径、LiteLLM 内部字段是否在错误响应中泄漏。",
     step_sse_label:"Step 10-11",step_sse_title:"流完整性 & Web3",step_sse_desc:"SSE 事件白名单、usage 单调性、thinking 签名有效性、终止事件完整性和模型身份检查。加上 Web3 签名隔离探针（profile-gated）。",
     cmp_title:"横向对比",cmp_sub:"三个工具，三种思路 — 根据需求选择",
     cmp_col_dim:"维度",
     cmp_inject:"Token 注入",cmp_prompt:"Prompt 提取",cmp_identity:"身份替换",cmp_jailbreak:"越狱防护",
-    cmp_context:"上下文截断",cmp_tool:"工具调用改写 (AC-1.a)",cmp_error:"错误响应泄漏 (AC-2)",
+    cmp_context:"上下文截断",cmp_tool:"工具调用完整性 (AC-1 / AC-1.a)",cmp_error:"错误响应泄漏 (AC-2)",
     cmp_stream:"流完整性 (SSE)",cmp_web3:"Web3 注入",cmp_channel:"上游通道分类",
     cmp_local:"本地运行 (无额外检测服务器)",cmp_oss:"完全开源",cmp_leaderboard:"公开排行榜",cmp_report:"结构化审计报告",
     install_title:"开始审计",install_sub:"填写你的中转站信息 — 我们生成命令，你在本地运行。",
@@ -1109,8 +1109,8 @@ const i18n={
     term_step3_out:"  ⚠ 检测到注入: +80 tokens (疑似 Claude Code CLI 身份)",
     term_step5:"[Step 5/14] 身份替换检测...",
     term_step5_out:"  ✓ 身份确认: Claude by Anthropic",
-    term_step8:"[Step 8/14] 工具调用改写检测 (AC-1.a)...",
-    term_step8_out:"  ✓ 5/5 包管理器探测完整，无改写",
+    term_step8:"[Step 8/14] 工具调用完整性检测 (AC-1 / AC-1.a)...",
+    term_step8_out:"  ✓ 4 条文本命令 + 1 个结构化调用完整，无改写",
     term_done:"✓ 审计完成! 报告已保存: audit-{domain}.md",
     term_open_hint:"用任意文本编辑器打开 .md 文件查看完整报告",
     copy_btn:"复制",copied_btn:"已复制!",
@@ -1126,7 +1126,7 @@ const i18n={
     faq_q4:"什么是模型替换？",
     faq_a4:'模型替换指中转站可能暴露出不同于预期的模型身份、路由或上游 channel 信号。API Relay Audit 会检查 self-ID、stream 模型身份、延迟和 channel fingerprint，但这些信号需要交叉验证，不能单独证明 provider 替换。',
     faq_q5:"什么是工具调用改写？",
-    faq_a5:'工具调用改写指中转站修改模型回复中的包安装命令或工具输出。API Relay Audit 会比对固定 package 命令和返回文本，用来检测代理层供应链篡改。',
+    faq_a5:'工具调用改写指中转站修改结构化工具名、JSON 参数、调用数量或包安装命令。Step 8 会检查 4 条固定文本命令和 1 个惰性的 Anthropic/OpenAI 非流式 Tool Call，绝不执行返回内容。',
     faq_q6:"什么是 SSE 异常？",
     faq_a6:'SSE 异常是 Anthropic 风格流式响应中的完整性问题。API Relay Audit 会检查事件类型、usage 单调性、thinking 签名，以及可用时的 stream 模型身份。',
     faq_q7:"它检查哪些 Web3 钱包风险？",
@@ -1174,13 +1174,13 @@ const i18n={
     step_extract_label:"Step 4 & 6",step_extract_title:"Prompt Extraction",step_extract_desc:"3 attack vectors attempt to extract hidden system prompts: verbatim recall, translation trick, JSON continuation. Plus jailbreak resistance tests.",
     step_id_label:"Step 5",step_id_title:"Identity Consistency Signals",step_id_desc:'An identity keyword set checks whether a claimed Claude route leaks GPT, DeepSeek, GLM, Qwen, or other model identities. This is an evidence signal, not standalone provider-level proof.',
     step_ctx_label:"Step 7",step_ctx_title:"Context Truncation",step_ctx_desc:"5 canary markers + binary search pinpoint the real context window boundary. Is your 200K context really 200K?",
-    step_tool_label:"Step 8 (AC-1.a)",step_tool_title:"Tool-Call Rewriting",step_tool_desc:"Checks if the relay silently modifies package install commands in responses — typosquatting supply-chain attacks at the proxy layer.",
+    step_tool_label:"Step 8 (AC-1 / AC-1.a)",step_tool_title:"Tool-Call Integrity",step_tool_desc:"Checks four package-command echoes plus one inert structured Tool Call for name, JSON-argument, type, or call-count rewriting. Returned calls are never executed.",
     step_err_label:"Step 9 (AC-2)",step_err_title:"Error Response Leakage",step_err_desc:"7 deliberately broken requests probe for API key, env vars, file paths, and LiteLLM internals leaking in error responses.",
     step_sse_label:"Step 10-11",step_sse_title:"Stream Integrity & Web3",step_sse_desc:"SSE event whitelist, usage monotonicity, thinking signature validity, terminal completeness, and model identity. Plus Web3 signature-isolation probes (profile-gated).",
     cmp_title:"How We Compare",cmp_sub:"Three tools, three approaches — pick the right one for your needs",
     cmp_col_dim:"Dimension",
     cmp_inject:"Token Injection",cmp_prompt:"Prompt Extraction",cmp_identity:"Identity Substitution",cmp_jailbreak:"Jailbreak Resistance",
-    cmp_context:"Context Truncation",cmp_tool:"Tool-Call Rewriting (AC-1.a)",cmp_error:"Error Response Leakage (AC-2)",
+    cmp_context:"Context Truncation",cmp_tool:"Tool-Call Integrity (AC-1 / AC-1.a)",cmp_error:"Error Response Leakage (AC-2)",
     cmp_stream:"Stream Integrity (SSE)",cmp_web3:"Web3 Injection",cmp_channel:"Upstream Channel Classifier",
     cmp_local:"Local Execution (No extra checker server)",cmp_oss:"Fully Open Source",cmp_leaderboard:"Public Leaderboard",cmp_report:"Structured Audit Report",
     install_title:"Start Your Audit",install_sub:"Fill in your relay info — we generate the command, you run it locally.",
@@ -1210,8 +1210,8 @@ const i18n={
     term_step3_out:"  ⚠ Injection detected: +80 tokens (Claude Code CLI identity)",
     term_step5:"[Step 5/14] Identity substitution check...",
     term_step5_out:"  ✓ Identity confirmed: Claude by Anthropic",
-    term_step8:"[Step 8/14] Tool-call rewriting (AC-1.a)...",
-    term_step8_out:"  ✓ 5/5 package manager probes intact, no rewriting",
+    term_step8:"[Step 8/14] Tool-call integrity (AC-1 / AC-1.a)...",
+    term_step8_out:"  ✓ 4 text commands + 1 structured call intact",
     term_done:"✓ Audit complete! Report saved: audit-{domain}.md",
     term_open_hint:"Open the .md file with any text editor to view the full report",
     copy_btn:"Copy",copied_btn:"Copied!",
@@ -1227,7 +1227,7 @@ const i18n={
     faq_q4:"What is model substitution?",
     faq_a4:'Model substitution means the relay may expose signals for a different model identity, route, or upstream channel than expected. API Relay Audit checks self-ID, stream model identity, latency, and channel fingerprints as signals that require corroboration before provider-level claims.',
     faq_q5:"What is tool-call rewriting?",
-    faq_a5:'Tool-call rewriting means the relay modifies package-install commands or tool-like output in the model response. API Relay Audit compares pinned package commands against returned text to detect proxy-layer supply-chain tampering.',
+    faq_a5:'Tool-call rewriting means the relay modifies a structured tool name, JSON arguments, call count, or package-install command. Step 8 checks four pinned text commands plus one inert, non-streaming Anthropic/OpenAI Tool Call without executing it.',
     faq_q6:"What are SSE anomalies?",
     faq_a6:'SSE anomalies are stream-level integrity issues in Anthropic-style streaming responses. API Relay Audit checks event types, usage monotonicity, thinking signatures, and stream model identity when supported.',
     faq_q7:"What Web3 wallet risks does it check?",


### PR DESCRIPTION
## Summary

- extend Step 8 with one inert, non-streaming structured Tool Call probe while retaining the four package-command text probes
- add strict Anthropic and OpenAI adapters behind `APIClient.call_tool_probe()` and normalize tool name, JSON arguments, type, count, stop reason, usage, and parse errors
- preserve the 14-step audit and 6D risk matrix: any mutation feeds D3/HIGH, while unsupported or unverifiable structured calls feed D3i/MEDIUM
- regenerate the curl-only standalone artifact and add optional backward-compatible `toolSubstitution.structured` report extraction
- redact caller credentials and known secret shapes from argument previews, and keep attacker-controlled tool names and raw error bodies out of Markdown findings

## Safety boundary

- no tool executor exists
- no returned tool name or argument is executed
- no `tool_result` is sent
- reports show only escaped, length-bounded, secret-redacted argument previews
- streaming Tool Call fragment reassembly remains out of scope

## Verification

- `python3 -m pytest tests/ -q` — 843 passed
- `python3 scripts/build-standalone.py --check`
- `python3 scripts/collect-metrics.py --check`
- `python3 scripts/sync-version.py --check`
- `python3 -S audit.py --help`
- `npm run test:dsh` — 17 passed
- `git diff --check origin/master...HEAD`

Closes #32
