### PR TITLE
docs: define release publication completion

### DIFF
--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -47,6 +47,22 @@ merged. If versioned skill or release docs now point at a new tag such as
 `v2.3.0`, create the draft release immediately after merge so the immutable tag
 exists before users follow those download commands.
 
+## Publish and Verify
+
+A successful draft-release workflow means only that the draft is ready for
+maintainer review. Before clicking **Publish release**, confirm that:
+
+1. The version, tag, and target commit match `VERSION` and the merged
+   release-prep commit.
+2. The release notes are complete for that version.
+3. Both `audit.py` and `audit.py.sha256` are attached, and the workflow's
+   artifact-provenance verification passed.
+
+After publication, confirm that the release is no longer a draft, GitHub's
+Latest Release matches `VERSION`, the tag resolves to the expected release
+commit, and both assets remain attached. Never replace assets on a published
+release to repair a mismatch; fix the source and publish a new patch release.
+
 ## Standalone Artifact Provenance
 
 Each release has one authoritative standalone artifact: `audit.py` at the


### PR DESCRIPTION
## Summary

- define the boundary between a successful draft-release run and a published release
- add the maintainer checks required before and after publication
- keep published release assets immutable; mismatches require a patch release

No runtime, workflow, version, or generated artifact changes.

## Verification

- python3 scripts/sync-version.py --check
- python3 scripts/build-standalone.py --check
- python3 scripts/collect-metrics.py --check
- python3 -m pytest tests/ -q (808 passed)
- python3 -S audit.py --help